### PR TITLE
into_iter() -> iter() for arrays

### DIFF
--- a/lucet-runtime/lucet-runtime-internals/src/region/mmap.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/region/mmap.rs
@@ -89,7 +89,7 @@ impl RegionInternal for MmapRegion {
             // make the sigstack read/writable
             (slot.sigstack, SIGSTKSZ),
         ]
-        .into_iter()
+        .iter()
         {
             // eprintln!("setting r/w {:p}[{:x}]", *ptr, len);
             unsafe { mprotect(*ptr, *len, ProtFlags::PROT_READ | ProtFlags::PROT_WRITE)? };
@@ -138,7 +138,7 @@ impl RegionInternal for MmapRegion {
             (slot.globals, slot.limits.globals_size),
             (slot.sigstack, SIGSTKSZ),
         ]
-        .into_iter()
+        .iter()
         {
             // eprintln!("setting none {:p}[{:x}]", *ptr, len);
             unsafe {


### PR DESCRIPTION
This was previously accepted by the compiler but is being phased out;
It will become a hard error in a future `rustc` release.

See https://github.com/rust-lang/rust/issues/66145