### PR TITLE
upgrade cranelift, wasi-common, witx deps, and friends

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -1,5 +1,9 @@
 name: 'Test Lucet'
 description: 'run tests using standardized lucet development environment'
+inputs:
+  target:
+    description: "Makefile target to execute"
+    required: true
 runs:
   using: 'docker'
   image: '../../../Dockerfile'
@@ -11,4 +15,4 @@ runs:
       # rustup expects $HOME to be set to /root during `docker run` because thats what
       # it was set to during container creation. Actions clears $HOME so we set it here.
       # The test target of the Makefile is our standard CI.
-    - 'export HOME=/root; make test'
+    - 'export HOME=/root; make ${{ inputs.target }}'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,9 +13,29 @@ jobs:
     # Testing uses the development environment Docker container.
     # This action builds the container and executes the test suite inside it.
     - uses: ./.github/actions/test
+      with:
+        target: test
 
     - name: Ensure testing did not change sources
       run: git diff --exit-code
+
+  package:
+    name: Package
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+      with:
+        submodules: true
+
+    # Testing uses the development environment Docker container.
+    # This action builds the container and executes the test suite inside it.
+    - uses: ./.github/actions/test
+      with:
+        target: package
+
+    - name: Ensure testing did not change sources
+      run: git diff --exit-code
+
 
   rustfmt:
     name: Rustfmt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,6 +22,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "approx"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -283,93 +288,96 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.46.1"
+version = "0.51.0"
 dependencies = [
- "cranelift-entity 0.46.1",
+ "cranelift-entity 0.51.0",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.46.1"
+version = "0.51.0"
 dependencies = [
- "cranelift-bforest 0.46.1",
- "cranelift-codegen-meta 0.46.1",
- "cranelift-codegen-shared 0.46.1",
- "cranelift-entity 0.46.1",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cranelift-bforest 0.51.0",
+ "cranelift-codegen-meta 0.51.0",
+ "cranelift-codegen-shared 0.51.0",
+ "cranelift-entity 0.51.0",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "target-lexicon 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "target-lexicon 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.46.1"
+version = "0.51.0"
 dependencies = [
- "cranelift-codegen-shared 0.46.1",
- "cranelift-entity 0.46.1",
+ "cranelift-codegen-shared 0.51.0",
+ "cranelift-entity 0.51.0",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.46.1"
+version = "0.51.0"
+dependencies = [
+ "packed_struct 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "packed_struct_codegen 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.46.1"
+version = "0.51.0"
 
 [[package]]
 name = "cranelift-faerie"
-version = "0.46.1"
+version = "0.51.0"
 dependencies = [
- "cranelift-codegen 0.46.1",
- "cranelift-module 0.46.1",
- "faerie 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cranelift-codegen 0.51.0",
+ "cranelift-module 0.51.0",
+ "faerie 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "goblin 0.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "target-lexicon 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "goblin 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "target-lexicon 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.46.1"
+version = "0.51.0"
 dependencies = [
- "cranelift-codegen 0.46.1",
+ "cranelift-codegen 0.51.0",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "target-lexicon 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "target-lexicon 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "cranelift-module"
-version = "0.46.1"
+version = "0.51.0"
 dependencies = [
- "cranelift-codegen 0.46.1",
- "cranelift-entity 0.46.1",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cranelift-codegen 0.51.0",
+ "cranelift-entity 0.51.0",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "cranelift-native"
-version = "0.46.1"
+version = "0.51.0"
 dependencies = [
- "cranelift-codegen 0.46.1",
- "raw-cpuid 6.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "target-lexicon 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cranelift-codegen 0.51.0",
+ "raw-cpuid 7.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "target-lexicon 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.46.1"
+version = "0.51.0"
 dependencies = [
- "cranelift-codegen 0.46.1",
- "cranelift-entity 0.46.1",
- "cranelift-frontend 0.46.1",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cranelift-codegen 0.51.0",
+ "cranelift-entity 0.51.0",
+ "cranelift-frontend 0.51.0",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmparser 0.39.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -546,16 +554,16 @@ dependencies = [
 
 [[package]]
 name = "faerie"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "goblin 0.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "goblin 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "scroll 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scroll 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "string-interner 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "target-lexicon 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "target-lexicon 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -655,6 +663,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "goblin"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "plain 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scroll 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "heck"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -742,6 +760,11 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "leb128"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "libc"
 version = "0.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -786,7 +809,7 @@ version = "0.4.1"
 dependencies = [
  "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "cranelift-entity 0.46.1",
+ "cranelift-entity 0.51.0",
  "derivative 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "memoffset 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -886,13 +909,13 @@ name = "lucet-validate"
 version = "0.4.1"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cranelift-entity 0.46.1",
+ "cranelift-entity 0.51.0",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lucet-wasi-sdk 0.4.1",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wabt 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmparser 0.39.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "witx 0.3.0",
+ "witx 0.6.0",
 ]
 
 [[package]]
@@ -913,7 +936,7 @@ dependencies = [
  "nix 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasi-common 0.4.0 (git+https://github.com/cranestation/wasi-common?rev=f4ac1299b2001b575cfc99f5544a4a96355a6bff)",
+ "wasi-common 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -958,15 +981,15 @@ dependencies = [
  "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cranelift-codegen 0.46.1",
- "cranelift-entity 0.46.1",
- "cranelift-faerie 0.46.1",
- "cranelift-frontend 0.46.1",
- "cranelift-module 0.46.1",
- "cranelift-native 0.46.1",
- "cranelift-wasm 0.46.1",
+ "cranelift-codegen 0.51.0",
+ "cranelift-entity 0.51.0",
+ "cranelift-faerie 0.51.0",
+ "cranelift-frontend 0.51.0",
+ "cranelift-module 0.51.0",
+ "cranelift-native 0.51.0",
+ "cranelift-wasm 0.51.0",
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "faerie 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "faerie 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "goblin 0.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "human-size 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -979,7 +1002,7 @@ dependencies = [
  "raw-cpuid 6.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "target-lexicon 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "target-lexicon 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wabt 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmonkey 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1161,6 +1184,25 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "packed_struct"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "packed_struct_codegen"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "packed_struct 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "parity-wasm"
 version = "0.40.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1251,6 +1293,11 @@ dependencies = [
 [[package]]
 name = "quick-error"
 version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "quote"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1442,6 +1489,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "raw-cpuid"
+version = "7.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rayon"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1572,6 +1629,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "scroll"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "scroll_derive 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "scroll_derive"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1579,6 +1644,16 @@ dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "scroll_derive"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1687,7 +1762,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "smallvec"
-version = "0.6.12"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1731,6 +1806,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "syn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "syn"
 version = "0.15.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -1747,6 +1832,14 @@ dependencies = [
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "synom"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1769,6 +1862,11 @@ dependencies = [
  "failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "target-lexicon"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "tempfile"
@@ -1809,6 +1907,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "thiserror-impl 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "thread_local"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1846,6 +1962,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "unicode-width"
 version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-xid"
+version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1919,12 +2040,12 @@ dependencies = [
 
 [[package]]
 name = "wasi-common"
-version = "0.4.0"
-source = "git+https://github.com/cranestation/wasi-common?rev=f4ac1299b2001b575cfc99f5544a4a96355a6bff#f4ac1299b2001b575cfc99f5544a4a96355a6bff"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "anyhow 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "cpu-time 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "filetime 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1932,15 +2053,17 @@ dependencies = [
  "nix 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasi-common-cbindgen 0.4.0 (git+https://github.com/cranestation/wasi-common?rev=f4ac1299b2001b575cfc99f5544a4a96355a6bff)",
+ "thiserror 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasi-common-cbindgen 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wig 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winx 0.4.0 (git+https://github.com/cranestation/wasi-common?rev=f4ac1299b2001b575cfc99f5544a4a96355a6bff)",
+ "winx 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasi-common-cbindgen"
-version = "0.4.0"
-source = "git+https://github.com/cranestation/wasi-common?rev=f4ac1299b2001b575cfc99f5544a4a96355a6bff#f4ac1299b2001b575cfc99f5544a4a96355a6bff"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1969,11 +2092,29 @@ version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "wast"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "leb128 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "which"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "wig"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "witx 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2035,8 +2176,8 @@ dependencies = [
 
 [[package]]
 name = "winx"
-version = "0.4.0"
-source = "git+https://github.com/cranestation/wasi-common?rev=f4ac1299b2001b575cfc99f5544a4a96355a6bff#f4ac1299b2001b575cfc99f5544a4a96355a6bff"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cvt 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2045,10 +2186,21 @@ dependencies = [
 
 [[package]]
 name = "witx"
-version = "0.3.0"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wast 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "witx"
+version = "0.6.0"
+dependencies = [
+ "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wast 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2060,6 +2212,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum adler32 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5d2e7343e7fc9de883d1b0341e0b13970f764c14101234857d2ddafa1cb1cac2"
 "checksum aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+"checksum anyhow 1.0.23 (registry+https://github.com/rust-lang/crates.io-index)" = "6f1072d8f55592084072d2d3cb23a4b680a8543c00f10d446118e85ad3718142"
 "checksum approx 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "08abcc3b4e9339e33a3d0a5ed15d84a687350c05689d825e0f6655eef9e76a94"
 "checksum arrayvec 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
 "checksum atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
@@ -2108,7 +2261,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
 "checksum errno 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c2a071601ed01b988f896ab14b95e67335d1eeb50190932a1320f7fe3cadc84e"
 "checksum errno-dragonfly 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "14ca354e36190500e1e1fb267c647932382b54053c50b14970856c0b00a35067"
-"checksum faerie 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "875d78b92b2a4d9e1e2c7eeccfa30a327d2ee6434db3beb8fd6fd92f41898bc4"
+"checksum faerie 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "01fed63609767c70e34203201032c249d60a24578a67ef0ce7cc13ff010e9cf2"
 "checksum failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f8273f13c977665c5db7eb2b99ae520952fe5ac831ae4cd09d80c4c7042b5ed9"
 "checksum failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0bc225b78e0391e4b8683440bf2e63c2deeeb2ce5189eab46e2b68c6d3725d08"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
@@ -2121,6 +2274,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 "checksum goblin 0.0.24 (registry+https://github.com/rust-lang/crates.io-index)" = "e3fa261d919c1ae9d1e4533c4a2f99e10938603c4208d56c05bec7a872b661b0"
+"checksum goblin 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5e6040506480da04a63de51a478e8021892d65d8411f29b2a422c2648bdd8bcb"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hermit-abi 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "307c3c9f937f38e3534b1d6447ecf090cafcc9744e4a6360e8b037b2cf5af120"
 "checksum hmac 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5dcb5e64cda4c23119ab41ba960d1e170a774c8e4b9d9e6a9bc18aabf5e59695"
@@ -2132,6 +2286,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+"checksum leb128 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3576a87f2ba00f6f106fdfcd16db1d698d648a26ad8e0573cad8537c3c362d2a"
 "checksum libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)" = "1a31a0627fdf1f6a39ec0dd577e101440b7db22672c0901fe00a9a6fbb5c24e8"
 "checksum libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
@@ -2154,6 +2309,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum num_cpus 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "155394f924cdddf08149da25bfb932d226b4a593ca7468b08191ff6335941af5"
 "checksum object 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a411a7fd46b7ebc9849c80513c84280f41cbc3159f489cd77fb30ecefdd1218a"
 "checksum opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+"checksum packed_struct 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "90caf80e74380d94f2aabc83edb900b49123b3132442fb147f9155c87a756281"
+"checksum packed_struct_codegen 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9f6fda15ebe37b7b28889bd4aa75bb134652eaec9eb99d1bf02f806fca4357fc"
 "checksum parity-wasm 0.40.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1e39faaa292a687ea15120b1ac31899b13586446521df6c149e46f1584671e0f"
 "checksum parity-wasm 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc878dac00da22f8f61e7af3157988424567ab01d9920b962ef7dcbd7cd865"
 "checksum pbkdf2 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "006c038a43a45995a9670da19e67600114740e8511d4333bf97a56e66a7542d9"
@@ -2168,6 +2325,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27"
 "checksum progress 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "17b820305721858696053a7fd0215cfeeee16ecaaf96b7a209945428e02f1c44"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
+"checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
 "checksum rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
@@ -2188,6 +2346,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
 "checksum rand_xoshiro 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0e18c91676f670f6f0312764c759405f13afb98d5d73819840cf72a518487bff"
 "checksum raw-cpuid 6.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "30a9d219c32c9132f7be513c18be77c9881c7107d2ab5569d205a6a0f0e6dc7d"
+"checksum raw-cpuid 7.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b4a349ca83373cfa5d6dbb66fd76e58b2cca08da71a5f6400de0a0a6a9bceeaf"
 "checksum rayon 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "83a27732a533a1be0a0035a111fe76db89ad312f6f0347004c220c57f209a123"
 "checksum rayon-core 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "98dcf634205083b17d0861252431eb2acbfb698ab7478a2d20de07954f47ec7b"
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
@@ -2204,7 +2363,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
 "checksum same-file 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "585e8ddcedc187886a30fa705c47985c3fa88d06624095856b36ca0b82ff4421"
 "checksum scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
+"checksum scroll 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "abb2332cb595d33f7edd5700f4cbf94892e680c7f0ae56adab58a35190b66cb1"
 "checksum scroll 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2f84d114ef17fd144153d608fba7c446b0145d038985e7a8cc5d08bb0ce20383"
+"checksum scroll_derive 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f8584eea9b9ff42825b46faf46a8c24d2cff13ec152fa2a50df788b87c07ee28"
 "checksum scroll_derive 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)" = "8f1aa96c45e7f5a91cb7fabe7b279f02fea7126239fc40b732316e8b6a2d0fcb"
 "checksum scrypt 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "656c79d0e90d0ab28ac86bf3c3d10bfbbac91450d3f190113b4e76d9fec3cfdd"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
@@ -2216,26 +2377,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b4d8bfd0e469f417657573d8451fb33d16cfe0989359b93baf3a1ffc639543d"
 "checksum shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 "checksum siphasher 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "83da420ee8d1a89e640d0948c646c1c088758d3a3c538f943bfa97bdac17929d"
-"checksum smallvec 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "533e29e15d0748f28afbaf4ff7cab44d73e483a8e50b38c40bd13b7f3d48f542"
+"checksum smallvec 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4ecf3b85f68e8abaa7555aa5abdb1153079387e60b718283d732f03897fcfc86"
 "checksum string-interner 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd710eadff449a1531351b0e43eb81ea404336fa2f56c777427ab0e32a4cf183"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum structopt 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6d4f66a4c0ddf7aee4677995697366de0749b0139057342eccbb609b12d0affc"
 "checksum structopt-derive 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8fe0c13e476b4e21ff7f5c4ace3818b6d7bdc16897c31c73862471bc1663acae"
 "checksum subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
+"checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
 "checksum syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0e7bedb3320d0f3035594b0b723c8a28d7d336a3eda3881db79e61d676fb644c"
+"checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum synstructure 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3f085a5855930c0441ca1288cf044ea4aecf4f43a91668abdb870b4ba546a203"
 "checksum target-lexicon 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7975cb2c6f37d77b190bc5004a2bb015971464756fde9514651a525ada2a741a"
+"checksum target-lexicon 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6f4c118a7a38378f305a9e111fcb2f7f838c0be324bfb31a77ea04f7f6e684b4"
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 "checksum termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "96d6098003bde162e4277c70665bd87c326f5a0c3f3fbfb285787fa482d54e6e"
 "checksum terminal_size 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "023345d35850b69849741bd9a5432aa35290e3d8eb76af8717026f270d1cf133"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+"checksum thiserror 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "cc6b305ec0e323c7b6cfff6098a22516e0063d0bb7c3d88660a890217dca099a"
+"checksum thiserror-impl 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45ba8d810d9c48fc456b7ad54574e8bfb7c7918a57ad7a6e6a0985d7959e8597"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum tinytemplate 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4574b75faccaacddb9b284faecdf0b544b80b6b294f3d062d325c5726a209c20"
 "checksum toml 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "01d1404644c8b12b16bfcffa4322403a91a451584daaaa7c28d3152e6cbc98cf"
 "checksum typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9"
 "checksum unicode-segmentation 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49f5526225fd8b77342d5986ab5f6055552e9c0776193b5b63fd53b46debfad7"
 "checksum unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7007dbd421b92cc6e28410fe7362e2e0a2503394908f417b68ec8d1c364c4e20"
+"checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a"
@@ -2246,11 +2413,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum wabt-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "af5d153dc96aad7dc13ab90835b892c69867948112d95299e522d370c4e13a08"
 "checksum wait-timeout 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 "checksum walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "9658c94fa8b940eab2250bd5a457f9c48b748420d71293b165c8cdbe2f55f71e"
-"checksum wasi-common 0.4.0 (git+https://github.com/cranestation/wasi-common?rev=f4ac1299b2001b575cfc99f5544a4a96355a6bff)" = "<none>"
-"checksum wasi-common-cbindgen 0.4.0 (git+https://github.com/cranestation/wasi-common?rev=f4ac1299b2001b575cfc99f5544a4a96355a6bff)" = "<none>"
+"checksum wasi-common 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2a703d47961a9c2bf1dbeec7612446692dd8b380839c3d05f7211f72919c96df"
+"checksum wasi-common-cbindgen 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ecab99a12e72a7442e5a9ecfc819f42520e1e0122cf06c0ba64c6a0b6b5263ce"
 "checksum wasmonkey 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "af7c4bc80224427965ba21d87982cfc07d12e859824f303272056fb19f571ef9"
 "checksum wasmparser 0.39.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e5083b449454f7de0b15f131eee17de54b5a71dcb9adcf11df2b2f78fad0cd82"
+"checksum wast 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "233648f540f07fce9b972436f2fbcae8a750c1121b6d32d949e1a44b4d9fc7b1"
 "checksum which 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5475d47078209a02e60614f7ba5e645ef3ed60f771920ac1906d7c1cc65024c8"
+"checksum wig 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ae3856dfac1bfc00633ac5b3b9b65c9c56cb5014b27ca6dfdae17bb8177a8c19"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
@@ -2259,5 +2428,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 "checksum wincolor 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "96f5016b18804d24db43cebf3c77269e7569b8954a8464501c216cc5e070eaa9"
 "checksum winconsole 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ef84b96d10db72dd980056666d7f1e7663ce93d82fa33b63e71c966f4cf5032"
-"checksum winx 0.4.0 (git+https://github.com/cranestation/wasi-common?rev=f4ac1299b2001b575cfc99f5544a4a96355a6bff)" = "<none>"
+"checksum winx 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c95125d6dc28a246c02340956929f4e67ac4c06c589b87de076d0dc0ad421b91"
+"checksum witx 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7f88e293d72e3bd74cc452f9c3e934958f075252324ea24bf40cc16f1f068a3d"
 "checksum xfailure 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "da90eac47bf1d7871b75004b9b631d107df15f37669383b23f0b5297bc7516b6"

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ ENV PATH=/root/.cargo/bin:$PATH
 RUN rustup component add rustfmt --toolchain nightly-2019-09-25-x86_64-unknown-linux-gnu
 RUN rustup target add wasm32-wasi
 
-RUN cargo install --debug cargo-audit cargo-watch rsign2
+RUN cargo install --debug cargo-audit cargo-watch rsign2 cargo-deb
 
 RUN curl -sS -L -O https://github.com/CraneStation/wasi-sdk/releases/download/wasi-sdk-7/wasi-sdk_7.0_amd64.deb \
 	&& dpkg -i wasi-sdk_7.0_amd64.deb && rm -f wasi-sdk_7.0_amd64.deb

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ install-dev: build-dev
 	@helpers/install.sh --unoptimized
 
 .PHONY: test
-test: indent-check test-except-fuzz test-fuzz
+test: indent-check test-except-fuzz test-fuzz package
 
 .PHONY: test-except-fuzz
 test-except-fuzz:
@@ -71,6 +71,11 @@ indent:
 .PHONY: indent-check
 indent-check:
 	helpers/indent.sh check
+
+.PHONY: package
+package:
+	cargo deb -p lucet-validate
+	cargo deb -p lucetc
 
 .PHONY: watch
 watch:

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ install-dev: build-dev
 	@helpers/install.sh --unoptimized
 
 .PHONY: test
-test: indent-check test-except-fuzz test-fuzz package
+test: indent-check test-except-fuzz test-fuzz
 
 .PHONY: test-except-fuzz
 test-except-fuzz:

--- a/benchmarks/lucet-benchmarks/src/seq.rs
+++ b/benchmarks/lucet-benchmarks/src/seq.rs
@@ -260,11 +260,9 @@ fn run_hello<R: RegionCreate + 'static>(c: &mut Criterion) {
         b.iter_batched_ref(
             || {
                 let ctx = WasiCtxBuilder::new()
-                    .expect("create a new WASI context")
                     .args(["hello"].iter())
-                    .expect("WASI arguments")
                     .build()
-                    .unwrap();
+                    .expect("build WasiCtx");
                 region
                     .new_instance_builder(module.clone())
                     .with_embed_ctx(ctx)

--- a/lucet-module/Cargo.toml
+++ b/lucet-module/Cargo.toml
@@ -10,7 +10,7 @@ authors = ["Lucet team <lucet@fastly.com>"]
 edition = "2018"
 
 [dependencies]
-cranelift-entity = { path = "../cranelift/cranelift-entity", version = "0.46.1" }
+cranelift-entity = { path = "../cranelift/cranelift-entity", version = "0.51.0" }
 failure = "0.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/lucet-validate/Cargo.toml
+++ b/lucet-validate/Cargo.toml
@@ -37,8 +37,8 @@ assets = [
     ["target/release/lucet-validate", "/opt/fst-lucet-validate/bin/lucet-validate", "755"],
     ["target/release/liblucet_validate.rlib", "/opt/fst-lucet-validate/lib/", "644"],
     ["LICENSE", "/opt/fst-lucet-validate/share/doc/lucet-validate/", "644"],
-    ["../wasi/phases/unstable/witx/typenames.witx",
-     "/opt/fst-lucet-validate/share/wasi/unstable/typenames.witx", "644"],
-    ["../wasi/phases/unstable/witx/wasi_unstable.witx",
-     "/opt/fst-lucet-validate/share/wasi/unstable/wasi_unstable_preview0.witx", "644"],
+    ["../wasi/phases/old/snapshot_0/witx/typenames.witx",
+     "/opt/fst-lucet-validate/share/wasi/snapshot_0/typenames.witx", "644"],
+    ["../wasi/phases/old/snapshot_0/witx/wasi_unstable.witx",
+     "/opt/fst-lucet-validate/share/wasi/snapshot_0/wasi_unstable.witx", "644"],
 ]

--- a/lucet-validate/Cargo.toml
+++ b/lucet-validate/Cargo.toml
@@ -19,8 +19,8 @@ path = "src/main.rs"
 [dependencies]
 clap = "2"
 failure = "0.1"
-witx = { path = "../wasi/tools/witx", version = "0.3.0" }
-cranelift-entity = { path = "../cranelift/cranelift-entity", version = "0.46.1" }
+witx = { path = "../wasi/tools/witx", version = "0.6.0" }
+cranelift-entity = { path = "../cranelift/cranelift-entity", version = "0.51.0" }
 wasmparser = "0.39.1"
 
 [dev-dependencies]
@@ -39,6 +39,6 @@ assets = [
     ["LICENSE", "/opt/fst-lucet-validate/share/doc/lucet-validate/", "644"],
     ["../wasi/phases/unstable/witx/typenames.witx",
      "/opt/fst-lucet-validate/share/wasi/unstable/typenames.witx", "644"],
-    ["../wasi/phases/unstable/witx/wasi_unstable_preview0.witx",
+    ["../wasi/phases/unstable/witx/wasi_unstable.witx",
      "/opt/fst-lucet-validate/share/wasi/unstable/wasi_unstable_preview0.witx", "644"],
 ]

--- a/lucet-validate/src/lib.rs
+++ b/lucet-validate/src/lib.rs
@@ -69,7 +69,7 @@ impl Validator {
     }
 
     pub fn load<P: AsRef<Path>>(source_path: P) -> Result<Self, WitxError> {
-        let witx = witx::load(source_path.as_ref())?;
+        let witx = witx::load(&[source_path.as_ref()])?;
         Ok(Self {
             witx,
             wasi_exe: false,
@@ -117,11 +117,9 @@ impl Validator {
     }
 
     fn witx_module(&self, module: &str) -> Result<Rc<Module>, Error> {
-        match module {
-            "wasi_unstable" => self.witx.module(&Id::new("wasi_unstable_preview0")),
-            _ => self.witx.module(&Id::new(module)),
-        }
-        .ok_or_else(|| Error::ModuleNotFound(module.to_string()))
+        self.witx
+            .module(&Id::new(module))
+            .ok_or_else(|| Error::ModuleNotFound(module.to_string()))
     }
 
     fn check_wasi_start_func(&self, moduletype: &ModuleType) -> Result<(), Error> {

--- a/lucet-validate/tests/wasitests.rs
+++ b/lucet-validate/tests/wasitests.rs
@@ -1,5 +1,5 @@
 #[cfg(test)]
-mod lucet_wasi_tests {
+mod lucet_validate_tests {
     use lucet_validate::Validator;
     use std::fs;
     use std::path::Path;
@@ -37,7 +37,7 @@ mod lucet_wasi_tests {
 
     #[test]
     fn validate_lucet_wasi_test_guests() {
-        let validator = Validator::load("../wasi/phases/unstable/witx/wasi_unstable_preview0.witx")
+        let validator = Validator::load("../wasi/phases/old/snapshot_0/witx/wasi_unstable.witx")
             .expect("load wasi_unstable_preview0");
 
         for entry in

--- a/lucet-wasi-fuzz/src/main.rs
+++ b/lucet-wasi-fuzz/src/main.rs
@@ -368,14 +368,11 @@ fn run_with_stdout<P: AsRef<Path>>(
     tmpdir: &TempDir,
     path: P,
 ) -> Result<(__wasi_exitcode_t, Vec<u8>), Error> {
-    let ctx = WasiCtxBuilder::new()
-        .map_err(|e| format_err!("WasiCtxBuilder: {}", e))?
-        .args(["gen"].iter())
-        .map_err(|e| format_err!("WasiCtxBuilder args: {}", e))?;
+    let ctx = WasiCtxBuilder::new().args(&["gen"]);
 
     let (pipe_out, pipe_in) = nix::unistd::pipe()?;
 
-    let ctx = ctx.stdout(unsafe { File::from_raw_fd(pipe_in) })?.build()?;
+    let ctx = ctx.stdout(unsafe { File::from_raw_fd(pipe_in) }).build()?;
 
     let exitcode = run(tmpdir, path, ctx)?;
 

--- a/lucet-wasi-sdk/tests/lucetc.rs
+++ b/lucet-wasi-sdk/tests/lucetc.rs
@@ -190,7 +190,7 @@ mod lucetc_tests {
         let b =
             Bindings::from_file("../lucet-wasi/bindings.json").expect("load lucet-wasi bindings");
         let h = HeapSettings::default();
-        let v = Validator::load("../wasi/phases/unstable/witx/wasi_unstable_preview0.witx")
+        let v = Validator::load("../wasi/phases/old/snapshot_0/witx/wasi_unstable.witx")
             .expect("wasi spec validation")
             .with_wasi_exe(true);
         // Compiler will only unwrap if the Validator defined above accepts the module

--- a/lucet-wasi/Cargo.toml
+++ b/lucet-wasi/Cargo.toml
@@ -34,7 +34,7 @@ lucet-module = { path = "../lucet-module", version = "0.4.1" }
 libc = "0.2.65"
 nix = "0.15"
 rand = "0.6"
-wasi-common = { git = "https://github.com/cranestation/wasi-common", rev = "f4ac1299b2001b575cfc99f5544a4a96355a6bff" }
+wasi-common = "0.7"
 
 [dev-dependencies]
 lucet-wasi-sdk = { path = "../lucet-wasi-sdk", version = "0.4.1" }

--- a/lucet-wasi/src/c_api.rs
+++ b/lucet-wasi/src/c_api.rs
@@ -27,7 +27,7 @@ pub unsafe extern "C" fn lucet_wasi_ctx_args(
     assert_nonnull!(wasi_ctx);
     let mut b = Box::from_raw(wasi_ctx as *mut WasiCtxBuilder);
     let args_raw = std::slice::from_raw_parts(argv, argc);
-    let args: Result<Vec<_>, _> = args_raw
+    let args: Result<Vec<&str>, _> = args_raw
         .into_iter()
         .map(|arg| CStr::from_ptr(*arg).to_str())
         .collect();
@@ -35,10 +35,7 @@ pub unsafe extern "C" fn lucet_wasi_ctx_args(
         Ok(args) => args,
         Err(_) => return lucet_error::InvalidArgument,
     };
-    *b = match b.args(args.iter()) {
-        Ok(b) => b,
-        Err(_) => return lucet_error::InvalidArgument,
-    };
+    *b = b.args(args.iter());
     Box::into_raw(b);
     lucet_error::Ok
 }
@@ -47,10 +44,7 @@ pub unsafe extern "C" fn lucet_wasi_ctx_args(
 pub unsafe extern "C" fn lucet_wasi_ctx_inherit_env(wasi_ctx: *mut lucet_wasi_ctx) -> lucet_error {
     assert_nonnull!(wasi_ctx);
     let mut b = Box::from_raw(wasi_ctx as *mut WasiCtxBuilder);
-    *b = match b.inherit_env() {
-        Ok(b) => b,
-        Err(_) => return lucet_error::InvalidArgument,
-    };
+    *b = b.inherit_env();
     Box::into_raw(b);
     lucet_error::Ok
 }
@@ -61,10 +55,7 @@ pub unsafe extern "C" fn lucet_wasi_ctx_inherit_stdio(
 ) -> lucet_error {
     assert_nonnull!(wasi_ctx);
     let mut b = Box::from_raw(wasi_ctx as *mut WasiCtxBuilder);
-    *b = match b.inherit_stdio() {
-        Ok(b) => b,
-        Err(_) => return lucet_error::Internal,
-    };
+    *b = b.inherit_stdio();
     Box::into_raw(b);
     lucet_error::Ok
 }

--- a/lucet-wasi/src/main.rs
+++ b/lucet-wasi/src/main.rs
@@ -235,13 +235,9 @@ fn run(config: Config<'_>) {
             .chain(config.guest_args.into_iter())
             .collect::<Vec<&str>>();
         let mut ctx = WasiCtxBuilder::new()
-            .expect("wasi context can be built")
             .args(args.iter())
-            .expect("arguments can be stored")
             .inherit_stdio()
-            .expect("stdio can be inherited")
-            .inherit_env()
-            .expect("environment can be inherited");
+            .inherit_env();
         for (dir, guest_path) in config.preopen_dirs {
             ctx = ctx.preopened_dir(dir, guest_path);
         }

--- a/lucet-wasi/tests/test_helpers/mod.rs
+++ b/lucet-wasi/tests/test_helpers/mod.rs
@@ -103,10 +103,7 @@ pub fn run_with_stdout<P: AsRef<Path>>(
 ) -> Result<(__wasi_exitcode_t, String), Error> {
     let (pipe_out, pipe_in) = nix::unistd::pipe()?;
 
-    let ctx = ctx
-        .stdout(unsafe { File::from_raw_fd(pipe_in) })
-        .unwrap()
-        .build()?;
+    let ctx = ctx.stdout(unsafe { File::from_raw_fd(pipe_in) }).build()?;
 
     let exitcode = run(path, ctx)?;
 
@@ -124,10 +121,7 @@ pub fn run_with_null_stdin<P: AsRef<Path>>(
 ) -> Result<__wasi_exitcode_t, Error> {
     let (pipe_out, pipe_in) = nix::unistd::pipe()?;
 
-    let ctx = ctx
-        .stdin(unsafe { File::from_raw_fd(pipe_out) })
-        .unwrap()
-        .build()?;
+    let ctx = ctx.stdin(unsafe { File::from_raw_fd(pipe_out) }).build()?;
 
     let exitcode = run(path, ctx)?;
 

--- a/lucet-wasi/tests/tests.rs
+++ b/lucet-wasi/tests/tests.rs
@@ -8,7 +8,7 @@ use tempfile::TempDir;
 
 #[test]
 fn double_import() {
-    let ctx = WasiCtxBuilder::new().unwrap();
+    let ctx = WasiCtxBuilder::new();
 
     let (exitcode, stdout) = run_with_stdout("duplicate_import.wat", ctx).unwrap();
 
@@ -18,10 +18,7 @@ fn double_import() {
 
 #[test]
 fn hello() {
-    let ctx = WasiCtxBuilder::new()
-        .unwrap()
-        .args(["hello"].into_iter())
-        .unwrap();
+    let ctx = WasiCtxBuilder::new().args(["hello"].into_iter());
 
     let (exitcode, stdout) = run_with_stdout(
         Path::new(LUCET_WASI_ROOT).join("examples").join("hello.c"),
@@ -35,10 +32,7 @@ fn hello() {
 
 #[test]
 fn hello_args() {
-    let ctx = WasiCtxBuilder::new()
-        .unwrap()
-        .args(["hello", "test suite"].into_iter())
-        .unwrap();
+    let ctx = WasiCtxBuilder::new().args(["hello", "test suite"].into_iter());
 
     let (exitcode, stdout) = run_with_stdout(
         Path::new(LUCET_WASI_ROOT).join("examples").join("hello.c"),
@@ -53,11 +47,8 @@ fn hello_args() {
 #[test]
 fn hello_env() {
     let ctx = WasiCtxBuilder::new()
-        .unwrap()
         .args(["hello", "test suite"].into_iter())
-        .unwrap()
-        .env("GREETING", "goodbye")
-        .unwrap();
+        .env("GREETING", "goodbye");
 
     let (exitcode, stdout) = run_with_stdout(
         Path::new(LUCET_WASI_ROOT).join("examples").join("hello.c"),
@@ -126,11 +117,8 @@ fn stdin() {
     drop(stdin_file);
 
     let ctx = WasiCtxBuilder::new()
-        .unwrap()
         .args(["stdin"].into_iter())
-        .unwrap()
-        .stdin(unsafe { File::from_raw_fd(pipe_out) })
-        .unwrap();
+        .stdin(unsafe { File::from_raw_fd(pipe_out) });
 
     let (exitcode, stdout) = run_with_stdout("stdin.c", ctx).unwrap();
 
@@ -146,9 +134,7 @@ fn preopen_populates() {
     let preopen_dir = File::open(preopen_host_path).unwrap();
 
     let ctx = WasiCtxBuilder::new()
-        .unwrap()
         .args(["preopen_populates"].into_iter())
-        .unwrap()
         .preopened_dir(preopen_dir, "/preopen")
         .build()
         .expect("can build WasiCtx");
@@ -168,9 +154,7 @@ fn write_file() {
     let preopen_dir = File::open(&preopen_host_path).unwrap();
 
     let ctx = WasiCtxBuilder::new()
-        .unwrap()
         .args(["write_file"].into_iter())
-        .unwrap()
         .preopened_dir(preopen_dir, "/sandbox")
         .build()
         .expect("can build WasiCtx");
@@ -197,9 +181,7 @@ fn read_file() {
     let preopen_dir = File::open(&preopen_host_path).unwrap();
 
     let ctx = WasiCtxBuilder::new()
-        .unwrap()
         .args(["read_file"].into_iter())
-        .unwrap()
         .preopened_dir(preopen_dir, "/sandbox");
 
     let (exitcode, stdout) = run_with_stdout("read_file.c", ctx).unwrap();
@@ -222,9 +204,7 @@ fn read_file_twice() {
     let preopen_dir = File::open(&preopen_host_path).unwrap();
 
     let ctx = WasiCtxBuilder::new()
-        .unwrap()
         .args(["read_file_twice"].into_iter())
-        .unwrap()
         .preopened_dir(preopen_dir, "/sandbox");
 
     let (exitcode, stdout) = run_with_stdout("read_file_twice.c", ctx).unwrap();
@@ -252,9 +232,7 @@ fn cant_dotdot() {
     let preopen_dir = File::open(&preopen_host_path).unwrap();
 
     let ctx = WasiCtxBuilder::new()
-        .unwrap()
         .args(["cant_dotdot"].into_iter())
-        .unwrap()
         .preopened_dir(preopen_dir, "/sandbox")
         .build()
         .unwrap();
@@ -278,9 +256,7 @@ fn notdir() {
     let preopen_dir = File::open(&preopen_host_path).unwrap();
 
     let ctx = WasiCtxBuilder::new()
-        .unwrap()
         .args(["notdir"].into_iter())
-        .unwrap()
         .preopened_dir(preopen_dir, "/sandbox")
         .build()
         .unwrap();
@@ -309,9 +285,7 @@ fn follow_symlink() {
     let preopen_dir = File::open(&preopen_host_path).unwrap();
 
     let ctx = WasiCtxBuilder::new()
-        .unwrap()
         .args(["follow_symlink"].into_iter())
-        .unwrap()
         .preopened_dir(preopen_dir, "/sandbox");
 
     let (exitcode, stdout) = run_with_stdout("follow_symlink.c", ctx).unwrap();
@@ -336,9 +310,7 @@ fn symlink_loop() {
     let preopen_dir = File::open(&preopen_host_path).unwrap();
 
     let ctx = WasiCtxBuilder::new()
-        .unwrap()
         .args(["symlink_loop"].into_iter())
-        .unwrap()
         .preopened_dir(preopen_dir, "/sandbox")
         .build()
         .unwrap();
@@ -368,9 +340,7 @@ fn symlink_escape() {
     let preopen_dir = File::open(&preopen_host_path).unwrap();
 
     let ctx = WasiCtxBuilder::new()
-        .unwrap()
         .args(["symlink_escape"].into_iter())
-        .unwrap()
         .preopened_dir(preopen_dir, "/sandbox")
         .build()
         .unwrap();
@@ -387,9 +357,7 @@ fn pseudoquine() {
     let pseudoquine_c = examples_dir.join("pseudoquine.c");
 
     let ctx = WasiCtxBuilder::new()
-        .unwrap()
         .args(["pseudoquine"].into_iter())
-        .unwrap()
         .preopened_dir(File::open(examples_dir).unwrap(), "/examples");
 
     let (exitcode, stdout) = run_with_stdout(&pseudoquine_c, ctx).unwrap();
@@ -406,10 +374,7 @@ fn pseudoquine() {
 #[ignore]
 #[test]
 fn poll() {
-    let ctx = WasiCtxBuilder::new()
-        .unwrap()
-        .args(["poll"].into_iter())
-        .unwrap();
+    let ctx = WasiCtxBuilder::new().args(["poll"].into_iter());
     let exitcode = run_with_null_stdin("poll.c", ctx).unwrap();
     assert_eq!(exitcode, 0);
 }
@@ -421,9 +386,7 @@ fn stat() {
     std::fs::create_dir(&preopen_host_path).unwrap();
     let preopen_dir = File::open(&preopen_host_path).unwrap();
     let ctx = WasiCtxBuilder::new()
-        .unwrap()
         .args(["stat"].into_iter())
-        .unwrap()
         .preopened_dir(preopen_dir, "/sandbox")
         .build()
         .expect("can build WasiCtx");
@@ -438,9 +401,7 @@ fn fs() {
     std::fs::create_dir(&preopen_host_path).unwrap();
     let preopen_dir = File::open(&preopen_host_path).unwrap();
     let ctx = WasiCtxBuilder::new()
-        .unwrap()
         .args(["stat"].into_iter())
-        .unwrap()
         .preopened_dir(preopen_dir, "/sandbox")
         .build()
         .expect("can build WasiCtx");

--- a/lucetc/Cargo.toml
+++ b/lucetc/Cargo.toml
@@ -15,21 +15,21 @@ path = "lucetc/main.rs"
 
 [dependencies]
 bincode = "1.1.4"
-cranelift-codegen = { path = "../cranelift/cranelift-codegen", version = "0.46.1" }
-cranelift-entity = { path = "../cranelift/cranelift-entity", version = "0.46.1" }
-cranelift-native = { path = "../cranelift/cranelift-native", version = "0.46.1" }
-cranelift-frontend = { path = "../cranelift/cranelift-frontend", version = "0.46.1" }
-cranelift-module = { path = "../cranelift/cranelift-module", version = "0.46.1" }
-cranelift-faerie = { path = "../cranelift/cranelift-faerie", version = "0.46.1" }
-cranelift-wasm = { path = "../cranelift/cranelift-wasm", version = "0.46.1" }
-target-lexicon = "0.8.0"
+cranelift-codegen = { path = "../cranelift/cranelift-codegen", version = "0.51.0" }
+cranelift-entity = { path = "../cranelift/cranelift-entity", version = "0.51.0" }
+cranelift-native = { path = "../cranelift/cranelift-native", version = "0.51.0" }
+cranelift-frontend = { path = "../cranelift/cranelift-frontend", version = "0.51.0" }
+cranelift-module = { path = "../cranelift/cranelift-module", version = "0.51.0" }
+cranelift-faerie = { path = "../cranelift/cranelift-faerie", version = "0.51.0" }
+cranelift-wasm = { path = "../cranelift/cranelift-wasm", version = "0.51.0" }
+target-lexicon = "0.9"
 lucet-module = { path = "../lucet-module", version = "0.4.1" }
 lucet-validate = { path = "../lucet-validate", version = "0.4.1" }
 wasmparser = "0.39.1"
 clap="2.32"
 log = "0.4"
 env_logger = "0.6"
-faerie = "0.11.0"
+faerie = "0.12.0"
 goblin = "0.0.24"
 failure = "0.1"
 byteorder = "1.2"
@@ -56,8 +56,12 @@ assets = [
     ["target/release/lucetc", "/opt/fst-lucetc/bin/lucetc", "755"],
     ["target/release/liblucetc.rlib", "/opt/fst-lucetc/lib/", "644"],
     ["LICENSE", "/opt/fst-lucetc/share/doc/lucetc/", "644"],
-    ["../wasi/phases/unstable/witx/typenames.witx",
-     "/opt/fst-lucetc/share/wasi/unstable/typenames.witx", "644"],
-    ["../wasi/phases/unstable/witx/wasi_unstable_preview0.witx",
-     "/opt/fst-lucetc/share/wasi/unstable/wasi_unstable_preview0.witx", "644"],
+    ["../wasi/phases/old/snapshot_0/witx/typenames.witx",
+     "/opt/fst-lucetc/share/wasi/snapshot_0/typenames.witx", "644"],
+    ["../wasi/phases/old/snapshot_0/witx/wasi_unstable.witx",
+     "/opt/fst-lucetc/share/wasi/snapshot_0/wasi_unstable.witx", "644"],
+    ["../wasi/phases/snapshot/witx/typenames.witx",
+     "/opt/fst-lucetc/share/wasi/snapshot_1/typenames.witx", "644"],
+    ["../wasi/phases/snapshot/witx/wasi_snapshot_preview1.witx",
+     "/opt/fst-lucetc/share/wasi/snapshot_1/wasi_snapshot_preview1.witx", "644"],
 ]


### PR DESCRIPTION
* pull in latest Cranelift release 0.51
* upgrade to wasi-common 0.7, which fixes a lot of the WasiCtxBuilder
  stuff that required many extra unwraps
* pull in latest WASI repo. This moves the preview0 stuff to another
  directory. Biggest change here is that the lucetc deb, which includes
  the wasi witx files, has a slightly different file layout now.
* transitive upgrades to target-lexicon, faerie