### PR TITLE
add option to report timing, as well as reporting time taken to output

### DIFF
--- a/lucetc/lucetc/main.rs
+++ b/lucetc/lucetc/main.rs
@@ -166,8 +166,7 @@ pub fn run(opts: &Options) -> Result<(), Error> {
         CodegenOutput::Obj => c.object_file(&opts.output)?,
         CodegenOutput::SharedObj => c.shared_object_file(&opts.output)?,
         CodegenOutput::Clif => c.clif_ir(&opts.output)?,
-    };
-
+    }
     Ok(())
 }
 

--- a/lucetc/lucetc/main.rs
+++ b/lucetc/lucetc/main.rs
@@ -14,9 +14,9 @@ use lucetc::{
 };
 use serde::Serialize;
 use serde_json;
-use std::time::Duration;
 use std::path::PathBuf;
 use std::process;
+use std::time::Duration;
 
 #[derive(Clone, Debug, Serialize)]
 pub struct SerializedLucetcError {

--- a/lucetc/lucetc/options.rs
+++ b/lucetc/lucetc/options.rs
@@ -118,6 +118,7 @@ pub struct Options {
     pub pk_path: Option<PathBuf>,
     pub sk_path: Option<PathBuf>,
     pub count_instructions: bool,
+    pub report_times: bool,
     pub error_style: ErrorStyle,
 }
 
@@ -196,6 +197,7 @@ impl Options {
         let sk_path = m.value_of("sk_path").map(PathBuf::from);
         let pk_path = m.value_of("pk_path").map(PathBuf::from);
         let count_instructions = m.is_present("count_instructions");
+        let report_times = m.is_present("report_times");
 
         let error_style = match m.value_of("error_style") {
             None => ErrorStyle::default(),
@@ -224,6 +226,7 @@ impl Options {
             sk_path,
             pk_path,
             count_instructions,
+            report_times,
             error_style,
         })
     }
@@ -428,6 +431,12 @@ SSE3 but not AVX:
                     .long("--count-instructions")
                     .takes_value(false)
                     .help("Instrument the produced binary to count the number of wasm operations the translated program executes")
+            )
+            .arg(
+                Arg::with_name("report_times")
+                    .long("--report-times")
+                    .takes_value(false)
+                    .help("Report times for lucetc and cranelift compilation passes")
             )
             .arg(
                 Arg::with_name("error_style")

--- a/lucetc/src/compiler.rs
+++ b/lucetc/src/compiler.rs
@@ -23,7 +23,7 @@ use failure::{format_err, Fail, ResultExt};
 use lucet_module::bindings::Bindings;
 use lucet_module::{FunctionSpec, ModuleData, ModuleFeatures, MODULE_DATA_SYM};
 use lucet_validate::Validator;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 #[derive(Debug, Clone, Copy)]
 pub enum OptLevel {
@@ -143,7 +143,7 @@ impl<'a> Compiler<'a> {
         self.decls.get_module_data(self.module_features())
     }
 
-    pub fn object_file(mut self) -> Result<(ObjectFile, Duration), LucetcError> {
+    pub fn object_file(mut self) -> Result<ObjectFile, LucetcError> {
         let mut func_translator = FuncTranslator::new();
 
         for (ref func, (code, code_offset)) in self.decls.function_bodies() {
@@ -197,7 +197,7 @@ impl<'a> Compiler<'a> {
             })
             .collect();
 
-        let start = Instant::now();
+        let object_start = Instant::now();
 
         let obj = ObjectFile::new(
             self.clif_module.finish(),
@@ -207,9 +207,9 @@ impl<'a> Compiler<'a> {
         )
         .context(LucetcErrorKind::Output)?;
 
-        let duration = start.elapsed();
+        crate::timing::record_output_time(object_start.elapsed());
 
-        Ok((obj, duration))
+        Ok(obj)
     }
 
     pub fn cranelift_funcs(self) -> Result<CraneliftFuncs, LucetcError> {

--- a/lucetc/src/timing.rs
+++ b/lucetc/src/timing.rs
@@ -1,0 +1,68 @@
+use crate::timing;
+use serde::Serialize;
+use std::cell::RefCell;
+use std::fmt;
+use std::mem;
+use std::time::Duration;
+
+thread_local! {
+    static OUTPUT_TIME: RefCell<Duration> = RefCell::new(Duration::default());
+}
+
+pub(crate) fn record_output_time(duration: Duration) {
+    OUTPUT_TIME.with(|rc| *rc.borrow_mut() = duration);
+}
+
+pub fn take_output_time() -> Duration {
+    OUTPUT_TIME.with(|rc| mem::replace(&mut *rc.borrow_mut(), Duration::default()))
+}
+
+#[derive(Serialize)]
+pub struct TimingInfo {
+    pass_times: Vec<String>,
+}
+
+impl TimingInfo {
+    pub fn collect() -> Self {
+        // `cranelift_codegen::timing::PassTimes` has hidden members at the moment
+        // so the best we can do consistently without deep sins like transmutes is to just split
+        // some strings.
+        let mut pass_times: Vec<String> = vec![];
+        let cranelift_time_text = cranelift_codegen::timing::take_current().to_string();
+        // skip the header text from Cranelift's `Display`, then take until we hit the end (also
+        // "======= ======= ==...")
+        for pass in cranelift_time_text
+            .split("\n")
+            .skip(3)
+            .take_while(|line| !line.starts_with("========"))
+        {
+            pass_times.push(pass.to_string());
+        }
+
+        // and now add our own recording of how long it took to write output
+        let output_time = timing::take_output_time();
+        if output_time != Duration::default() {
+            // Round to nearest ms by adding 500us (copied from cranelift-codegen)
+            let output_time = output_time + Duration::new(0, 500_000);
+            let ms = output_time.subsec_millis();
+            let secs = output_time.as_secs();
+            // match cranelift pass timing format
+            pass_times.push(format!(
+                "{:4}.{:03} {:4}.{:03}  Emit output",
+                secs, ms, secs, ms
+            ));
+        }
+
+        Self { pass_times }
+    }
+}
+
+impl fmt::Display for TimingInfo {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        for pass in self.pass_times.iter() {
+            writeln!(f, "{}", pass)?;
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Adds a `--report-times` which makes for nice breakdowns via `lucetc --report-times slow_to_compile.wat` like:
```
======== ========  ==================================
   Total     Self  Pass
-------- --------  ----------------------------------
   0.000    0.000  Translate WASM module
   0.001    0.001  Translate WASM function
  12.435    3.888  Verify Cranelift IR
   0.005    0.005  Verify CSSA
   0.008    0.008  Verify live ranges
   0.005    0.005  Verify value locations
   0.086    0.086  Verify CPU flags
  15.781    0.006  Compilation passes
   0.049    0.049  Control flow graph
  10.828   10.828  Dominator tree
   0.260    0.260  Loop analysis
   0.003    0.003  Post-legalization rewriting
   0.000    0.000  Pre-legalization rewriting
   0.001    0.001  Dead code elimination
   0.009    0.009  Legalization
   0.002    0.002  Global value numbering
   0.402    0.000  Loop invariant code motion
   0.000    0.000  Remove unreachable blocks
   5.229    0.018  Register allocation
   0.002    0.002  RA liveness analysis
   0.001    0.001  RA coalescing CSSA
   0.006    0.006  RA spilling
   0.005    0.005  RA reloading
   0.007    0.007  RA coloring
   0.001    0.001  Prologue/epilogue insertion
   0.005    0.005  Instruction encoding shrinking
   0.990    0.588  Branch relaxation
   0.000    0.000  Binary machine code emission
   0.000    0.000  Layout full renumbering
   0.000    0.000  Emit output
```

or in json (` ../target/debug/lucetc tests/wasm/arith.wat --report-times --error-style json`):
```
{"errors":null,"timing":{"pass_times":["   0.000    0.000  Translate WASM module","   0.000    0.000  Translate WASM function","   0.004    0.003  Verify Cranelift IR","   0.000    0.000  Verify CSSA","   0.000    0.000  Verify live ranges","   0.000    0.000  Verify value locations","   0.000    0.000  Verify CPU flags","   0.006    0.000  Compilation passes","   0.000    0.000  Control flow graph","   0.000    0.000  Dominator tree","   0.000    0.000  Loop analysis","   0.000    0.000  Post-legalization rewriting","   0.000    0.000  Pre-legalization rewriting","   0.000    0.000  Dead code elimination","   0.000    0.000  Legalization","   0.000    0.000  Global value numbering","   0.000    0.000  Loop invariant code motion","   0.000    0.000  Remove unreachable blocks","   0.002    0.000  Register allocation","   0.000
 0.000  RA liveness analysis","   0.000    0.000  RA coalescing CSSA","   0.000    0.000  RA spilling","   0.000    0.000  RA reloading","   0.000    0.000  RA coloring","   0.000    0.000  Prologue/epilogue insertion","   0.000    0.000  Instruction encoding shrinking","   0.000    0.000  Branch relaxation","   0.000    0.000  Binary machine code emission","   0.000    0.000  Emit output"]}}
```