### PR TITLE
replace empty constructor w/ default impl

### DIFF
--- a/lucet-runtime/lucet-runtime-internals/src/embed_ctx.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/embed_ctx.rs
@@ -59,4 +59,8 @@ impl CtxMap {
                 .expect("value stored with TypeId::of::<T> is always type T")
         })
     }
+
+    pub fn new() -> Self {
+        Self::default()
+    }
 }

--- a/lucet-runtime/lucet-runtime-internals/src/embed_ctx.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/embed_ctx.rs
@@ -10,6 +10,14 @@ pub struct CtxMap {
     map: HashMap<TypeId, RefCell<Box<dyn Any>>>,
 }
 
+impl Default for CtxMap {
+    fn default() -> Self {
+        CtxMap {
+            map: HashMap::default(),
+        }
+    }
+}
+
 impl CtxMap {
     pub fn clear(&mut self) {
         self.map.clear();
@@ -49,12 +57,6 @@ impl CtxMap {
                     .downcast::<T>()
                     .expect("value stored with TypeId::of::<T> is always type T")
             })
-    }
-
-    pub fn new() -> Self {
-        CtxMap {
-            map: HashMap::new(),
-        }
     }
 
     pub fn remove<T: Any>(&mut self) -> Option<T> {

--- a/lucet-runtime/lucet-runtime-internals/src/embed_ctx.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/embed_ctx.rs
@@ -6,16 +6,9 @@ use std::collections::HashMap;
 ///
 /// This is similar to the type provided by the `anymap` crate, but we can get away with simpler
 /// types on the methods due to our more specialized use case.
+#[derive(Default)]
 pub struct CtxMap {
     map: HashMap<TypeId, RefCell<Box<dyn Any>>>,
-}
-
-impl Default for CtxMap {
-    fn default() -> Self {
-        CtxMap {
-            map: HashMap::default(),
-        }
-    }
 }
 
 impl CtxMap {

--- a/lucet-runtime/lucet-runtime-internals/src/region/mod.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/region/mod.rs
@@ -80,7 +80,7 @@ impl<'a> InstanceBuilder<'a> {
         InstanceBuilder {
             region,
             module,
-            embed_ctx: CtxMap::new(),
+            embed_ctx: CtxMap::default(),
         }
     }
 


### PR DESCRIPTION
This is another "tiny lint fix I found while looking around at things" PR.

Rather than using a `CtxMap::new()` constructor, we can implement the `Default` trait, and use that instead.