### PR TITLE
Fix lucet-wasi compilation

### DIFF
--- a/lucet-wasi/src/host.rs
+++ b/lucet-wasi/src/host.rs
@@ -3,6 +3,8 @@
 
 include!(concat!(env!("OUT_DIR"), "/wasi_host.rs"));
 
+pub use crate::wasm32::*;
+
 pub type void = ::std::os::raw::c_void;
 
 pub unsafe fn ciovec_to_nix<'a>(ciovec: &'a __wasi_ciovec_t) -> nix::sys::uio::IoVec<&'a [u8]> {


### PR DESCRIPTION
Not sure if this is the best fix, but `lucet-wasi` doesn't compile any more since the addition of support for preopened files.

Types such as `__wasi_prestat_t` and definitions such as `__WASI_PREOPENTYPE_DIR` are not defined in the `host` module, but in `wasm32`.