### PR TITLE
Export the `KillSwitch` type from the public runtime API

### DIFF
--- a/lucet-runtime/lucet-runtime-internals/src/instance/execution.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/instance/execution.rs
@@ -225,6 +225,7 @@ pub enum Domain {
     Terminated,
 }
 
+/// An object that can be used to terminate an instance's execution from a separate thread.
 pub struct KillSwitch {
     state: Weak<KillState>,
 }
@@ -242,7 +243,6 @@ pub enum KillError {
 
 type KillResult = Result<KillSuccess, KillError>;
 
-/// An object that can be used to terminate an instance's execution from a separate thread.
 impl KillSwitch {
     pub(crate) fn new(state: Weak<KillState>) -> Self {
         KillSwitch { state }

--- a/lucet-runtime/src/lib.rs
+++ b/lucet-runtime/src/lib.rs
@@ -343,8 +343,8 @@ pub use lucet_module::{PublicKey, TrapCode};
 pub use lucet_runtime_internals::alloc::Limits;
 pub use lucet_runtime_internals::error::Error;
 pub use lucet_runtime_internals::instance::{
-    FaultDetails, Instance, InstanceHandle, KillError, KillSuccess, RunResult, SignalBehavior,
-    TerminationDetails, YieldedVal,
+    FaultDetails, Instance, InstanceHandle, KillError, KillSuccess, KillSwitch, RunResult,
+    SignalBehavior, TerminationDetails, YieldedVal,
 };
 #[allow(deprecated)]
 pub use lucet_runtime_internals::lucet_hostcalls;


### PR DESCRIPTION
It was already possible to use via the `Instance::kill_switch()` method, but couldn't be named in a type signature or a type declaration.