### PR TITLE
Make yield methods take `&mut Vmctx`; update semver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -791,12 +791,12 @@ name = "lucet-benchmarks"
 version = "0.4.1"
 dependencies = [
  "criterion 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.4.2",
- "lucet-runtime 0.4.2",
- "lucet-runtime-internals 0.4.2",
- "lucet-wasi 0.4.2",
- "lucet-wasi-sdk 0.4.2",
- "lucetc 0.4.2",
+ "lucet-module 0.5.0",
+ "lucet-runtime 0.5.0",
+ "lucet-runtime-internals 0.5.0",
+ "lucet-wasi 0.5.0",
+ "lucet-wasi-sdk 0.5.0",
+ "lucetc 0.5.0",
  "nix 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "lucet-module"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -824,28 +824,28 @@ dependencies = [
 
 [[package]]
 name = "lucet-objdump"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "colored 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "goblin 0.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.4.2",
+ "lucet-module 0.5.0",
 ]
 
 [[package]]
 name = "lucet-runtime"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.4.2",
- "lucet-runtime-internals 0.4.2",
- "lucet-runtime-tests 0.4.2",
- "lucet-wasi-sdk 0.4.2",
- "lucetc 0.4.2",
+ "lucet-module 0.5.0",
+ "lucet-runtime-internals 0.5.0",
+ "lucet-runtime-tests 0.5.0",
+ "lucet-wasi-sdk 0.5.0",
+ "lucetc 0.5.0",
  "nix 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -855,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "lucet-runtime-internals"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -866,8 +866,8 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.4.2",
- "lucet-runtime-macros 0.4.2",
+ "lucet-module 0.5.0",
+ "lucet-runtime-macros 0.5.0",
  "memoffset 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -878,7 +878,7 @@ dependencies = [
 
 [[package]]
 name = "lucet-runtime-macros"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -886,27 +886,27 @@ dependencies = [
 
 [[package]]
 name = "lucet-runtime-tests"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "cc 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.4.2",
- "lucet-runtime-internals 0.4.2",
- "lucet-wasi-sdk 0.4.2",
- "lucetc 0.4.2",
+ "lucet-module 0.5.0",
+ "lucet-runtime-internals 0.5.0",
+ "lucet-wasi-sdk 0.5.0",
+ "lucetc 0.5.0",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "lucet-spectest"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.4.2",
- "lucet-runtime 0.4.2",
- "lucetc 0.4.2",
+ "lucet-module 0.5.0",
+ "lucet-runtime 0.5.0",
+ "lucetc 0.5.0",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -915,12 +915,12 @@ dependencies = [
 
 [[package]]
 name = "lucet-validate"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cranelift-entity 0.51.0",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-wasi-sdk 0.4.2",
+ "lucet-wasi-sdk 0.5.0",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wabt 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmparser 0.39.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "lucet-wasi"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "bindgen 0.51.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cast 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -937,11 +937,11 @@ dependencies = [
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "human-size 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.4.2",
- "lucet-runtime 0.4.2",
- "lucet-runtime-internals 0.4.2",
- "lucet-wasi-sdk 0.4.2",
- "lucetc 0.4.2",
+ "lucet-module 0.5.0",
+ "lucet-runtime 0.5.0",
+ "lucet-runtime-internals 0.5.0",
+ "lucet-wasi-sdk 0.5.0",
+ "lucetc 0.5.0",
  "nix 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -950,16 +950,16 @@ dependencies = [
 
 [[package]]
 name = "lucet-wasi-fuzz"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.4.2",
- "lucet-runtime 0.4.2",
- "lucet-wasi 0.4.2",
- "lucet-wasi-sdk 0.4.2",
- "lucetc 0.4.2",
+ "lucet-module 0.5.0",
+ "lucet-runtime 0.5.0",
+ "lucet-wasi 0.5.0",
+ "lucet-wasi-sdk 0.5.0",
+ "lucetc 0.5.0",
  "nix 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "progress 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -973,18 +973,18 @@ dependencies = [
 
 [[package]]
 name = "lucet-wasi-sdk"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.4.2",
- "lucet-validate 0.4.2",
- "lucetc 0.4.2",
+ "lucet-module 0.5.0",
+ "lucet-validate 0.5.0",
+ "lucetc 0.5.0",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "lucetc"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "bimap 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1003,8 +1003,8 @@ dependencies = [
  "goblin 0.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "human-size 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.4.2",
- "lucet-validate 0.4.2",
+ "lucet-module 0.5.0",
+ "lucet-validate 0.5.0",
  "memoffset 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "minisign 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-wasm 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/lucet-module/Cargo.toml
+++ b/lucet-module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-module"
-version = "0.4.2"
+version = "0.5.0"
 description = "A structured interface for Lucet modules"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"

--- a/lucet-objdump/Cargo.toml
+++ b/lucet-objdump/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-objdump"
-version = "0.4.2"
+version = "0.5.0"
 description = "Analyze object files emitted by the Lucet compiler"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -13,7 +13,7 @@ edition = "2018"
 goblin="0.0.24"
 byteorder="1.2.1"
 colored="1.8.0"
-lucet-module = { path = "../lucet-module", version = "0.4.2" }
+lucet-module = { path = "../lucet-module", version = "0.5.0" }
 
 [package.metadata.deb]
 name = "fst-lucet-objdump"

--- a/lucet-runtime/Cargo.toml
+++ b/lucet-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-runtime"
-version = "0.4.2"
+version = "0.5.0"
 description = "Pure Rust runtime for Lucet WebAssembly toolchain"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -11,8 +11,8 @@ edition = "2018"
 
 [dependencies]
 libc = "0.2.65"
-lucet-runtime-internals = { path = "lucet-runtime-internals", version = "0.4.2" }
-lucet-module = { path = "../lucet-module", version = "0.4.2" }
+lucet-runtime-internals = { path = "lucet-runtime-internals", version = "0.5.0" }
+lucet-module = { path = "../lucet-module", version = "0.5.0" }
 num-traits = "0.2"
 num-derive = "0.3.0"
 
@@ -20,9 +20,9 @@ num-derive = "0.3.0"
 byteorder = "1.2"
 failure = "0.1"
 lazy_static = "1.1"
-lucetc = { path = "../lucetc", version = "0.4.2" }
-lucet-runtime-tests = { path = "lucet-runtime-tests", version = "0.4.2" }
-lucet-wasi-sdk = { path = "../lucet-wasi-sdk", version = "0.4.2" }
+lucetc = { path = "../lucetc", version = "0.5.0" }
+lucet-runtime-tests = { path = "lucet-runtime-tests", version = "0.5.0" }
+lucet-wasi-sdk = { path = "../lucet-wasi-sdk", version = "0.5.0" }
 nix = "0.15"
 rayon = "1.0"
 tempfile = "3.0"

--- a/lucet-runtime/lucet-runtime-internals/Cargo.toml
+++ b/lucet-runtime/lucet-runtime-internals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-runtime-internals"
-version = "0.4.2"
+version = "0.5.0"
 description = "Pure Rust runtime for Lucet WebAssembly toolchain (internals)"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -10,8 +10,8 @@ authors = ["Lucet team <lucet@fastly.com>"]
 edition = "2018"
 
 [dependencies]
-lucet-module = { path = "../../lucet-module", version = "0.4.2" }
-lucet-runtime-macros = { path = "../lucet-runtime-macros", version = "0.4.2" }
+lucet-module = { path = "../../lucet-module", version = "0.5.0" }
+lucet-runtime-macros = { path = "../lucet-runtime-macros", version = "0.5.0" }
 
 bitflags = "1.0"
 bincode = "1.1.4"

--- a/lucet-runtime/lucet-runtime-internals/src/hostcall_macros.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/hostcall_macros.rs
@@ -22,7 +22,7 @@
 /// }
 /// ```
 #[macro_export]
-#[deprecated(since = "0.4.2", note = "Use the #[lucet_hostcall] attribute instead")]
+#[deprecated(since = "0.5.0", note = "Use the #[lucet_hostcall] attribute instead")]
 macro_rules! lucet_hostcalls {
     {
         $(

--- a/lucet-runtime/lucet-runtime-internals/src/vmctx.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/vmctx.rs
@@ -78,7 +78,7 @@ pub trait VmctxInternal {
     ///
     /// The dynamic type checks used by the other yield methods should make this explicit option
     /// type redundant, however this interface is used to avoid exposing a panic to the C API.
-    fn yield_val_try_val<A: Any + 'static, R: Any + 'static>(&self, val: A) -> Option<R>;
+    fn yield_val_try_val<A: Any + 'static, R: Any + 'static>(&mut self, val: A) -> Option<R>;
 }
 
 impl VmctxInternal for Vmctx {
@@ -105,7 +105,7 @@ impl VmctxInternal for Vmctx {
         }
     }
 
-    fn yield_val_try_val<A: Any + 'static, R: Any + 'static>(&self, val: A) -> Option<R> {
+    fn yield_val_try_val<A: Any + 'static, R: Any + 'static>(&mut self, val: A) -> Option<R> {
         self.yield_impl::<A, R>(val);
         self.try_take_resumed_val()
     }
@@ -321,7 +321,7 @@ impl Vmctx {
     ///
     /// (The reason for the trailing underscore in the name is that Rust reserves `yield` as a
     /// keyword for future use.)
-    pub fn yield_(&self) {
+    pub fn yield_(&mut self) {
         self.yield_val_expecting_val::<EmptyYieldVal, EmptyYieldVal>(EmptyYieldVal);
     }
 
@@ -332,7 +332,7 @@ impl Vmctx {
     /// After suspending, the instance may be resumed by calling
     /// [`Instance::resume_with_val()`](../struct.Instance.html#method.resume_with_val) from the
     /// host with a value of type `R`.
-    pub fn yield_expecting_val<R: Any + 'static>(&self) -> R {
+    pub fn yield_expecting_val<R: Any + 'static>(&mut self) -> R {
         self.yield_val_expecting_val::<EmptyYieldVal, R>(EmptyYieldVal)
     }
 
@@ -342,7 +342,7 @@ impl Vmctx {
     ///
     /// After suspending, the instance may be resumed by the host using
     /// [`Instance::resume()`](../struct.Instance.html#method.resume).
-    pub fn yield_val<A: Any + 'static>(&self, val: A) {
+    pub fn yield_val<A: Any + 'static>(&mut self, val: A) {
         self.yield_val_expecting_val::<A, EmptyYieldVal>(val);
     }
 
@@ -353,12 +353,12 @@ impl Vmctx {
     /// After suspending, the instance may be resumed by calling
     /// [`Instance::resume_with_val()`](../struct.Instance.html#method.resume_with_val) from the
     /// host with a value of type `R`.
-    pub fn yield_val_expecting_val<A: Any + 'static, R: Any + 'static>(&self, val: A) -> R {
+    pub fn yield_val_expecting_val<A: Any + 'static, R: Any + 'static>(&mut self, val: A) -> R {
         self.yield_impl::<A, R>(val);
         self.take_resumed_val()
     }
 
-    fn yield_impl<A: Any + 'static, R: Any + 'static>(&self, val: A) {
+    fn yield_impl<A: Any + 'static, R: Any + 'static>(&mut self, val: A) {
         let inst = unsafe { self.instance_mut() };
         let expecting: Box<PhantomData<R>> = Box::new(PhantomData);
         inst.state = State::Yielding {

--- a/lucet-runtime/lucet-runtime-macros/Cargo.toml
+++ b/lucet-runtime/lucet-runtime-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-runtime-macros"
-version = "0.4.2"
+version = "0.5.0"
 description = "Macros for the Lucet WebAssembly runtime"
 homepage = "https://github.com/bytecodealliance/lucet"
 repository = "https://github.com/bytecodealliance/lucet"

--- a/lucet-runtime/lucet-runtime-tests/Cargo.toml
+++ b/lucet-runtime/lucet-runtime-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-runtime-tests"
-version = "0.4.2"
+version = "0.5.0"
 description = "Pure Rust runtime for Lucet WebAssembly toolchain (tests)"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -18,10 +18,10 @@ test = false
 failure = "0.1"
 lazy_static = "1.1"
 tempfile = "3.0"
-lucet-module = { path = "../../lucet-module", version = "0.4.2" }
-lucet-runtime-internals = { path = "../lucet-runtime-internals", version = "0.4.2" }
-lucet-wasi-sdk = { path = "../../lucet-wasi-sdk", version = "0.4.2" }
-lucetc = { path = "../../lucetc", version = "0.4.2" }
+lucet-module = { path = "../../lucet-module", version = "0.5.0" }
+lucet-runtime-internals = { path = "../lucet-runtime-internals", version = "0.5.0" }
+lucet-wasi-sdk = { path = "../../lucet-wasi-sdk", version = "0.5.0" }
+lucetc = { path = "../../lucetc", version = "0.5.0" }
 
 [build-dependencies]
 cc = "1.0"

--- a/lucet-spectest/Cargo.toml
+++ b/lucet-spectest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-spectest"
-version = "0.4.2"
+version = "0.5.0"
 description = "Test harness to run WebAssembly spec tests (.wast) against the Lucet toolchain"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -17,9 +17,9 @@ name = "spec-test"
 path = "src/main.rs"
 
 [dependencies]
-lucetc = { path = "../lucetc", version = "0.4.2" }
-lucet-module = { path = "../lucet-module", version = "0.4.2" }
-lucet-runtime = { path = "../lucet-runtime", version = "0.4.2" }
+lucetc = { path = "../lucetc", version = "0.5.0" }
+lucet-module = { path = "../lucet-module", version = "0.5.0" }
+lucet-runtime = { path = "../lucet-runtime", version = "0.5.0" }
 wabt = "0.9.2"
 serde = "1.0"
 serde_json = "1.0"

--- a/lucet-validate/Cargo.toml
+++ b/lucet-validate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-validate"
-version = "0.4.2"
+version = "0.5.0"
 description = "Parse and validate webassembly files against witx interface"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -24,7 +24,7 @@ cranelift-entity = { path = "../cranelift/cranelift-entity", version = "0.51.0" 
 wasmparser = "0.39.1"
 
 [dev-dependencies]
-lucet-wasi-sdk = { path = "../lucet-wasi-sdk", version = "0.4.2" }
+lucet-wasi-sdk = { path = "../lucet-wasi-sdk", version = "0.5.0" }
 tempfile = "3.0"
 wabt = "0.9.2"
 

--- a/lucet-wasi-fuzz/Cargo.toml
+++ b/lucet-wasi-fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-wasi-fuzz"
-version = "0.4.2"
+version = "0.5.0"
 description = "Test the Lucet toolchain against native code execution using Csmith"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"

--- a/lucet-wasi-sdk/Cargo.toml
+++ b/lucet-wasi-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-wasi-sdk"
-version = "0.4.2"
+version = "0.5.0"
 description = "A Rust interface to the wasi-sdk compiler and linker"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -11,9 +11,9 @@ edition = "2018"
 
 [dependencies]
 failure = "0.1"
-lucetc = { path = "../lucetc", version = "0.4.2" }
-lucet-module = { path = "../lucet-module", version = "0.4.2" }
+lucetc = { path = "../lucetc", version = "0.5.0" }
+lucet-module = { path = "../lucet-module", version = "0.5.0" }
 tempfile = "3.0"
 
 [dev-dependencies]
-lucet-validate = { path = "../lucet-validate", version  = "0.4.2" }
+lucet-validate = { path = "../lucet-validate", version  = "0.5.0" }

--- a/lucet-wasi/Cargo.toml
+++ b/lucet-wasi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-wasi"
-version = "0.4.2"
+version = "0.5.0"
 description = "Fastly's runtime for the WebAssembly System Interface (WASI)"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -28,17 +28,17 @@ cast = "0.2"
 clap = "2.23"
 failure = "0.1"
 human-size = "0.4"
-lucet-runtime = { path = "../lucet-runtime", version = "0.4.2" }
-lucet-runtime-internals = { path = "../lucet-runtime/lucet-runtime-internals", version = "0.4.2" }
-lucet-module = { path = "../lucet-module", version = "0.4.2" }
+lucet-runtime = { path = "../lucet-runtime", version = "0.5.0" }
+lucet-runtime-internals = { path = "../lucet-runtime/lucet-runtime-internals", version = "0.5.0" }
+lucet-module = { path = "../lucet-module", version = "0.5.0" }
 libc = "0.2.65"
 nix = "0.15"
 rand = "0.6"
 wasi-common = "0.7"
 
 [dev-dependencies]
-lucet-wasi-sdk = { path = "../lucet-wasi-sdk", version = "0.4.2" }
-lucetc = { path = "../lucetc", version = "0.4.2" }
+lucet-wasi-sdk = { path = "../lucet-wasi-sdk", version = "0.5.0" }
+lucetc = { path = "../lucetc", version = "0.5.0" }
 tempfile = "3.0"
 
 [build-dependencies]

--- a/lucetc/Cargo.toml
+++ b/lucetc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucetc"
-version = "0.4.2"
+version = "0.5.0"
 description = "Fastly's WebAssembly to native code compiler"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -23,8 +23,8 @@ cranelift-module = { path = "../cranelift/cranelift-module", version = "0.51.0" 
 cranelift-faerie = { path = "../cranelift/cranelift-faerie", version = "0.51.0" }
 cranelift-wasm = { path = "../cranelift/cranelift-wasm", version = "0.51.0" }
 target-lexicon = "0.9"
-lucet-module = { path = "../lucet-module", version = "0.4.2" }
-lucet-validate = { path = "../lucet-validate", version = "0.4.2" }
+lucet-module = { path = "../lucet-module", version = "0.5.0" }
+lucet-validate = { path = "../lucet-validate", version = "0.5.0" }
 wasmparser = "0.39.1"
 clap="2.32"
 log = "0.4"


### PR DESCRIPTION
This prevents resources like embedder contexts or heap views from living across yield points, which is important for safety since the host can modify the data underlying those resources while the instance is suspended.

Since this is a semver breaking change, this patch also updates the package versions.