### PR TITLE
Use actions/checkout@v1 to support submodules checkout

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -9,7 +9,7 @@ jobs:
 
     runs-on: ubuntu-16.04
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v1
       with:
         submodules: true
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v1
       with:
         submodules: true
 
@@ -23,7 +23,7 @@ jobs:
     name: Package
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v1
       with:
         submodules: true
 
@@ -41,7 +41,7 @@ jobs:
     name: Rustfmt
     runs-on: ubuntu-16.04
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v1
       with:
         submodules: true
     - name: Install Rust (rustup)


### PR DESCRIPTION
This commit fixes the CI by setting `actions/checkout` at version `v1`. The current master of `actions/checkout` now obsoleted the `with: submodules: true` input. See [actions/checkout/releases/tag/v2-beta] for more info.

[actions/checkout/releases/tag/v2-beta]: https://github.com/actions/checkout/releases/tag/v2-beta