### PR TITLE
Show unsupported global import in error message

### DIFF
--- a/lucet-runtime/lucet-runtime-internals/src/instance.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/instance.rs
@@ -546,7 +546,7 @@ impl Instance {
                 Global::Import { .. } => {
                     return Err(Error::Unsupported(format!(
                         "global imports are unsupported; found: {:?}",
-                        i
+                        v
                     )));
                 }
                 Global::Def(def) => def.init_val(),


### PR DESCRIPTION
I spent a little time last night getting a lay of the land in our spectests, seeing where things were failing. One of the small things I noticed related to global imports, and `Unsupported` error variant that is thrown by :point_down: this block in `lucet-runtime/lucet-runtime-internals/src/instance.rs:549`.

```rust
for (i, v) in mod_globals.iter().enumerate() {
    globals[i] = match v.global() {
        Global::Import { .. } => {
            return Err(Error::Unsupported(format!(
                "global imports are unsupported; found: {:?}",
                i
            )));
        }
        Global::Def(def) => def.init_val(),
    };
}
```

This is passing the `usize` (functionally the import index here?) given by `enumerate` to the error. This
meant the error reported looked like this:

```
FAIL in Module, line 108: SpecTestError { inner: InstantiateError(Unsupported("global imports are unsupported; found: 0"))
```

It took me a moment to realize what is happening here, so I figured it would be a small but tangible improvement to our error reporting if we actually show the import that was found, rather than the index, like so:

```
FAIL in Module, line 108: SpecTestError { inner: InstantiateError(Unsupported("global imports are unsupported; found: GlobalSpec { global: Import { module: \"spectest\", field: \"global_i32\" }, export_names: [] }
"))
```

For a one line diff, that seems like a nice improvement :smile_cat: 