### PR TITLE
break lucetc dep in runtime-internals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -817,6 +817,7 @@ dependencies = [
 name = "lucet-runtime"
 version = "0.5.0"
 dependencies = [
+ "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -848,7 +849,6 @@ dependencies = [
  "libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lucet-module 0.5.0",
  "lucet-runtime-macros 0.5.0",
- "lucetc 0.5.0",
  "memoffset 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/lucet-runtime/Cargo.toml
+++ b/lucet-runtime/Cargo.toml
@@ -25,6 +25,7 @@ lucet-wasi-sdk = { path = "../lucet-wasi-sdk", version = "0.5.0" }
 nix = "0.15"
 rayon = "1.0"
 tempfile = "3.0"
+anyhow = "1"
 
 [build-dependencies]
 # only used for tests

--- a/lucet-runtime/lucet-runtime-internals/Cargo.toml
+++ b/lucet-runtime/lucet-runtime-internals/Cargo.toml
@@ -10,7 +10,6 @@ authors = ["Lucet team <lucet@fastly.com>"]
 edition = "2018"
 
 [dependencies]
-lucetc = { path = "../../lucetc", version = "0.5.0" }
 lucet-module = { path = "../../lucet-module", version = "0.5.0" }
 lucet-runtime-macros = { path = "../lucet-runtime-macros", version = "0.5.0" }
 

--- a/lucet-runtime/lucet-runtime-internals/src/error.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/error.rs
@@ -1,5 +1,4 @@
 use crate::instance::{FaultDetails, TerminationDetails};
-use lucetc::Error as LucetcError;
 use thiserror::Error;
 
 /// Lucet runtime errors.
@@ -69,12 +68,6 @@ pub enum Error {
     /// An unsupported feature was used.
     #[error("Unsupported feature: {0}")]
     Unsupported(String),
-}
-
-impl From<LucetcError> for Error {
-    fn from(e: LucetcError) -> Error {
-        Error::InternalError(e.into())
-    }
 }
 
 impl From<crate::context::Error> for Error {

--- a/lucet-runtime/tests/instruction_counting.rs
+++ b/lucet-runtime/tests/instruction_counting.rs
@@ -1,4 +1,5 @@
-use lucet_runtime::{DlModule, Error, Limits, MmapRegion, Region, RunResult};
+use anyhow::Error;
+use lucet_runtime::{DlModule, Limits, MmapRegion, Region, RunResult};
 use lucetc::{Lucetc, LucetcOpts};
 use rayon::prelude::*;
 use std::fs::DirEntry;


### PR DESCRIPTION
In code review I wanted to understand exactly why lucetc was a dep of runtime-internals and by the time I used the compiler to figure it out, the fix was only two more lines.