### PR TITLE
ModuleDecls Cleanup

### DIFF
--- a/lucetc/src/decls.rs
+++ b/lucetc/src/decls.rs
@@ -394,8 +394,8 @@ impl<'a> ModuleDecls<'a> {
                 Ok(Some(HeapSpec {
                     reserved_size,
                     guard_size: heap_settings.guard_size,
-                    initial_size: initial_size,
-                    max_size: max_size,
+                    initial_size,
+                    max_size,
                 }))
             }
             _ => Err(format_err!("lucetc only supports memory 0"))


### PR DESCRIPTION
For reasons unrelated to this PR, I ended up looking through `lucetc/src/decls.rs` this morning. I noticed a few warts that would be easy fixes, so this is a small gardening PR.

* Addresses two lint warnings about redundant field names, using the shorthand notation instead.
* Moves `*_name_for` helper functions nested inside of `declare_funcs` out of a loop body. This is just a small readability fix for our loop.