### PR TITLE
 Partially address #282 - allow statically linked wasm modules

### DIFF
--- a/lucet-module/Cargo.toml
+++ b/lucet-module/Cargo.toml
@@ -17,6 +17,10 @@ serde_json = "1.0"
 bincode = "1.1.4"
 num-derive = "0.2"
 num-traits = "0.2"
-minisign = "0.5.11"
+minisign = { version = "0.5.11", optional = true }
 object = "0.12"
 byteorder = "1.3"
+
+[features]
+default = ["signature_checking"]
+signature_checking = ["minisign"]

--- a/lucet-module/src/error.rs
+++ b/lucet-module/src/error.rs
@@ -9,6 +9,7 @@ pub enum Error {
     DeserializationError(#[cause] bincode::Error),
     #[fail(display = "Serialization error: {}", _0)]
     SerializationError(#[cause] bincode::Error),
+    #[cfg(feature = "signature_checking")]
     #[fail(display = "Module signature error: {}", _0)]
     ModuleSignatureError(#[cause] minisign::PError),
     #[fail(display = "I/O error: {}", _0)]

--- a/lucet-module/src/lib.rs
+++ b/lucet-module/src/lib.rs
@@ -28,7 +28,9 @@ pub use crate::linear_memory::{HeapSpec, LinearMemorySpec, SparseData};
 pub use crate::module::{Module, SerializedModule, LUCET_MODULE_SYM};
 pub use crate::module_data::{ModuleData, MODULE_DATA_SYM};
 pub use crate::runtime::InstanceRuntimeData;
-pub use crate::signature::{ModuleSignature, PublicKey};
+pub use crate::signature::ModuleSignature;
+#[cfg(feature = "signature_checking")]
+pub use crate::signature::PublicKey;
 pub use crate::tables::TableElement;
 pub use crate::traps::{TrapCode, TrapManifest, TrapSite};
 pub use crate::types::{Signature, ValueType};

--- a/lucet-module/src/module_data.rs
+++ b/lucet-module/src/module_data.rs
@@ -7,6 +7,7 @@ use crate::{
     types::Signature,
     Error,
 };
+#[cfg(feature = "signature_checking")]
 use minisign::SignatureBones;
 use serde::{Deserialize, Serialize};
 
@@ -37,6 +38,7 @@ pub struct ModuleData<'a> {
 }
 
 impl<'a> ModuleData<'a> {
+    #[cfg(feature = "signature_checking")]
     pub fn new(
         linear_memory: Option<LinearMemorySpec<'a>>,
         globals_spec: Vec<GlobalSpec<'a>>,
@@ -46,6 +48,27 @@ impl<'a> ModuleData<'a> {
         signatures: Vec<Signature>,
     ) -> Self {
         let module_signature = vec![0u8; SignatureBones::BYTES];
+        Self {
+            linear_memory,
+            globals_spec,
+            function_info,
+            import_functions,
+            export_functions,
+            signatures,
+            module_signature,
+        }
+    }
+
+    #[cfg(not(feature = "signature_checking"))]
+    pub fn new(
+        linear_memory: Option<LinearMemorySpec<'a>>,
+        globals_spec: Vec<GlobalSpec<'a>>,
+        function_info: Vec<FunctionMetadata<'a>>,
+        import_functions: Vec<ImportFunction<'a>>,
+        export_functions: Vec<ExportFunction<'a>>,
+        signatures: Vec<Signature>,
+    ) -> Self {
+        let module_signature = vec![0u8; 0];
         Self {
             linear_memory,
             globals_spec,
@@ -113,6 +136,7 @@ impl<'a> ModuleData<'a> {
         &self.module_signature
     }
 
+    #[cfg(feature = "signature_checking")]
     pub fn patch_module_signature(
         module_data_bin: &'a [u8],
         module_signature: &[u8],
@@ -127,6 +151,7 @@ impl<'a> ModuleData<'a> {
         Ok(patched_module_data_bin)
     }
 
+    #[cfg(feature = "signature_checking")]
     pub fn clear_module_signature(module_data_bin: &'a [u8]) -> Result<Vec<u8>, Error> {
         let module_signature = vec![0u8; SignatureBones::BYTES];
         Self::patch_module_signature(module_data_bin, &module_signature)

--- a/lucet-module/src/signature.rs
+++ b/lucet-module/src/signature.rs
@@ -1,17 +1,24 @@
+#[cfg(feature = "signature_checking")]
 use crate::error::Error::{self, IOError, ModuleSignatureError};
 use crate::module::LUCET_MODULE_SYM;
 use crate::module_data::MODULE_DATA_SYM;
+#[cfg(feature = "signature_checking")]
 use crate::ModuleData;
 use byteorder::{ByteOrder, LittleEndian};
+#[cfg(feature = "signature_checking")]
 pub use minisign::{PublicKey, SecretKey};
+#[cfg(feature = "signature_checking")]
 use minisign::{SignatureBones, SignatureBox};
 use object::*;
 use std::fs::{File, OpenOptions};
-use std::io::{self, Cursor, Read, Seek, SeekFrom, Write};
+#[cfg(feature = "signature_checking")]
+use std::io::Cursor;
+use std::io::{self, Read, Seek, SeekFrom, Write};
 use std::path::Path;
 
 pub struct ModuleSignature;
 
+#[cfg(feature = "signature_checking")]
 impl ModuleSignature {
     pub fn verify<P: AsRef<Path>>(
         so_path: P,
@@ -68,12 +75,14 @@ struct SymbolData {
     len: usize,
 }
 
+#[allow(dead_code)]
 struct RawModuleAndData {
     pub obj_bin: Vec<u8>,
     pub module_data_offset: usize,
     pub module_data_len: usize,
 }
 
+#[allow(dead_code)]
 impl RawModuleAndData {
     pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Self, io::Error> {
         let mut obj_bin: Vec<u8> = Vec::new();

--- a/lucet-runtime/Cargo.toml
+++ b/lucet-runtime/Cargo.toml
@@ -31,6 +31,9 @@ tempfile = "3.0"
 # only used for tests
 cc = "1.0"
 
+[features]
+signature_checking = ["lucet-module/signature_checking"]
+
 [lib]
 name = "lucet_runtime"
 crate-type = ["rlib", "staticlib", "cdylib"]

--- a/lucet-runtime/lucet-runtime-internals/Cargo.toml
+++ b/lucet-runtime/lucet-runtime-internals/Cargo.toml
@@ -37,3 +37,6 @@ byteorder = "1.2"
 
 [build-dependencies]
 cc = "1.0"
+
+[features]
+signature_checking = ["lucet-module/signature_checking"]

--- a/lucet-runtime/src/lib.rs
+++ b/lucet-runtime/src/lib.rs
@@ -342,7 +342,9 @@
 
 pub mod c_api;
 
-pub use lucet_module::{PublicKey, TrapCode};
+#[cfg(feature = "signature_checking")]
+pub use lucet_module::PublicKey;
+pub use lucet_module::TrapCode;
 pub use lucet_runtime_internals::alloc::Limits;
 pub use lucet_runtime_internals::error::Error;
 pub use lucet_runtime_internals::instance::{

--- a/lucetc/Cargo.toml
+++ b/lucetc/Cargo.toml
@@ -43,3 +43,6 @@ human-size = "0.4"
 parity-wasm = "0.38"
 minisign = "0.5.11"
 memoffset = "0.5.1"
+
+[features]
+signature_checking = ["lucet-module/signature_checking"]

--- a/lucetc/src/error.rs
+++ b/lucetc/src/error.rs
@@ -67,4 +67,6 @@ pub enum LucetcErrorKind {
     Signature,
     #[fail(display = "Unsupported")]
     Unsupported,
+    #[fail(display = "Module Signing disabled at compile time")]
+    NoSigningSupport,
 }

--- a/lucetc/src/signature.rs
+++ b/lucetc/src/signature.rs
@@ -1,4 +1,6 @@
+use crate::error::LucetcErrorKind::NoSigningSupport;
 use failure::*;
+#[cfg(feature = "signature_checking")]
 use lucet_module::ModuleSignature;
 pub use minisign::{KeyPair, PublicKey, SecretKey, SignatureBones, SignatureBox};
 use std::fs::File;
@@ -74,6 +76,12 @@ pub fn verify_source_code(
 }
 
 // Sign the compiled code
+#[cfg(feature = "signature_checking")]
 pub fn sign_module<P: AsRef<Path>>(path: P, sk: &SecretKey) -> Result<(), Error> {
     ModuleSignature::sign(path, sk).map_err(|e| e.into())
+}
+
+#[cfg(not(feature = "signature_checking"))]
+pub fn sign_module<P: AsRef<Path>>(_path: P, _sk: &SecretKey) -> Result<(), Error> {
+    Err(NoSigningSupport).map_err(|e| e.into())
 }


### PR DESCRIPTION
This small change allows the first step in allowing use of statically linked wasm modules - allow use of symbols from the current binary. This works only if
1) There is only one wasm module statically linked
2) The application is compiled with "rdynamic" linker flag

I built this on another PR (for optionally excluding minisign) which modifies similar code so that there won't be merge conflicts. So please ignore the "combined diff of the 2 PRs/commits" and only see the diff of the one commit for this change.