### PR TITLE
Use exact dependencies for crates within the repo

### DIFF
--- a/lucet-objdump/Cargo.toml
+++ b/lucet-objdump/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 goblin="0.0.24"
 byteorder="1.2.1"
 colored="1.8.0"
-lucet-module = { path = "../lucet-module", version = "0.5.0" }
+lucet-module = { path = "../lucet-module", version = "=0.5.0" }
 
 [package.metadata.deb]
 name = "fst-lucet-objdump"

--- a/lucet-runtime/Cargo.toml
+++ b/lucet-runtime/Cargo.toml
@@ -11,17 +11,17 @@ edition = "2018"
 
 [dependencies]
 libc = "0.2.65"
-lucet-runtime-internals = { path = "lucet-runtime-internals", version = "0.5.0" }
-lucet-module = { path = "../lucet-module", version = "0.5.0" }
+lucet-runtime-internals = { path = "lucet-runtime-internals", version = "=0.5.0" }
+lucet-module = { path = "../lucet-module", version = "=0.5.0" }
 num-traits = "0.2"
 num-derive = "0.3.0"
 
 [dev-dependencies]
 byteorder = "1.2"
 lazy_static = "1.1"
-lucetc = { path = "../lucetc", version = "0.5.0" }
-lucet-runtime-tests = { path = "lucet-runtime-tests", version = "0.5.0" }
-lucet-wasi-sdk = { path = "../lucet-wasi-sdk", version = "0.5.0" }
+lucetc = { path = "../lucetc", version = "=0.5.0" }
+lucet-runtime-tests = { path = "lucet-runtime-tests", version = "=0.5.0" }
+lucet-wasi-sdk = { path = "../lucet-wasi-sdk", version = "=0.5.0" }
 nix = "0.15"
 rayon = "1.0"
 tempfile = "3.0"

--- a/lucet-runtime/lucet-runtime-internals/Cargo.toml
+++ b/lucet-runtime/lucet-runtime-internals/Cargo.toml
@@ -10,8 +10,8 @@ authors = ["Lucet team <lucet@fastly.com>"]
 edition = "2018"
 
 [dependencies]
-lucet-module = { path = "../../lucet-module", version = "0.5.0" }
-lucet-runtime-macros = { path = "../lucet-runtime-macros", version = "0.5.0" }
+lucet-module = { path = "../../lucet-module", version = "=0.5.0" }
+lucet-runtime-macros = { path = "../lucet-runtime-macros", version = "=0.5.0" }
 
 anyhow = "1.0"
 bitflags = "1.0"

--- a/lucet-runtime/lucet-runtime-tests/Cargo.toml
+++ b/lucet-runtime/lucet-runtime-tests/Cargo.toml
@@ -18,10 +18,10 @@ test = false
 anyhow = "1"
 lazy_static = "1.1"
 tempfile = "3.0"
-lucet-module = { path = "../../lucet-module", version = "0.5.0" }
-lucet-runtime-internals = { path = "../lucet-runtime-internals", version = "0.5.0" }
-lucet-wasi-sdk = { path = "../../lucet-wasi-sdk", version = "0.5.0" }
-lucetc = { path = "../../lucetc", version = "0.5.0" }
+lucet-module = { path = "../../lucet-module", version = "=0.5.0" }
+lucet-runtime-internals = { path = "../lucet-runtime-internals", version = "=0.5.0" }
+lucet-wasi-sdk = { path = "../../lucet-wasi-sdk", version = "=0.5.0" }
+lucetc = { path = "../../lucetc", version = "=0.5.0" }
 
 [build-dependencies]
 cc = "1.0"

--- a/lucet-spectest/Cargo.toml
+++ b/lucet-spectest/Cargo.toml
@@ -18,9 +18,9 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1"
-lucetc = { path = "../lucetc", version = "0.5.0" }
-lucet-module = { path = "../lucet-module", version = "0.5.0" }
-lucet-runtime = { path = "../lucet-runtime", version = "0.5.0" }
+lucetc = { path = "../lucetc", version = "=0.5.0" }
+lucet-module = { path = "../lucet-module", version = "=0.5.0" }
+lucet-runtime = { path = "../lucet-runtime", version = "=0.5.0" }
 wabt = "0.9.2"
 serde = "1.0"
 serde_json = "1.0"

--- a/lucet-validate/Cargo.toml
+++ b/lucet-validate/Cargo.toml
@@ -20,11 +20,11 @@ path = "src/main.rs"
 clap = "2"
 witx = { path = "../wasi/tools/witx", version = "0.6.0" }
 cranelift-entity = { path = "../cranelift/cranelift-entity", version = "0.51.0" }
-thiserror = "1.0.4" 
+thiserror = "1.0.4"
 wasmparser = "0.39.1"
 
 [dev-dependencies]
-lucet-wasi-sdk = { path = "../lucet-wasi-sdk", version = "0.5.0" }
+lucet-wasi-sdk = { path = "../lucet-wasi-sdk", version = "=0.5.0" }
 tempfile = "3.0"
 wabt = "0.9.2"
 

--- a/lucet-wasi-sdk/Cargo.toml
+++ b/lucet-wasi-sdk/Cargo.toml
@@ -11,11 +11,11 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1"
-lucetc = { path = "../lucetc", version = "0.5.0" }
-lucet-module = { path = "../lucet-module", version = "0.5.0" }
+lucetc = { path = "../lucetc", version = "=0.5.0" }
+lucet-module = { path = "../lucet-module", version = "=0.5.0" }
 target-lexicon = "0.9"
 tempfile = "3.0"
 thiserror = "1.0.4"
 
 [dev-dependencies]
-lucet-validate = { path = "../lucet-validate", version  = "0.5.0" }
+lucet-validate = { path = "../lucet-validate", version  = "=0.5.0" }

--- a/lucet-wasi/Cargo.toml
+++ b/lucet-wasi/Cargo.toml
@@ -28,17 +28,17 @@ anyhow = "1"
 cast = "0.2"
 clap = "2.23"
 human-size = "0.4"
-lucet-runtime = { path = "../lucet-runtime", version = "0.5.0" }
-lucet-runtime-internals = { path = "../lucet-runtime/lucet-runtime-internals", version = "0.5.0" }
-lucet-module = { path = "../lucet-module", version = "0.5.0" }
+lucet-runtime = { path = "../lucet-runtime", version = "=0.5.0" }
+lucet-runtime-internals = { path = "../lucet-runtime/lucet-runtime-internals", version = "=0.5.0" }
+lucet-module = { path = "../lucet-module", version = "=0.5.0" }
 libc = "0.2.65"
 nix = "0.15"
 rand = "0.6"
 wasi-common = "0.7"
 
 [dev-dependencies]
-lucet-wasi-sdk = { path = "../lucet-wasi-sdk", version = "0.5.0" }
-lucetc = { path = "../lucetc", version = "0.5.0" }
+lucet-wasi-sdk = { path = "../lucet-wasi-sdk", version = "=0.5.0" }
+lucetc = { path = "../lucetc", version = "=0.5.0" }
 tempfile = "3.0"
 
 [build-dependencies]

--- a/lucetc/Cargo.toml
+++ b/lucetc/Cargo.toml
@@ -24,8 +24,8 @@ cranelift-module = { path = "../cranelift/cranelift-module", version = "0.51.0" 
 cranelift-faerie = { path = "../cranelift/cranelift-faerie", version = "0.51.0" }
 cranelift-wasm = { path = "../cranelift/cranelift-wasm", version = "0.51.0" }
 target-lexicon = "0.9"
-lucet-module = { path = "../lucet-module", version = "0.5.0" }
-lucet-validate = { path = "../lucet-validate", version = "0.5.0" }
+lucet-module = { path = "../lucet-module", version = "=0.5.0" }
+lucet-validate = { path = "../lucet-validate", version = "=0.5.0" }
 wasmparser = "0.39.1"
 clap="2.32"
 log = "0.4"
@@ -46,7 +46,7 @@ minisign = "0.5.11"
 memoffset = "0.5.1"
 serde = "1.0"
 serde_json = "1.0"
-thiserror = "1.0.4" 
+thiserror = "1.0.4"
 raw-cpuid = "6.0.0"
 
 [package.metadata.deb]


### PR DESCRIPTION
Most of our thinking about semver for this project is concerned with the more "public-facing" crates like `lucetc`, `lucet-runtime`, and `lucet-wasi`, as opposed to "implementation detail" crates like `lucet-module`, `lucet-runtime-internals`, etc. As the project matures, we are paying more attention to semver for all of the crates, but this change makes the released sets of packages more consistent.