### PR TITLE
add blank rustfmt config file

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,1 @@
+# This file tells tools we use rustfmt. We use the default settings.


### PR DESCRIPTION
This adds a blank `.rustfmt.toml` file, which ostensibly "tells tools we use `rustfmt`". While I can't actually find any example of a tool that falls over without a blank file in place, I figure this is still a nice-to-have for **(a)** the sake of explicitly stating that we are using the default formatting configuration, and **(b)** consistency with [cranelift](https://github.com/bytecodealliance/cranelift/blob/master/.rustfmt.toml) and [wasmtime](https://github.com/bytecodealliance/wasmtime/blob/master/.rustfmt.toml).