### PR TITLE
Add `#[lucet_hostcall]` attribute macro and deprecate `lucet_hostcalls!`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -844,12 +844,21 @@ dependencies = [
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lucet-module 0.4.1",
+ "lucet-runtime-macros 0.4.1",
  "memoffset 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "raw-cpuid 6.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "xfailure 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "lucet-runtime-macros"
+version = "0.4.1"
+dependencies = [
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -768,12 +768,12 @@ name = "lucet-benchmarks"
 version = "0.4.1"
 dependencies = [
  "criterion 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.4.1",
- "lucet-runtime 0.4.1",
- "lucet-runtime-internals 0.4.1",
- "lucet-wasi 0.4.1",
- "lucet-wasi-sdk 0.4.1",
- "lucetc 0.4.1",
+ "lucet-module 0.4.2",
+ "lucet-runtime 0.4.2",
+ "lucet-runtime-internals 0.4.2",
+ "lucet-wasi 0.4.2",
+ "lucet-wasi-sdk 0.4.2",
+ "lucetc 0.4.2",
  "nix 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -782,7 +782,7 @@ dependencies = [
 
 [[package]]
 name = "lucet-module"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -801,28 +801,28 @@ dependencies = [
 
 [[package]]
 name = "lucet-objdump"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "colored 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "goblin 0.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.4.1",
+ "lucet-module 0.4.2",
 ]
 
 [[package]]
 name = "lucet-runtime"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.4.1",
- "lucet-runtime-internals 0.4.1",
- "lucet-runtime-tests 0.4.1",
- "lucet-wasi-sdk 0.4.1",
- "lucetc 0.4.1",
+ "lucet-module 0.4.2",
+ "lucet-runtime-internals 0.4.2",
+ "lucet-runtime-tests 0.4.2",
+ "lucet-wasi-sdk 0.4.2",
+ "lucetc 0.4.2",
  "nix 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "lucet-runtime-internals"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -843,8 +843,8 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.4.1",
- "lucet-runtime-macros 0.4.1",
+ "lucet-module 0.4.2",
+ "lucet-runtime-macros 0.4.2",
  "memoffset 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -855,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "lucet-runtime-macros"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -863,27 +863,27 @@ dependencies = [
 
 [[package]]
 name = "lucet-runtime-tests"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "cc 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.4.1",
- "lucet-runtime-internals 0.4.1",
- "lucet-wasi-sdk 0.4.1",
- "lucetc 0.4.1",
+ "lucet-module 0.4.2",
+ "lucet-runtime-internals 0.4.2",
+ "lucet-wasi-sdk 0.4.2",
+ "lucetc 0.4.2",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "lucet-spectest"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.4.1",
- "lucet-runtime 0.4.1",
- "lucetc 0.4.1",
+ "lucet-module 0.4.2",
+ "lucet-runtime 0.4.2",
+ "lucetc 0.4.2",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -892,12 +892,12 @@ dependencies = [
 
 [[package]]
 name = "lucet-validate"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cranelift-entity 0.46.1",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-wasi-sdk 0.4.1",
+ "lucet-wasi-sdk 0.4.2",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wabt 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmparser 0.39.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "lucet-wasi"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "bindgen 0.51.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cast 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -914,11 +914,11 @@ dependencies = [
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "human-size 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.4.1",
- "lucet-runtime 0.4.1",
- "lucet-runtime-internals 0.4.1",
- "lucet-wasi-sdk 0.4.1",
- "lucetc 0.4.1",
+ "lucet-module 0.4.2",
+ "lucet-runtime 0.4.2",
+ "lucet-runtime-internals 0.4.2",
+ "lucet-wasi-sdk 0.4.2",
+ "lucetc 0.4.2",
  "nix 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -927,16 +927,16 @@ dependencies = [
 
 [[package]]
 name = "lucet-wasi-fuzz"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.4.1",
- "lucet-runtime 0.4.1",
- "lucet-wasi 0.4.1",
- "lucet-wasi-sdk 0.4.1",
- "lucetc 0.4.1",
+ "lucet-module 0.4.2",
+ "lucet-runtime 0.4.2",
+ "lucet-wasi 0.4.2",
+ "lucet-wasi-sdk 0.4.2",
+ "lucetc 0.4.2",
  "nix 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "progress 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -950,18 +950,18 @@ dependencies = [
 
 [[package]]
 name = "lucet-wasi-sdk"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.4.1",
- "lucet-validate 0.4.1",
- "lucetc 0.4.1",
+ "lucet-module 0.4.2",
+ "lucet-validate 0.4.2",
+ "lucetc 0.4.2",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "lucetc"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "bimap 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -980,8 +980,8 @@ dependencies = [
  "goblin 0.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "human-size 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.4.1",
- "lucet-validate 0.4.1",
+ "lucet-module 0.4.2",
+ "lucet-validate 0.4.2",
  "memoffset 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "minisign 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-wasm 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
   "lucet-objdump",
   "lucet-runtime",
   "lucet-runtime/lucet-runtime-internals",
+  "lucet-runtime/lucet-runtime-macros",
   "lucet-runtime/lucet-runtime-tests",
   "lucet-spectest",
   "lucet-validate",

--- a/benchmarks/lucet-benchmarks/src/modules.rs
+++ b/benchmarks/lucet-benchmarks/src/modules.rs
@@ -1,5 +1,5 @@
 use lucet_module::lucet_signature;
-use lucet_runtime::lucet_hostcalls;
+use lucet_runtime::lucet_hostcall;
 use lucet_runtime::vmctx::{lucet_vmctx, Vmctx};
 use lucet_runtime_internals::module::{
     FunctionPointer, HeapSpec, MockExportBuilder, MockModuleBuilder, Module,
@@ -215,33 +215,32 @@ pub fn many_args_mock() -> Arc<dyn Module> {
 }
 
 pub fn hostcalls_mock() -> Arc<dyn Module> {
-    lucet_hostcalls! {
-        #[inline(never)]
-        #[no_mangle]
-        pub unsafe extern "C" fn hostcall_wrapped(
-            &mut vmctx,
-            x1: u64,
-            x2: u64,
-            x3: u64,
-            x4: u64,
-            x5: u64,
-            x6: u64,
-            x7: u64,
-            x8: u64,
-            x9: u64,
-            x10: u64,
-            x11: u64,
-            x12: u64,
-            x13: u64,
-            x14: u64,
-            x15: u64,
-            x16: u64,
-        ) -> () {
-            vmctx.heap_mut()[0] =
-                (x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9 + x10 + x11 + x12 + x13 + x14 + x15 + x16)
-                    as u8;
-            assert_eq!(vmctx.heap()[0], 136);
-        }
+    #[lucet_hostcall]
+    #[inline(never)]
+    #[no_mangle]
+    pub unsafe extern "C" fn hostcall_wrapped(
+        vmctx: &mut Vmctx,
+        x1: u64,
+        x2: u64,
+        x3: u64,
+        x4: u64,
+        x5: u64,
+        x6: u64,
+        x7: u64,
+        x8: u64,
+        x9: u64,
+        x10: u64,
+        x11: u64,
+        x12: u64,
+        x13: u64,
+        x14: u64,
+        x15: u64,
+        x16: u64,
+    ) -> () {
+        vmctx.heap_mut()[0] =
+            (x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9 + x10 + x11 + x12 + x13 + x14 + x15 + x16)
+                as u8;
+        assert_eq!(vmctx.heap()[0], 136);
     }
 
     #[inline(never)]

--- a/lucet-module/Cargo.toml
+++ b/lucet-module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-module"
-version = "0.4.1"
+version = "0.4.2"
 description = "A structured interface for Lucet modules"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"

--- a/lucet-objdump/Cargo.toml
+++ b/lucet-objdump/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-objdump"
-version = "0.4.1"
+version = "0.4.2"
 description = "Analyze object files emitted by the Lucet compiler"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -13,7 +13,7 @@ edition = "2018"
 goblin="0.0.24"
 byteorder="1.2.1"
 colored="1.8.0"
-lucet-module = { path = "../lucet-module", version = "0.4.1" }
+lucet-module = { path = "../lucet-module", version = "0.4.2" }
 
 [package.metadata.deb]
 name = "fst-lucet-objdump"

--- a/lucet-runtime/Cargo.toml
+++ b/lucet-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-runtime"
-version = "0.4.1"
+version = "0.4.2"
 description = "Pure Rust runtime for Lucet WebAssembly toolchain"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -11,8 +11,8 @@ edition = "2018"
 
 [dependencies]
 libc = "0.2.65"
-lucet-runtime-internals = { path = "lucet-runtime-internals", version = "0.4.1" }
-lucet-module = { path = "../lucet-module", version = "0.4.1" }
+lucet-runtime-internals = { path = "lucet-runtime-internals", version = "0.4.2" }
+lucet-module = { path = "../lucet-module", version = "0.4.2" }
 num-traits = "0.2"
 num-derive = "0.3.0"
 
@@ -20,9 +20,9 @@ num-derive = "0.3.0"
 byteorder = "1.2"
 failure = "0.1"
 lazy_static = "1.1"
-lucetc = { path = "../lucetc", version = "0.4.1" }
-lucet-runtime-tests = { path = "lucet-runtime-tests", version = "0.4.1" }
-lucet-wasi-sdk = { path = "../lucet-wasi-sdk", version = "0.4.1" }
+lucetc = { path = "../lucetc", version = "0.4.2" }
+lucet-runtime-tests = { path = "lucet-runtime-tests", version = "0.4.2" }
+lucet-wasi-sdk = { path = "../lucet-wasi-sdk", version = "0.4.2" }
 nix = "0.15"
 rayon = "1.0"
 tempfile = "3.0"

--- a/lucet-runtime/lucet-runtime-internals/Cargo.toml
+++ b/lucet-runtime/lucet-runtime-internals/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 
 [dependencies]
 lucet-module = { path = "../../lucet-module", version = "0.4.1" }
+lucet-runtime-macros = { path = "../lucet-runtime-macros", version = "0.4.1" }
 
 bitflags = "1.0"
 bincode = "1.1.4"

--- a/lucet-runtime/lucet-runtime-internals/Cargo.toml
+++ b/lucet-runtime/lucet-runtime-internals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-runtime-internals"
-version = "0.4.1"
+version = "0.4.2"
 description = "Pure Rust runtime for Lucet WebAssembly toolchain (internals)"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -10,8 +10,8 @@ authors = ["Lucet team <lucet@fastly.com>"]
 edition = "2018"
 
 [dependencies]
-lucet-module = { path = "../../lucet-module", version = "0.4.1" }
-lucet-runtime-macros = { path = "../lucet-runtime-macros", version = "0.4.1" }
+lucet-module = { path = "../../lucet-module", version = "0.4.2" }
+lucet-runtime-macros = { path = "../lucet-runtime-macros", version = "0.4.2" }
 
 bitflags = "1.0"
 bincode = "1.1.4"

--- a/lucet-runtime/lucet-runtime-internals/src/hostcall_macros.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/hostcall_macros.rs
@@ -5,7 +5,7 @@
 /// It is important to use this macro for hostcalls, rather than exporting them directly, as it
 /// installs unwind protection that prevents panics from unwinding into the guest stack.
 ///
-/// Since this is not yet a proc macro, the syntax is unfortunately fairly brittle. The functions it
+/// Since this is not a proc macro, the syntax is unfortunately fairly brittle. The functions it
 /// encloses must be of the form:
 ///
 /// ```ignore
@@ -41,7 +41,7 @@ macro_rules! lucet_hostcalls {
             #[$crate::lucet_hostcall]
             $(#[$attr])*
             pub unsafe extern "C" fn $name(
-                $vmctx: &mut $crate::vmctx::Vmctx,
+                $vmctx: &mut lucet_runtime::vmctx::Vmctx,
                 $( $arg: $arg_ty ),*
             ) -> $ret_ty {
                 $($body)*

--- a/lucet-runtime/lucet-runtime-internals/src/hostcall_macros.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/hostcall_macros.rs
@@ -1,5 +1,7 @@
 /// The macro that surrounds definitions of Lucet hostcalls in Rust.
 ///
+/// **Note:** this macro has been deprecated and replaced by the `#[lucet_hostcall]` attribute.
+///
 /// It is important to use this macro for hostcalls, rather than exporting them directly, as it
 /// installs unwind protection that prevents panics from unwinding into the guest stack.
 ///
@@ -20,6 +22,7 @@
 /// }
 /// ```
 #[macro_export]
+#[deprecated(since = "0.4.2", note = "Use the #[lucet_hostcall] attribute instead")]
 macro_rules! lucet_hostcalls {
     {
         $(

--- a/lucet-runtime/lucet-runtime-internals/src/lib.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/lib.rs
@@ -8,6 +8,7 @@
 pub mod error;
 #[macro_use]
 pub mod hostcall_macros;
+pub use lucet_runtime_macros::lucet_hostcall;
 
 #[macro_use]
 #[cfg(test)]

--- a/lucet-runtime/lucet-runtime-macros/Cargo.toml
+++ b/lucet-runtime/lucet-runtime-macros/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "lucet-runtime-macros"
+version = "0.4.1"
+description = "Macros for the Lucet WebAssembly runtime"
+homepage = "https://github.com/bytecodealliance/lucet"
+repository = "https://github.com/bytecodealliance/lucet"
+license = "Apache-2.0 WITH LLVM-exception"
+categories = ["wasm"]
+authors = ["Lucet team <lucet@fastly.com>"]
+edition = "2018"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = { version = "1.0", features = ["full"] }
+quote = "1.0"

--- a/lucet-runtime/lucet-runtime-macros/Cargo.toml
+++ b/lucet-runtime/lucet-runtime-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-runtime-macros"
-version = "0.4.1"
+version = "0.4.2"
 description = "Macros for the Lucet WebAssembly runtime"
 homepage = "https://github.com/bytecodealliance/lucet"
 repository = "https://github.com/bytecodealliance/lucet"

--- a/lucet-runtime/lucet-runtime-macros/src/lib.rs
+++ b/lucet-runtime/lucet-runtime-macros/src/lib.rs
@@ -1,0 +1,122 @@
+extern crate proc_macro;
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::spanned::Spanned;
+
+/// This attribute generates a Lucet hostcall from a standalone Rust function that takes a `&mut
+/// Vmctx` as its first argument.
+///
+/// It is important to use this attribute for hostcalls, rather than exporting them
+/// directly. Otherwise the behavior of instance termination and timeouts are
+/// undefined. Additionally, the attribute makes the resulting function `unsafe extern "C"`
+/// regardless of how the function is defined, as this ABI is required for all hostcalls.
+///
+/// In most cases, you will want to also provide the `#[no_mangle]` attribute and `pub` visibility
+/// in order for the hostcall to be exported from the final executable.
+///
+/// ```ignore
+/// #[lucet_hostcall]
+/// #[no_mangle]
+/// pub fn yield_5(vmctx: &mut Vmctx) {
+///     vmctx.yield_val(5);
+/// }
+/// ```
+///
+/// Note that `lucet-runtime` must be a dependency of any crate where this attribute is used, and it
+/// may not be renamed (this restriction may be lifted once [this
+/// issue](https://github.com/rust-lang/rust/issues/54363) is resolved).
+#[proc_macro_attribute]
+pub fn lucet_hostcall(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    // determine whether we need to import from `lucet_runtime_internals`; this is useful if we want
+    // to define a hostcall for a target (or tests, more concretely) that doesn't depend on
+    // `lucet-runtime`
+    let in_internals = std::env::var("CARGO_PKG_NAME").unwrap() == "lucet-runtime-internals";
+
+    let mut hostcall = syn::parse_macro_input!(item as syn::ItemFn);
+    let hostcall_ident = hostcall.sig.ident.clone();
+
+    // use the same attributes and visibility as the impl hostcall
+    let attrs = hostcall.attrs.clone();
+    let vis = hostcall.vis.clone();
+
+    // remove #[no_mangle] from the attributes of the impl hostcall if it's there
+    hostcall.attrs = attrs
+        .iter()
+        .filter(|attr| !attr.path.is_ident("no_mangle"))
+        .cloned()
+        .collect();
+    // make the impl hostcall private
+    hostcall.vis = syn::Visibility::Inherited;
+
+    // modify the type signature of the exported raw hostcall based on the original signature
+    let mut raw_sig = hostcall.sig.clone();
+
+    // hostcalls are always unsafe
+    raw_sig.unsafety = Some(syn::Token![unsafe](raw_sig.span()));
+
+    // hostcalls are always extern "C"
+    raw_sig.abi = Some(syn::parse_quote!(extern "C"));
+
+    let vmctx_mod = if in_internals {
+        quote! { lucet_runtime_internals::vmctx }
+    } else {
+        quote! { lucet_runtime::vmctx }
+    };
+
+    // replace the first argument to the raw hostcall with the vmctx pointer
+    if let Some(arg0) = raw_sig.inputs.iter_mut().nth(0) {
+        let lucet_vmctx: syn::FnArg = syn::parse_quote!(vmctx_raw: *mut #vmctx_mod::lucet_vmctx);
+        *arg0 = lucet_vmctx;
+    }
+
+    // the args after the first to provide to the hostcall impl
+    let impl_args = hostcall
+        .sig
+        .inputs
+        .iter()
+        .skip(1)
+        .map(|arg| match arg {
+            syn::FnArg::Receiver(_) => {
+                // this case is an error, but humor the token stream so it will produce a nicer
+                // error later
+                let s = syn::Token![self](arg.span());
+                quote!(#s)
+            }
+            syn::FnArg::Typed(syn::PatType { pat, .. }) => quote!(#pat),
+        })
+        .collect::<Vec<_>>();
+
+    let termination_details = if in_internals {
+        quote! { lucet_runtime_internals::instance::TerminationDetails }
+    } else {
+        quote! { lucet_runtime::TerminationDetails }
+    };
+
+    let raw_hostcall = quote! {
+        #(#attrs)*
+        #vis
+        #raw_sig {
+            #[inline(always)]
+            #hostcall
+
+            let mut vmctx = #vmctx_mod::Vmctx::from_raw(vmctx_raw);
+            #vmctx_mod::VmctxInternal::instance_mut(&mut vmctx).uninterruptable(|| {
+                let res = std::panic::catch_unwind(move || {
+                    #hostcall_ident(&mut #vmctx_mod::Vmctx::from_raw(vmctx_raw), #(#impl_args),*)
+                });
+                match res {
+                    Ok(res) => res,
+                    Err(e) => {
+                        match e.downcast::<#termination_details>() {
+                            Ok(details) => {
+                                #vmctx_mod::Vmctx::from_raw(vmctx_raw).terminate_no_unwind(*details)
+                            },
+                            Err(e) => std::panic::resume_unwind(e),
+                        }
+                    }
+                }
+            })
+        }
+    };
+    raw_hostcall.into()
+}

--- a/lucet-runtime/lucet-runtime-macros/src/lib.rs
+++ b/lucet-runtime/lucet-runtime-macros/src/lib.rs
@@ -77,8 +77,8 @@ pub fn lucet_hostcall(_attr: TokenStream, item: TokenStream) -> TokenStream {
         .skip(1)
         .map(|arg| match arg {
             syn::FnArg::Receiver(_) => {
-                // this case is an error, but humor the token stream so it will produce a nicer
-                // error later
+                // this case is an error, but we produce some valid rust code anyway so that the
+                // compiler can produce a more meaningful error message at a later point
                 let s = syn::Token![self](arg.span());
                 quote!(#s)
             }

--- a/lucet-runtime/lucet-runtime-macros/src/lib.rs
+++ b/lucet-runtime/lucet-runtime-macros/src/lib.rs
@@ -40,11 +40,9 @@ pub fn lucet_hostcall(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let vis = hostcall.vis.clone();
 
     // remove #[no_mangle] from the attributes of the impl hostcall if it's there
-    hostcall.attrs = attrs
-        .iter()
-        .filter(|attr| !attr.path.is_ident("no_mangle"))
-        .cloned()
-        .collect();
+    hostcall
+        .attrs
+        .retain(|attr| !attr.path.is_ident("no_mangle"));
     // make the impl hostcall private
     hostcall.vis = syn::Visibility::Inherited;
 

--- a/lucet-runtime/lucet-runtime-tests/Cargo.toml
+++ b/lucet-runtime/lucet-runtime-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-runtime-tests"
-version = "0.4.1"
+version = "0.4.2"
 description = "Pure Rust runtime for Lucet WebAssembly toolchain (tests)"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -18,10 +18,10 @@ test = false
 failure = "0.1"
 lazy_static = "1.1"
 tempfile = "3.0"
-lucet-module = { path = "../../lucet-module", version = "0.4.1" }
-lucet-runtime-internals = { path = "../lucet-runtime-internals", version = "0.4.1" }
-lucet-wasi-sdk = { path = "../../lucet-wasi-sdk", version = "0.4.1" }
-lucetc = { path = "../../lucetc", version = "0.4.1" }
+lucet-module = { path = "../../lucet-module", version = "0.4.2" }
+lucet-runtime-internals = { path = "../lucet-runtime-internals", version = "0.4.2" }
+lucet-wasi-sdk = { path = "../../lucet-wasi-sdk", version = "0.4.2" }
+lucetc = { path = "../../lucetc", version = "0.4.2" }
 
 [build-dependencies]
 cc = "1.0"

--- a/lucet-runtime/lucet-runtime-tests/src/host.rs
+++ b/lucet-runtime/lucet-runtime-tests/src/host.rs
@@ -53,12 +53,12 @@ macro_rules! host_tests {
         #[lucet_hostcall]
         #[allow(unreachable_code)]
         #[no_mangle]
-        pub fn hostcall_test_func_hostcall_error_unwind(vmctx: &mut Vmctx) {
-            let lock = HOSTCALL_MUTEX.lock().unwrap();
+        pub fn hostcall_test_func_hostcall_error_unwind(_vmctx: &mut Vmctx) {
+            let _lock = HOSTCALL_MUTEX.lock().unwrap();
             unsafe {
                 lucet_hostcall_terminate!(ERROR_MESSAGE);
             }
-            drop(lock);
+            drop(_lock);
         }
 
         #[lucet_hostcall]

--- a/lucet-runtime/lucet-runtime-tests/src/host.rs
+++ b/lucet-runtime/lucet-runtime-tests/src/host.rs
@@ -5,7 +5,7 @@ macro_rules! host_tests {
         use libc::c_void;
         use lucet_runtime::vmctx::{lucet_vmctx, Vmctx};
         use lucet_runtime::{
-            lucet_hostcall_terminate, lucet_hostcalls, DlModule, Error, Limits, Region,
+            lucet_hostcall, lucet_hostcall_terminate, DlModule, Error, Limits, Region,
             TerminationDetails, TrapCode,
         };
         use std::sync::{Arc, Mutex};
@@ -29,115 +29,97 @@ macro_rules! host_tests {
             static ref HOSTCALL_MUTEX: Mutex<()> = Mutex::new(());
         }
 
-        lucet_hostcalls! {
-            #[no_mangle]
-            pub unsafe extern "C" fn hostcall_test_func_hello(
-                &mut vmctx,
-                hello_ptr: u32,
-                hello_len: u32,
-            ) -> () {
-                let heap = vmctx.heap();
-                let hello = heap.as_ptr() as usize + hello_ptr as usize;
-                if !vmctx.check_heap(hello as *const c_void, hello_len as usize) {
-                    lucet_hostcall_terminate!("heap access");
-                }
-                let hello = std::slice::from_raw_parts(hello as *const u8, hello_len as usize);
-                if hello.starts_with(b"hello") {
-                    *vmctx.get_embed_ctx_mut::<bool>() = true;
-                }
-            }
+        #[lucet_hostcall]
+        #[no_mangle]
+        pub fn hostcall_test_func_hostcall_error(_vmctx: &mut Vmctx) {
+            lucet_hostcall_terminate!(ERROR_MESSAGE);
+        }
 
-            #[no_mangle]
-            pub unsafe extern "C" fn hostcall_test_func_hostcall_error(
-                &mut _vmctx,
-            ) -> () {
+        #[lucet_hostcall]
+        #[no_mangle]
+        pub fn hostcall_test_func_hello(vmctx: &mut Vmctx, hello_ptr: u32, hello_len: u32) {
+            let heap = vmctx.heap();
+            let hello = heap.as_ptr() as usize + hello_ptr as usize;
+            if !vmctx.check_heap(hello as *const c_void, hello_len as usize) {
+                lucet_hostcall_terminate!("heap access");
+            }
+            let hello =
+                unsafe { std::slice::from_raw_parts(hello as *const u8, hello_len as usize) };
+            if hello.starts_with(b"hello") {
+                *vmctx.get_embed_ctx_mut::<bool>() = true;
+            }
+        }
+
+        #[lucet_hostcall]
+        #[allow(unreachable_code)]
+        #[no_mangle]
+        pub fn hostcall_test_func_hostcall_error_unwind(vmctx: &mut Vmctx) {
+            let lock = HOSTCALL_MUTEX.lock().unwrap();
+            unsafe {
                 lucet_hostcall_terminate!(ERROR_MESSAGE);
             }
+            drop(lock);
+        }
 
-            #[allow(unreachable_code)]
-            #[no_mangle]
-            pub unsafe extern "C" fn hostcall_test_func_hostcall_error_unwind(
-                &mut vmctx,
-            ) -> () {
-                let lock = HOSTCALL_MUTEX.lock().unwrap();
-                unsafe {
-                    lucet_hostcall_terminate!(ERROR_MESSAGE);
-                }
-                drop(lock);
+        #[lucet_hostcall]
+        #[no_mangle]
+        pub fn hostcall_bad_borrow(vmctx: &mut Vmctx) -> bool {
+            let heap = vmctx.heap();
+            let mut other_heap = vmctx.heap_mut();
+            heap[0] == other_heap[0]
+        }
+
+        #[lucet_hostcall]
+        #[no_mangle]
+        pub fn hostcall_missing_embed_ctx(vmctx: &mut Vmctx) -> bool {
+            struct S {
+                x: bool,
             }
+            let ctx = vmctx.get_embed_ctx::<S>();
+            ctx.x
+        }
 
-            #[no_mangle]
-            pub unsafe extern "C" fn hostcall_bad_borrow(
-                &mut vmctx,
-            ) -> bool {
-                let heap = vmctx.heap();
-                let mut other_heap = vmctx.heap_mut();
-                heap[0] == other_heap[0]
+        #[lucet_hostcall]
+        #[no_mangle]
+        pub fn hostcall_multiple_vmctx(vmctx: &mut Vmctx) -> bool {
+            let mut vmctx1 = unsafe { Vmctx::from_raw(vmctx.as_raw()) };
+            vmctx1.heap_mut()[0] = 0xAF;
+            drop(vmctx1);
+
+            let mut vmctx2 = unsafe { Vmctx::from_raw(vmctx.as_raw()) };
+            let res = vmctx2.heap()[0] == 0xAF;
+            drop(vmctx2);
+
+            res
+        }
+
+        #[lucet_hostcall]
+        #[no_mangle]
+        pub fn hostcall_yields(vmctx: &mut Vmctx) {
+            vmctx.yield_();
+        }
+
+        #[lucet_hostcall]
+        #[no_mangle]
+        pub fn hostcall_yield_expects_5(vmctx: &mut Vmctx) -> u64 {
+            vmctx.yield_expecting_val()
+        }
+
+        #[lucet_hostcall]
+        #[no_mangle]
+        pub fn hostcall_yields_5(vmctx: &mut Vmctx) {
+            vmctx.yield_val(5u64);
+        }
+
+        #[lucet_hostcall]
+        #[no_mangle]
+        pub fn hostcall_yield_facts(vmctx: &mut Vmctx, n: u64) -> u64 {
+            fn fact(vmctx: &mut Vmctx, n: u64) -> u64 {
+                let result = if n <= 1 { 1 } else { n * fact(vmctx, n - 1) };
+                vmctx.yield_val(result);
+                result
             }
-
-            #[no_mangle]
-            pub unsafe extern "C" fn hostcall_missing_embed_ctx(
-                &mut vmctx,
-            ) -> bool {
-                struct S {
-                    x: bool
-                }
-                let ctx = vmctx.get_embed_ctx::<S>();
-                ctx.x
-            }
-
-            #[no_mangle]
-            pub unsafe extern "C" fn hostcall_multiple_vmctx(
-                &mut vmctx,
-            ) -> bool {
-                let mut vmctx1 = Vmctx::from_raw(vmctx.as_raw());
-                vmctx1.heap_mut()[0] = 0xAF;
-                drop(vmctx1);
-
-                let mut vmctx2 = Vmctx::from_raw(vmctx.as_raw());
-                let res = vmctx2.heap()[0] == 0xAF;
-                drop(vmctx2);
-
-                res
-            }
-
-            #[no_mangle]
-            pub unsafe extern "C" fn hostcall_yields(
-                &mut vmctx,
-            ) -> () {
-                vmctx.yield_();
-            }
-
-            #[no_mangle]
-            pub unsafe extern "C" fn hostcall_yield_expects_5(
-                &mut vmctx,
-            ) -> u64 {
-                vmctx.yield_expecting_val()
-            }
-
-            #[no_mangle]
-            pub unsafe extern "C" fn hostcall_yields_5(
-                &mut vmctx,
-            ) -> () {
-                vmctx.yield_val(5u64);
-            }
-
-            #[no_mangle]
-            pub unsafe extern "C" fn hostcall_yield_facts(
-                &mut vmctx,
-                n: u64,
-            ) -> u64 {
-                fn fact(vmctx: &mut Vmctx, n: u64) -> u64 {
-                    let result = if n <= 1 {
-                        1
-                    } else {
-                        n * fact(vmctx, n - 1)
-                    };
-                    vmctx.yield_val(result);
-                    result
-                }
-                fact(vmctx, n)
-            }
+            fact(vmctx, n)
         }
 
         pub enum CoopFactsK {
@@ -145,24 +127,20 @@ macro_rules! host_tests {
             Result(u64),
         }
 
-        lucet_hostcalls! {
-            #[no_mangle]
-            pub unsafe extern "C" fn hostcall_coop_facts(
-                &mut vmctx,
-                n: u64,
-            ) -> u64 {
-                fn fact(vmctx: &mut Vmctx, n: u64) -> u64 {
-                    let result = if n <= 1 {
-                        1
-                    } else {
-                        let n_rec = fact(vmctx, n - 1);
-                        vmctx.yield_val_expecting_val(CoopFactsK::Mult(n, n_rec))
-                    };
-                    vmctx.yield_val(CoopFactsK::Result(result));
-                    result
-                }
-                fact(vmctx, n)
+        #[lucet_hostcall]
+        #[no_mangle]
+        pub fn hostcall_coop_facts(vmctx: &mut Vmctx, n: u64) -> u64 {
+            fn fact(vmctx: &mut Vmctx, n: u64) -> u64 {
+                let result = if n <= 1 {
+                    1
+                } else {
+                    let n_rec = fact(vmctx, n - 1);
+                    vmctx.yield_val_expecting_val(CoopFactsK::Mult(n, n_rec))
+                };
+                vmctx.yield_val(CoopFactsK::Result(result));
+                result
             }
+            fact(vmctx, n)
         }
 
         #[test]

--- a/lucet-runtime/lucet-runtime-tests/src/strcmp.rs
+++ b/lucet-runtime/lucet-runtime-tests/src/strcmp.rs
@@ -2,19 +2,18 @@
 macro_rules! strcmp_tests {
     ( $TestRegion:path ) => {
         use libc::{c_char, c_int, c_void, strcmp};
-        use lucet_runtime::vmctx::lucet_vmctx;
-        use lucet_runtime::{lucet_hostcalls, Error, Limits, Region, Val, WASM_PAGE_SIZE};
+        use lucet_runtime::vmctx::{lucet_vmctx, Vmctx};
+        use lucet_runtime::{lucet_hostcall, Error, Limits, Region, Val, WASM_PAGE_SIZE};
         use std::ffi::CString;
         use std::sync::Arc;
         use $TestRegion as TestRegion;
         use $crate::build::test_module_c;
 
-        lucet_hostcalls! {
-            #[no_mangle]
-            pub unsafe extern "C" fn hostcall_host_fault(
-                &mut _vmctx,
-            ) -> () {
-                let oob = (-1isize) as *mut c_char;
+        #[lucet_hostcall]
+        #[no_mangle]
+        pub fn hostcall_host_fault(_vmctx: &mut Vmctx) {
+            let oob = (-1isize) as *mut c_char;
+            unsafe {
                 *oob = 'x' as c_char;
             }
         }

--- a/lucet-runtime/lucet-runtime-tests/src/timeout.rs
+++ b/lucet-runtime/lucet-runtime-tests/src/timeout.rs
@@ -58,7 +58,7 @@ macro_rules! timeout_tests {
     ( $TestRegion:path ) => {
         use lucet_runtime::vmctx::{lucet_vmctx, Vmctx};
         use lucet_runtime::{
-            lucet_hostcall_terminate, lucet_hostcalls, DlModule, Error, FaultDetails, Instance,
+            lucet_hostcall, lucet_hostcall_terminate, DlModule, Error, FaultDetails, Instance,
             KillError, KillSuccess, Limits, Region, RunResult, SignalBehavior, TerminationDetails,
             TrapCode, YieldedVal,
         };
@@ -75,22 +75,18 @@ macro_rules! timeout_tests {
         use $crate::helpers::{FunctionPointer, MockExportBuilder, MockModuleBuilder};
         use $crate::timeout::mock_timeout_module;
 
-        lucet_hostcalls! {
-            #[no_mangle]
-            pub unsafe extern "C" fn slow_hostcall(
-                &mut vmctx,
-            ) -> bool {
-                // make a window of time so we can timeout in a hostcall
-                thread::sleep(Duration::from_millis(200));
-                true
-            }
+        #[lucet_hostcall]
+        #[no_mangle]
+        pub fn slow_hostcall(vmctx: &mut Vmctx) -> bool {
+            // make a window of time so we can timeout in a hostcall
+            thread::sleep(Duration::from_millis(200));
+            true
+        }
 
-            #[no_mangle]
-            pub unsafe extern "C" fn yielding_hostcall(
-                &mut vmctx,
-            ) -> () {
-                vmctx.yield_();
-            }
+        #[lucet_hostcall]
+        #[no_mangle]
+        pub fn yielding_hostcall(vmctx: &mut Vmctx) {
+            vmctx.yield_();
         }
 
         fn run_onetwothree(inst: &mut Instance) {

--- a/lucet-spectest/Cargo.toml
+++ b/lucet-spectest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-spectest"
-version = "0.4.1"
+version = "0.4.2"
 description = "Test harness to run WebAssembly spec tests (.wast) against the Lucet toolchain"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -17,9 +17,9 @@ name = "spec-test"
 path = "src/main.rs"
 
 [dependencies]
-lucetc = { path = "../lucetc", version = "0.4.1" }
-lucet-module = { path = "../lucet-module", version = "0.4.1" }
-lucet-runtime = { path = "../lucet-runtime", version = "0.4.1" }
+lucetc = { path = "../lucetc", version = "0.4.2" }
+lucet-module = { path = "../lucet-module", version = "0.4.2" }
+lucet-runtime = { path = "../lucet-runtime", version = "0.4.2" }
 wabt = "0.9.2"
 serde = "1.0"
 serde_json = "1.0"

--- a/lucet-spectest/src/bindings.rs
+++ b/lucet-spectest/src/bindings.rs
@@ -1,27 +1,24 @@
 use lucet_module::bindings::Bindings;
+use lucet_runtime::lucet_hostcall;
+use lucet_runtime::vmctx::Vmctx;
 use serde_json::json;
 
-use lucet_runtime::lucet_hostcalls;
-
-lucet_hostcalls! {
-    #[no_mangle]
-    pub unsafe extern "C" fn print(&mut _vmctx,) -> () {
-        println!("hello, world!");
-    }
+#[lucet_hostcall]
+#[no_mangle]
+pub fn print(_vmctx: &mut Vmctx) {
+    println!("hello, world!");
 }
 
-lucet_hostcalls! {
-    #[no_mangle]
-    pub unsafe extern "C" fn print_i32(&mut _vmctx, x: i32,) -> () {
-        println!("{}", x);
-    }
+#[lucet_hostcall]
+#[no_mangle]
+pub fn print_i32(_vmctx: &mut Vmctx, x: i32) {
+    println!("{}", x);
 }
 
-lucet_hostcalls! {
-    #[no_mangle]
-    pub unsafe extern "C" fn print_f32(&mut _vmctx, x: i32,) -> () {
-        println!("{}", x);
-    }
+#[lucet_hostcall]
+#[no_mangle]
+pub fn print_f32(_vmctx: &mut Vmctx, x: i32) {
+    println!("{}", x);
 }
 
 pub fn spec_test_bindings() -> Bindings {

--- a/lucet-validate/Cargo.toml
+++ b/lucet-validate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-validate"
-version = "0.4.1"
+version = "0.4.2"
 description = "Parse and validate webassembly files against witx interface"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -24,7 +24,7 @@ cranelift-entity = { path = "../cranelift/cranelift-entity", version = "0.46.1" 
 wasmparser = "0.39.1"
 
 [dev-dependencies]
-lucet-wasi-sdk = { path = "../lucet-wasi-sdk", version = "0.4.1" }
+lucet-wasi-sdk = { path = "../lucet-wasi-sdk", version = "0.4.2" }
 tempfile = "3.0"
 wabt = "0.9.2"
 

--- a/lucet-wasi-fuzz/Cargo.toml
+++ b/lucet-wasi-fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-wasi-fuzz"
-version = "0.4.1"
+version = "0.4.2"
 description = "Test the Lucet toolchain against native code execution using Csmith"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"

--- a/lucet-wasi-sdk/Cargo.toml
+++ b/lucet-wasi-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-wasi-sdk"
-version = "0.4.1"
+version = "0.4.2"
 description = "A Rust interface to the wasi-sdk compiler and linker"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -11,9 +11,9 @@ edition = "2018"
 
 [dependencies]
 failure = "0.1"
-lucetc = { path = "../lucetc", version = "0.4.1" }
-lucet-module = { path = "../lucet-module", version = "0.4.1" }
+lucetc = { path = "../lucetc", version = "0.4.2" }
+lucet-module = { path = "../lucet-module", version = "0.4.2" }
 tempfile = "3.0"
 
 [dev-dependencies]
-lucet-validate = { path = "../lucet-validate", version  = "0.4.1" }
+lucet-validate = { path = "../lucet-validate", version  = "0.4.2" }

--- a/lucet-wasi/Cargo.toml
+++ b/lucet-wasi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-wasi"
-version = "0.4.1"
+version = "0.4.2"
 description = "Fastly's runtime for the WebAssembly System Interface (WASI)"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -28,17 +28,17 @@ cast = "0.2"
 clap = "2.23"
 failure = "0.1"
 human-size = "0.4"
-lucet-runtime = { path = "../lucet-runtime", version = "0.4.1" }
-lucet-runtime-internals = { path = "../lucet-runtime/lucet-runtime-internals", version = "0.4.1" }
-lucet-module = { path = "../lucet-module", version = "0.4.1" }
+lucet-runtime = { path = "../lucet-runtime", version = "0.4.2" }
+lucet-runtime-internals = { path = "../lucet-runtime/lucet-runtime-internals", version = "0.4.2" }
+lucet-module = { path = "../lucet-module", version = "0.4.2" }
 libc = "0.2.65"
 nix = "0.15"
 rand = "0.6"
 wasi-common = { git = "https://github.com/cranestation/wasi-common", rev = "f4ac1299b2001b575cfc99f5544a4a96355a6bff" }
 
 [dev-dependencies]
-lucet-wasi-sdk = { path = "../lucet-wasi-sdk", version = "0.4.1" }
-lucetc = { path = "../lucetc", version = "0.4.1" }
+lucet-wasi-sdk = { path = "../lucet-wasi-sdk", version = "0.4.2" }
+lucetc = { path = "../lucetc", version = "0.4.2" }
 tempfile = "3.0"
 
 [build-dependencies]

--- a/lucet-wasi/src/wasi.rs
+++ b/lucet-wasi/src/wasi.rs
@@ -1,27 +1,23 @@
 #![allow(clippy::too_many_arguments)]
 
-pub use lucet_runtime::{self, vmctx::lucet_vmctx};
-pub use wasi_common::{wasi, wasi32, WasiCtx};
-
-use lucet_runtime::lucet_hostcall_terminate;
+use lucet_runtime::vmctx::Vmctx;
+use lucet_runtime::{lucet_hostcall, lucet_hostcall_terminate};
 use std::mem;
 use std::rc::Rc;
 use wasi_common::hostcalls::*;
+use wasi_common::{wasi, wasi32, WasiCtx};
 
-lucet_runtime::lucet_hostcalls! {
-
+#[lucet_hostcall]
 #[no_mangle]
-pub unsafe extern "C" fn __wasi_proc_exit(
-    &mut _lucet_vmctx,
-    rval: wasi::__wasi_exitcode_t,
-) -> ! {
+pub unsafe fn __wasi_proc_exit(_lucet_ctx: &mut Vmctx, rval: wasi::__wasi_exitcode_t) -> ! {
     export_wasi_funcs();
     lucet_hostcall_terminate!(rval);
 }
 
+#[lucet_hostcall]
 #[no_mangle]
-pub unsafe extern "C" fn __wasi_args_get(
-    &mut lucet_ctx,
+pub unsafe fn __wasi_args_get(
+    lucet_ctx: &mut Vmctx,
     argv_ptr: wasi32::uintptr_t,
     argv_buf: wasi32::uintptr_t,
 ) -> wasi::__wasi_errno_t {
@@ -30,9 +26,10 @@ pub unsafe extern "C" fn __wasi_args_get(
     args_get(wasi_ctx, heap, argv_ptr, argv_buf)
 }
 
+#[lucet_hostcall]
 #[no_mangle]
-pub unsafe extern "C" fn __wasi_args_sizes_get(
-    &mut lucet_ctx,
+pub unsafe fn __wasi_args_sizes_get(
+    lucet_ctx: &mut Vmctx,
     argc_ptr: wasi32::uintptr_t,
     argv_buf_size_ptr: wasi32::uintptr_t,
 ) -> wasi::__wasi_errno_t {
@@ -41,14 +38,16 @@ pub unsafe extern "C" fn __wasi_args_sizes_get(
     args_sizes_get(wasi_ctx, heap, argc_ptr, argv_buf_size_ptr)
 }
 
+#[lucet_hostcall]
 #[no_mangle]
-pub unsafe extern "C" fn __wasi_sched_yield(&mut _lucet_ctx,) -> wasi::__wasi_errno_t {
+pub unsafe fn __wasi_sched_yield(_lucet_ctx: &mut Vmctx) -> wasi::__wasi_errno_t {
     sched_yield()
 }
 
+#[lucet_hostcall]
 #[no_mangle]
-pub unsafe extern "C" fn __wasi_clock_res_get(
-    &mut lucet_ctx,
+pub unsafe fn __wasi_clock_res_get(
+    lucet_ctx: &mut Vmctx,
     clock_id: wasi::__wasi_clockid_t,
     resolution_ptr: wasi32::uintptr_t,
 ) -> wasi::__wasi_errno_t {
@@ -56,9 +55,10 @@ pub unsafe extern "C" fn __wasi_clock_res_get(
     clock_res_get(heap, clock_id, resolution_ptr)
 }
 
+#[lucet_hostcall]
 #[no_mangle]
-pub unsafe extern "C" fn __wasi_clock_time_get(
-    &mut lucet_ctx,
+pub unsafe fn __wasi_clock_time_get(
+    lucet_ctx: &mut Vmctx,
     clock_id: wasi::__wasi_clockid_t,
     precision: wasi::__wasi_timestamp_t,
     time_ptr: wasi32::uintptr_t,
@@ -67,9 +67,10 @@ pub unsafe extern "C" fn __wasi_clock_time_get(
     clock_time_get(heap, clock_id, precision, time_ptr)
 }
 
+#[lucet_hostcall]
 #[no_mangle]
-pub unsafe extern "C" fn __wasi_environ_get(
-    &mut lucet_ctx,
+pub unsafe fn __wasi_environ_get(
+    lucet_ctx: &mut Vmctx,
     environ_ptr: wasi32::uintptr_t,
     environ_buf: wasi32::uintptr_t,
 ) -> wasi::__wasi_errno_t {
@@ -78,9 +79,10 @@ pub unsafe extern "C" fn __wasi_environ_get(
     environ_get(wasi_ctx, heap, environ_ptr, environ_buf)
 }
 
+#[lucet_hostcall]
 #[no_mangle]
-pub unsafe extern "C" fn __wasi_environ_sizes_get(
-    &mut lucet_ctx,
+pub unsafe fn __wasi_environ_sizes_get(
+    lucet_ctx: &mut Vmctx,
     environ_count_ptr: wasi32::uintptr_t,
     environ_size_ptr: wasi32::uintptr_t,
 ) -> wasi::__wasi_errno_t {
@@ -89,18 +91,20 @@ pub unsafe extern "C" fn __wasi_environ_sizes_get(
     environ_sizes_get(wasi_ctx, heap, environ_count_ptr, environ_size_ptr)
 }
 
+#[lucet_hostcall]
 #[no_mangle]
-pub unsafe extern "C" fn __wasi_fd_close(
-    &mut lucet_ctx,
+pub unsafe fn __wasi_fd_close(
+    lucet_ctx: &mut Vmctx,
     fd: wasi::__wasi_fd_t,
 ) -> wasi::__wasi_errno_t {
     let wasi_ctx = &mut lucet_ctx.get_embed_ctx_mut::<WasiCtx>();
     fd_close(wasi_ctx, fd)
 }
 
+#[lucet_hostcall]
 #[no_mangle]
-pub unsafe extern "C" fn __wasi_fd_fdstat_get(
-    &mut lucet_ctx,
+pub unsafe fn __wasi_fd_fdstat_get(
+    lucet_ctx: &mut Vmctx,
     fd: wasi::__wasi_fd_t,
     fdstat_ptr: wasi32::uintptr_t,
 ) -> wasi::__wasi_errno_t {
@@ -109,9 +113,10 @@ pub unsafe extern "C" fn __wasi_fd_fdstat_get(
     fd_fdstat_get(wasi_ctx, heap, fd, fdstat_ptr)
 }
 
+#[lucet_hostcall]
 #[no_mangle]
-pub unsafe extern "C" fn __wasi_fd_fdstat_set_flags(
-    &mut lucet_ctx,
+pub unsafe fn __wasi_fd_fdstat_set_flags(
+    lucet_ctx: &mut Vmctx,
     fd: wasi::__wasi_fd_t,
     fdflags: wasi::__wasi_fdflags_t,
 ) -> wasi::__wasi_errno_t {
@@ -119,9 +124,10 @@ pub unsafe extern "C" fn __wasi_fd_fdstat_set_flags(
     fd_fdstat_set_flags(wasi_ctx, fd, fdflags)
 }
 
+#[lucet_hostcall]
 #[no_mangle]
-pub unsafe extern "C" fn __wasi_fd_tell(
-    &mut lucet_ctx,
+pub unsafe fn __wasi_fd_tell(
+    lucet_ctx: &mut Vmctx,
     fd: wasi::__wasi_fd_t,
     offset: wasi32::uintptr_t,
 ) -> wasi::__wasi_errno_t {
@@ -130,9 +136,10 @@ pub unsafe extern "C" fn __wasi_fd_tell(
     fd_tell(wasi_ctx, heap, fd, offset)
 }
 
+#[lucet_hostcall]
 #[no_mangle]
-pub unsafe extern "C" fn __wasi_fd_seek(
-    &mut lucet_ctx,
+pub unsafe fn __wasi_fd_seek(
+    lucet_ctx: &mut Vmctx,
     fd: wasi::__wasi_fd_t,
     offset: wasi::__wasi_filedelta_t,
     whence: wasi::__wasi_whence_t,
@@ -143,9 +150,10 @@ pub unsafe extern "C" fn __wasi_fd_seek(
     fd_seek(wasi_ctx, heap, fd, offset, whence, newoffset)
 }
 
+#[lucet_hostcall]
 #[no_mangle]
-pub unsafe extern "C" fn __wasi_fd_prestat_get(
-    &mut lucet_ctx,
+pub unsafe fn __wasi_fd_prestat_get(
+    lucet_ctx: &mut Vmctx,
     fd: wasi::__wasi_fd_t,
     prestat_ptr: wasi32::uintptr_t,
 ) -> wasi::__wasi_errno_t {
@@ -154,9 +162,10 @@ pub unsafe extern "C" fn __wasi_fd_prestat_get(
     fd_prestat_get(wasi_ctx, heap, fd, prestat_ptr)
 }
 
+#[lucet_hostcall]
 #[no_mangle]
-pub unsafe extern "C" fn __wasi_fd_prestat_dir_name(
-    &mut lucet_ctx,
+pub unsafe fn __wasi_fd_prestat_dir_name(
+    lucet_ctx: &mut Vmctx,
     fd: wasi::__wasi_fd_t,
     path_ptr: wasi32::uintptr_t,
     path_len: wasi32::size_t,
@@ -166,9 +175,10 @@ pub unsafe extern "C" fn __wasi_fd_prestat_dir_name(
     fd_prestat_dir_name(wasi_ctx, heap, fd, path_ptr, path_len)
 }
 
+#[lucet_hostcall]
 #[no_mangle]
-pub unsafe extern "C" fn __wasi_fd_read(
-    &mut lucet_ctx,
+pub unsafe fn __wasi_fd_read(
+    lucet_ctx: &mut Vmctx,
     fd: wasi::__wasi_fd_t,
     iovs_ptr: wasi32::uintptr_t,
     iovs_len: wasi32::size_t,
@@ -179,9 +189,10 @@ pub unsafe extern "C" fn __wasi_fd_read(
     fd_read(wasi_ctx, heap, fd, iovs_ptr, iovs_len, nread)
 }
 
+#[lucet_hostcall]
 #[no_mangle]
-pub unsafe extern "C" fn __wasi_fd_write(
-    &mut lucet_ctx,
+pub unsafe fn __wasi_fd_write(
+    lucet_ctx: &mut Vmctx,
     fd: wasi::__wasi_fd_t,
     iovs_ptr: wasi32::uintptr_t,
     iovs_len: wasi32::size_t,
@@ -192,9 +203,10 @@ pub unsafe extern "C" fn __wasi_fd_write(
     fd_write(wasi_ctx, heap, fd, iovs_ptr, iovs_len, nwritten)
 }
 
+#[lucet_hostcall]
 #[no_mangle]
-pub unsafe extern "C" fn __wasi_path_open(
-    &mut lucet_ctx,
+pub unsafe fn __wasi_path_open(
+    lucet_ctx: &mut Vmctx,
     dirfd: wasi::__wasi_fd_t,
     dirflags: wasi::__wasi_lookupflags_t,
     path_ptr: wasi32::uintptr_t,
@@ -222,9 +234,10 @@ pub unsafe extern "C" fn __wasi_path_open(
     )
 }
 
+#[lucet_hostcall]
 #[no_mangle]
-pub unsafe extern "C" fn __wasi_random_get(
-    &mut lucet_ctx,
+pub unsafe fn __wasi_random_get(
+    lucet_ctx: &mut Vmctx,
     buf_ptr: wasi32::uintptr_t,
     buf_len: wasi32::size_t,
 ) -> wasi::__wasi_errno_t {
@@ -232,9 +245,10 @@ pub unsafe extern "C" fn __wasi_random_get(
     random_get(heap, buf_ptr, buf_len)
 }
 
+#[lucet_hostcall]
 #[no_mangle]
-pub unsafe extern "C" fn __wasi_poll_oneoff(
-    &mut lucet_ctx,
+pub unsafe fn __wasi_poll_oneoff(
+    lucet_ctx: &mut Vmctx,
     input: wasi32::uintptr_t,
     output: wasi32::uintptr_t,
     nsubscriptions: wasi32::size_t,
@@ -245,9 +259,10 @@ pub unsafe extern "C" fn __wasi_poll_oneoff(
     poll_oneoff(wasi_ctx, heap, input, output, nsubscriptions, nevents)
 }
 
+#[lucet_hostcall]
 #[no_mangle]
-pub unsafe extern "C" fn __wasi_fd_filestat_get(
-    &mut lucet_ctx,
+pub unsafe fn __wasi_fd_filestat_get(
+    lucet_ctx: &mut Vmctx,
     fd: wasi::__wasi_fd_t,
     filestat_ptr: wasi32::uintptr_t,
 ) -> wasi::__wasi_errno_t {
@@ -256,9 +271,10 @@ pub unsafe extern "C" fn __wasi_fd_filestat_get(
     fd_filestat_get(wasi_ctx, heap, fd, filestat_ptr)
 }
 
+#[lucet_hostcall]
 #[no_mangle]
-pub unsafe extern "C" fn __wasi_path_filestat_get(
-    &mut lucet_ctx,
+pub unsafe fn __wasi_path_filestat_get(
+    lucet_ctx: &mut Vmctx,
     dirfd: wasi::__wasi_fd_t,
     dirflags: wasi::__wasi_lookupflags_t,
     path_ptr: wasi32::uintptr_t,
@@ -278,9 +294,10 @@ pub unsafe extern "C" fn __wasi_path_filestat_get(
     )
 }
 
+#[lucet_hostcall]
 #[no_mangle]
-pub unsafe extern "C" fn __wasi_path_create_directory(
-    &mut lucet_ctx,
+pub unsafe fn __wasi_path_create_directory(
+    lucet_ctx: &mut Vmctx,
     dirfd: wasi::__wasi_fd_t,
     path_ptr: wasi32::uintptr_t,
     path_len: wasi32::size_t,
@@ -290,9 +307,10 @@ pub unsafe extern "C" fn __wasi_path_create_directory(
     path_create_directory(wasi_ctx, heap, dirfd, path_ptr, path_len)
 }
 
+#[lucet_hostcall]
 #[no_mangle]
-pub unsafe extern "C" fn __wasi_path_unlink_file(
-    &mut lucet_ctx,
+pub unsafe fn __wasi_path_unlink_file(
+    lucet_ctx: &mut Vmctx,
     dirfd: wasi::__wasi_fd_t,
     path_ptr: wasi32::uintptr_t,
     path_len: wasi32::size_t,
@@ -302,9 +320,10 @@ pub unsafe extern "C" fn __wasi_path_unlink_file(
     path_unlink_file(wasi_ctx, heap, dirfd, path_ptr, path_len)
 }
 
+#[lucet_hostcall]
 #[no_mangle]
-pub unsafe extern "C" fn __wasi_fd_allocate(
-    &mut lucet_ctx,
+pub unsafe fn __wasi_fd_allocate(
+    lucet_ctx: &mut Vmctx,
     fd: wasi::__wasi_fd_t,
     offset: wasi::__wasi_filesize_t,
     len: wasi::__wasi_filesize_t,
@@ -313,9 +332,10 @@ pub unsafe extern "C" fn __wasi_fd_allocate(
     fd_allocate(wasi_ctx, fd, offset, len)
 }
 
+#[lucet_hostcall]
 #[no_mangle]
-pub unsafe extern "C" fn __wasi_fd_advise(
-    &mut lucet_ctx,
+pub unsafe fn __wasi_fd_advise(
+    lucet_ctx: &mut Vmctx,
     fd: wasi::__wasi_fd_t,
     offset: wasi::__wasi_filesize_t,
     len: wasi::__wasi_filesize_t,
@@ -325,27 +345,27 @@ pub unsafe extern "C" fn __wasi_fd_advise(
     fd_advise(wasi_ctx, fd, offset, len, advice)
 }
 
+#[lucet_hostcall]
 #[no_mangle]
-pub unsafe extern "C" fn __wasi_fd_datasync(
-    &mut lucet_ctx,
+pub unsafe fn __wasi_fd_datasync(
+    lucet_ctx: &mut Vmctx,
     fd: wasi::__wasi_fd_t,
 ) -> wasi::__wasi_errno_t {
     let wasi_ctx = &lucet_ctx.get_embed_ctx::<WasiCtx>();
     fd_datasync(wasi_ctx, fd)
 }
 
+#[lucet_hostcall]
 #[no_mangle]
-pub unsafe extern "C" fn __wasi_fd_sync(
-    &mut lucet_ctx,
-    fd: wasi::__wasi_fd_t,
-) -> wasi::__wasi_errno_t {
+pub unsafe fn __wasi_fd_sync(lucet_ctx: &mut Vmctx, fd: wasi::__wasi_fd_t) -> wasi::__wasi_errno_t {
     let wasi_ctx = &lucet_ctx.get_embed_ctx::<WasiCtx>();
     fd_sync(wasi_ctx, fd)
 }
 
+#[lucet_hostcall]
 #[no_mangle]
-pub unsafe extern "C" fn __wasi_fd_fdstat_set_rights(
-    &mut lucet_ctx,
+pub unsafe fn __wasi_fd_fdstat_set_rights(
+    lucet_ctx: &mut Vmctx,
     fd: wasi::__wasi_fd_t,
     fs_rights_base: wasi::__wasi_rights_t,
     fs_rights_inheriting: wasi::__wasi_rights_t,
@@ -354,9 +374,10 @@ pub unsafe extern "C" fn __wasi_fd_fdstat_set_rights(
     fd_fdstat_set_rights(wasi_ctx, fd, fs_rights_base, fs_rights_inheriting)
 }
 
+#[lucet_hostcall]
 #[no_mangle]
-pub unsafe extern "C" fn __wasi_fd_filestat_set_size(
-    &mut lucet_ctx,
+pub unsafe fn __wasi_fd_filestat_set_size(
+    lucet_ctx: &mut Vmctx,
     fd: wasi::__wasi_fd_t,
     st_size: wasi::__wasi_filesize_t,
 ) -> wasi::__wasi_errno_t {
@@ -364,9 +385,10 @@ pub unsafe extern "C" fn __wasi_fd_filestat_set_size(
     fd_filestat_set_size(wasi_ctx, fd, st_size)
 }
 
+#[lucet_hostcall]
 #[no_mangle]
-pub unsafe extern "C" fn __wasi_fd_filestat_set_times(
-    &mut lucet_ctx,
+pub unsafe fn __wasi_fd_filestat_set_times(
+    lucet_ctx: &mut Vmctx,
     fd: wasi::__wasi_fd_t,
     st_atim: wasi::__wasi_timestamp_t,
     st_mtim: wasi::__wasi_timestamp_t,
@@ -376,9 +398,10 @@ pub unsafe extern "C" fn __wasi_fd_filestat_set_times(
     fd_filestat_set_times(wasi_ctx, fd, st_atim, st_mtim, fst_flags)
 }
 
+#[lucet_hostcall]
 #[no_mangle]
-pub unsafe extern "C" fn __wasi_fd_pread(
-    &mut lucet_ctx,
+pub unsafe fn __wasi_fd_pread(
+    lucet_ctx: &mut Vmctx,
     fd: wasi::__wasi_fd_t,
     iovs_ptr: wasi32::uintptr_t,
     iovs_len: wasi32::size_t,
@@ -390,9 +413,10 @@ pub unsafe extern "C" fn __wasi_fd_pread(
     fd_pread(wasi_ctx, heap, fd, iovs_ptr, iovs_len, offset, nread)
 }
 
+#[lucet_hostcall]
 #[no_mangle]
-pub unsafe extern "C" fn __wasi_fd_pwrite(
-    &mut lucet_ctx,
+pub unsafe fn __wasi_fd_pwrite(
+    lucet_ctx: &mut Vmctx,
     fd: wasi::__wasi_fd_t,
     iovs_ptr: wasi32::uintptr_t,
     iovs_len: wasi32::size_t,
@@ -404,9 +428,10 @@ pub unsafe extern "C" fn __wasi_fd_pwrite(
     fd_pwrite(wasi_ctx, heap, fd, iovs_ptr, iovs_len, offset, nwritten)
 }
 
+#[lucet_hostcall]
 #[no_mangle]
-pub unsafe extern "C" fn __wasi_fd_readdir(
-    &mut lucet_ctx,
+pub unsafe fn __wasi_fd_readdir(
+    lucet_ctx: &mut Vmctx,
     fd: wasi::__wasi_fd_t,
     buf: wasi32::uintptr_t,
     buf_len: wasi32::size_t,
@@ -418,9 +443,10 @@ pub unsafe extern "C" fn __wasi_fd_readdir(
     fd_readdir(wasi_ctx, heap, fd, buf, buf_len, cookie, bufused)
 }
 
+#[lucet_hostcall]
 #[no_mangle]
-pub unsafe extern "C" fn __wasi_fd_renumber(
-    &mut lucet_ctx,
+pub unsafe fn __wasi_fd_renumber(
+    lucet_ctx: &mut Vmctx,
     from: wasi::__wasi_fd_t,
     to: wasi::__wasi_fd_t,
 ) -> wasi::__wasi_errno_t {
@@ -428,9 +454,10 @@ pub unsafe extern "C" fn __wasi_fd_renumber(
     fd_renumber(wasi_ctx, from, to)
 }
 
+#[lucet_hostcall]
 #[no_mangle]
-pub unsafe extern "C" fn __wasi_path_filestat_set_times(
-    &mut lucet_ctx,
+pub unsafe fn __wasi_path_filestat_set_times(
+    lucet_ctx: &mut Vmctx,
     dirfd: wasi::__wasi_fd_t,
     dirflags: wasi::__wasi_lookupflags_t,
     path_ptr: wasi32::uintptr_t,
@@ -446,9 +473,10 @@ pub unsafe extern "C" fn __wasi_path_filestat_set_times(
     )
 }
 
+#[lucet_hostcall]
 #[no_mangle]
-pub unsafe extern "C" fn __wasi_path_link(
-    &mut lucet_ctx,
+pub unsafe fn __wasi_path_link(
+    lucet_ctx: &mut Vmctx,
     old_fd: wasi::__wasi_fd_t,
     old_flags: wasi::__wasi_lookupflags_t,
     old_path_ptr: wasi32::uintptr_t,
@@ -472,9 +500,10 @@ pub unsafe extern "C" fn __wasi_path_link(
     )
 }
 
+#[lucet_hostcall]
 #[no_mangle]
-pub unsafe extern "C" fn __wasi_path_readlink(
-    &mut lucet_ctx,
+pub unsafe fn __wasi_path_readlink(
+    lucet_ctx: &mut Vmctx,
     dirfd: wasi::__wasi_fd_t,
     path_ptr: wasi32::uintptr_t,
     path_len: wasi32::size_t,
@@ -489,9 +518,10 @@ pub unsafe extern "C" fn __wasi_path_readlink(
     )
 }
 
+#[lucet_hostcall]
 #[no_mangle]
-pub unsafe extern "C" fn __wasi_path_remove_directory(
-    &mut lucet_ctx,
+pub unsafe fn __wasi_path_remove_directory(
+    lucet_ctx: &mut Vmctx,
     dirfd: wasi::__wasi_fd_t,
     path_ptr: wasi32::uintptr_t,
     path_len: wasi32::size_t,
@@ -501,9 +531,10 @@ pub unsafe extern "C" fn __wasi_path_remove_directory(
     path_remove_directory(wasi_ctx, heap, dirfd, path_ptr, path_len)
 }
 
+#[lucet_hostcall]
 #[no_mangle]
-pub unsafe extern "C" fn __wasi_path_rename(
-    &mut lucet_ctx,
+pub unsafe fn __wasi_path_rename(
+    lucet_ctx: &mut Vmctx,
     old_dirfd: wasi::__wasi_fd_t,
     old_path_ptr: wasi32::uintptr_t,
     old_path_len: wasi32::size_t,
@@ -525,9 +556,10 @@ pub unsafe extern "C" fn __wasi_path_rename(
     )
 }
 
+#[lucet_hostcall]
 #[no_mangle]
-pub unsafe extern "C" fn __wasi_path_symlink(
-    &mut lucet_ctx,
+pub unsafe fn __wasi_path_symlink(
+    lucet_ctx: &mut Vmctx,
     old_path_ptr: wasi32::uintptr_t,
     old_path_len: wasi32::size_t,
     dir_fd: wasi::__wasi_fd_t,
@@ -545,8 +577,6 @@ pub unsafe extern "C" fn __wasi_path_symlink(
         new_path_ptr,
         new_path_len,
     )
-}
-
 }
 
 pub fn export_wasi_funcs() {

--- a/lucetc/Cargo.toml
+++ b/lucetc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucetc"
-version = "0.4.1"
+version = "0.4.2"
 description = "Fastly's WebAssembly to native code compiler"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -23,8 +23,8 @@ cranelift-module = { path = "../cranelift/cranelift-module", version = "0.46.1" 
 cranelift-faerie = { path = "../cranelift/cranelift-faerie", version = "0.46.1" }
 cranelift-wasm = { path = "../cranelift/cranelift-wasm", version = "0.46.1" }
 target-lexicon = "0.8.0"
-lucet-module = { path = "../lucet-module", version = "0.4.1" }
-lucet-validate = { path = "../lucet-validate", version = "0.4.1" }
+lucet-module = { path = "../lucet-module", version = "0.4.2" }
+lucet-validate = { path = "../lucet-validate", version = "0.4.2" }
 wasmparser = "0.39.1"
 clap="2.32"
 log = "0.4"


### PR DESCRIPTION
The attribute macro is much more flexible syntactically, and in particular allows hostcall implementations to be properly `rustfmt`ed rather than being stuck in the invocation of a macro.

This PR also bumps the version to 0.4.2 due to a new API and a deprecation.

Unfortunately the size of the diff is pretty large on this patch, but it's mostly due to the indentation changes that are necessary when converting from a macro invocation block to an attribute.
