### PR TITLE
Fix incorrect globals/sigstack allocation layout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,7 +146,7 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -391,7 +391,7 @@ dependencies = [
  "rayon 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "tinytemplate 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -460,7 +460,7 @@ name = "csv"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bstr 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bstr 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "csv-core 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -773,15 +773,15 @@ dependencies = [
 
 [[package]]
 name = "lucet-benchmarks"
-version = "0.4.1"
+version = "0.5.1"
 dependencies = [
  "criterion 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.5.0",
- "lucet-runtime 0.5.0",
- "lucet-runtime-internals 0.5.0",
- "lucet-wasi 0.5.0",
- "lucet-wasi-sdk 0.5.0",
- "lucetc 0.5.0",
+ "lucet-module 0.5.1",
+ "lucet-runtime 0.5.1",
+ "lucet-runtime-internals 0.5.1",
+ "lucet-wasi 0.5.1",
+ "lucet-wasi-sdk 0.5.1",
+ "lucetc 0.5.1",
  "nix 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "lucet-module"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -804,34 +804,34 @@ dependencies = [
  "object 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-big-array 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "lucet-objdump"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "colored 1.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "goblin 0.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.5.0",
+ "lucet-module 0.5.1",
 ]
 
 [[package]]
 name = "lucet-runtime"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.5.0",
- "lucet-runtime-internals 0.5.0",
- "lucet-runtime-tests 0.5.0",
- "lucet-wasi-sdk 0.5.0",
- "lucetc 0.5.0",
+ "lucet-module 0.5.1",
+ "lucet-runtime-internals 0.5.1",
+ "lucet-runtime-tests 0.5.1",
+ "lucet-wasi-sdk 0.5.1",
+ "lucetc 0.5.1",
  "nix 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -841,7 +841,7 @@ dependencies = [
 
 [[package]]
 name = "lucet-runtime-internals"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -852,8 +852,8 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.5.0",
- "lucet-runtime-macros 0.5.0",
+ "lucet-module 0.5.1",
+ "lucet-runtime-macros 0.5.1",
  "memoffset 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -864,7 +864,7 @@ dependencies = [
 
 [[package]]
 name = "lucet-runtime-macros"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -872,29 +872,28 @@ dependencies = [
 
 [[package]]
 name = "lucet-runtime-tests"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.5.0",
- "lucet-runtime-internals 0.5.0",
- "lucet-wasi-sdk 0.5.0",
- "lucetc 0.5.0",
+ "lucet-module 0.5.1",
+ "lucet-runtime-internals 0.5.1",
+ "lucet-wasi-sdk 0.5.1",
+ "lucetc 0.5.1",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "lucet-spectest"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
- "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.5.0",
- "lucet-runtime 0.5.0",
- "lucetc 0.5.0",
+ "lucet-module 0.5.1",
+ "lucet-runtime 0.5.1",
+ "lucetc 0.5.1",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "target-lexicon 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -903,11 +902,11 @@ dependencies = [
 
 [[package]]
 name = "lucet-validate"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cranelift-entity 0.51.0",
- "lucet-wasi-sdk 0.5.0",
+ "lucet-wasi-sdk 0.5.1",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "wabt 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -917,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "lucet-wasi"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "bindgen 0.51.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -925,11 +924,11 @@ dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "human-size 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.5.0",
- "lucet-runtime 0.5.0",
- "lucet-runtime-internals 0.5.0",
- "lucet-wasi-sdk 0.5.0",
- "lucetc 0.5.0",
+ "lucet-module 0.5.1",
+ "lucet-runtime 0.5.1",
+ "lucet-runtime-internals 0.5.1",
+ "lucet-wasi-sdk 0.5.1",
+ "lucetc 0.5.1",
  "nix 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -938,16 +937,16 @@ dependencies = [
 
 [[package]]
 name = "lucet-wasi-fuzz"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.5.0",
- "lucet-runtime 0.5.0",
- "lucet-wasi 0.5.0",
- "lucet-wasi-sdk 0.5.0",
- "lucetc 0.5.0",
+ "lucet-module 0.5.1",
+ "lucet-runtime 0.5.1",
+ "lucet-wasi 0.5.1",
+ "lucet-wasi-sdk 0.5.1",
+ "lucetc 0.5.1",
  "nix 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "progress 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -961,12 +960,13 @@ dependencies = [
 
 [[package]]
 name = "lucet-wasi-sdk"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.5.0",
- "lucet-validate 0.5.0",
- "lucetc 0.5.0",
+ "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lucet-module 0.5.1",
+ "lucet-validate 0.5.1",
+ "lucetc 0.5.1",
  "target-lexicon 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -974,7 +974,7 @@ dependencies = [
 
 [[package]]
 name = "lucetc"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "bimap 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -994,14 +994,14 @@ dependencies = [
  "goblin 0.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "human-size 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.5.0",
- "lucet-validate 0.5.0",
+ "lucet-module 0.5.1",
+ "lucet-validate 0.5.1",
  "memoffset 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "minisign 0.5.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-wasm 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "raw-cpuid 6.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "target-lexicon 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1252,7 +1252,7 @@ dependencies = [
  "proc-macro-error-attr 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustversion 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustversion 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1263,7 +1263,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustversion 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustversion 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn-mid 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1587,7 +1587,7 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1704,7 +1704,7 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1744,7 +1744,7 @@ dependencies = [
  "printtable 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "xfailure 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1865,7 +1865,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1943,7 +1943,7 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2011,7 +2011,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "wabt-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2086,7 +2086,7 @@ dependencies = [
  "parity-wasm 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "siphasher 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "xfailure 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2212,7 +2212,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 "checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 "checksum block-padding 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
-"checksum bstr 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3ede750122d9d1f87919570cb2cccee38c84fbc8c5599b25c289af40625b7030"
+"checksum bstr 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "fe8a65814ca90dfc9705af76bb6ba3c6e2534489a72270e797e603783bb4990b"
 "checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 "checksum c2-chacha 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
@@ -2340,7 +2340,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 "checksum rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7540fc8b0c49f096ee9c961cda096467dce8084bec6bdca2fc83895fd9b28cb8"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-"checksum rustversion 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3a0538bd897e17257b0128d2fd95c2ed6df939374073a36166051a79e2eb7986"
+"checksum rustversion 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b3bba175698996010c4f6dce5e7f173b6eb781fce25d2cfc45e27091ce0b79f6"
 "checksum ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
 "checksum same-file 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 "checksum scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
@@ -2354,7 +2354,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449"
 "checksum serde-big-array 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "883eee5198ea51720eab8be52a36cf6c0164ac90eea0ed95b649d5e35382404e"
 "checksum serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64"
-"checksum serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)" = "48c575e0cc52bdd09b47f330f646cf59afc586e9c4e3ccd6fc1f625b8ea1dad7"
+"checksum serde_json 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)" = "eab8f15f15d6c41a154c1b128a22f2dfabe350ef53c40953d84e36155c91192b"
 "checksum sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "27044adfd2e1f077f649f59deb9490d3941d674002f7d062870a60ebe9bd47a0"
 "checksum shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 "checksum siphasher 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "83da420ee8d1a89e640d0948c646c1c088758d3a3c538f943bfa97bdac17929d"

--- a/benchmarks/lucet-benchmarks/Cargo.toml
+++ b/benchmarks/lucet-benchmarks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-benchmarks"
-version = "0.4.1"
+version = "0.5.1"
 description = "Benchmarks for the Lucet runtime"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"

--- a/lucet-module/Cargo.toml
+++ b/lucet-module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-module"
-version = "0.5.0"
+version = "0.5.1"
 description = "A structured interface for Lucet modules"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"

--- a/lucet-objdump/Cargo.toml
+++ b/lucet-objdump/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-objdump"
-version = "0.5.0"
+version = "0.5.1"
 description = "Analyze object files emitted by the Lucet compiler"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -13,7 +13,7 @@ edition = "2018"
 goblin="0.0.24"
 byteorder="1.2.1"
 colored="1.8.0"
-lucet-module = { path = "../lucet-module", version = "=0.5.0" }
+lucet-module = { path = "../lucet-module", version = "=0.5.1" }
 
 [package.metadata.deb]
 name = "fst-lucet-objdump"

--- a/lucet-runtime/Cargo.toml
+++ b/lucet-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-runtime"
-version = "0.5.0"
+version = "0.5.1"
 description = "Pure Rust runtime for Lucet WebAssembly toolchain"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -11,17 +11,17 @@ edition = "2018"
 
 [dependencies]
 libc = "0.2.65"
-lucet-runtime-internals = { path = "lucet-runtime-internals", version = "=0.5.0" }
-lucet-module = { path = "../lucet-module", version = "=0.5.0" }
+lucet-runtime-internals = { path = "lucet-runtime-internals", version = "=0.5.1" }
+lucet-module = { path = "../lucet-module", version = "=0.5.1" }
 num-traits = "0.2"
 num-derive = "0.3.0"
 
 [dev-dependencies]
 byteorder = "1.2"
 lazy_static = "1.1"
-lucetc = { path = "../lucetc", version = "=0.5.0" }
-lucet-runtime-tests = { path = "lucet-runtime-tests", version = "=0.5.0" }
-lucet-wasi-sdk = { path = "../lucet-wasi-sdk", version = "=0.5.0" }
+lucetc = { path = "../lucetc", version = "=0.5.1" }
+lucet-runtime-tests = { path = "lucet-runtime-tests", version = "=0.5.1" }
+lucet-wasi-sdk = { path = "../lucet-wasi-sdk", version = "=0.5.1" }
 nix = "0.15"
 rayon = "1.0"
 tempfile = "3.0"

--- a/lucet-runtime/include/lucet_types.h
+++ b/lucet-runtime/include/lucet_types.h
@@ -123,6 +123,13 @@ struct lucet_alloc_limits {
      * Size of the globals region in bytes; each global uses 8 bytes. (default 4K)
      */
     uint64_t globals_size;
+    /**
+     * Size of the signal stack region in bytes.
+     *
+     * SIGSTKSZ from <signals.h> is a good default when linking against a Rust release build of
+     * lucet-runtime, but 12K or more is recommended when using a Rust debug build.
+     */
+    uint64_t signal_stack_size;
 };
 
 typedef enum lucet_signal_behavior (*lucet_signal_handler)(struct lucet_instance *   inst,

--- a/lucet-runtime/lucet-runtime-internals/Cargo.toml
+++ b/lucet-runtime/lucet-runtime-internals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-runtime-internals"
-version = "0.5.0"
+version = "0.5.1"
 description = "Pure Rust runtime for Lucet WebAssembly toolchain (internals)"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -10,8 +10,8 @@ authors = ["Lucet team <lucet@fastly.com>"]
 edition = "2018"
 
 [dependencies]
-lucet-module = { path = "../../lucet-module", version = "=0.5.0" }
-lucet-runtime-macros = { path = "../lucet-runtime-macros", version = "=0.5.0" }
+lucet-module = { path = "../../lucet-module", version = "=0.5.1" }
+lucet-runtime-macros = { path = "../lucet-runtime-macros", version = "=0.5.1" }
 
 anyhow = "1.0"
 bitflags = "1.0"

--- a/lucet-runtime/lucet-runtime-internals/src/alloc/tests.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/alloc/tests.rs
@@ -21,6 +21,7 @@ macro_rules! alloc_tests {
             heap_address_space_size: LIMITS_HEAP_ADDRSPACE_SIZE,
             stack_size: LIMITS_STACK_SIZE,
             globals_size: LIMITS_GLOBALS_SIZE,
+            ..Limits::default()
         };
 
         const SPEC_HEAP_RESERVED_SIZE: u64 = LIMITS_HEAP_ADDRSPACE_SIZE as u64 / 2;
@@ -264,6 +265,7 @@ macro_rules! alloc_tests {
                 heap_address_space_size: LIMITS_HEAP_ADDRSPACE_SIZE,
                 stack_size: LIMITS_STACK_SIZE,
                 globals_size: LIMITS_GLOBALS_SIZE,
+                ..Limits::default()
             };
             let res = TestRegion::create(10, &LIMITS);
             assert!(res.is_err(), "region creation fails");
@@ -366,7 +368,7 @@ macro_rules! alloc_tests {
                 }
 
                 let sigstack = unsafe { inst.alloc_mut().sigstack_mut() };
-                assert_eq!(sigstack.len(), libc::SIGSTKSZ);
+                assert_eq!(sigstack.len(), LIMITS.signal_stack_size);
 
                 assert_eq!(sigstack[0], 0);
                 sigstack[0] = 0xFF;
@@ -569,6 +571,7 @@ macro_rules! alloc_tests {
             heap_address_space_size: 2 * 4096,
             stack_size: 4096,
             globals_size: 4096,
+            ..Limits::default()
         };
         const CONTEXT_TEST_INITIAL_SIZE: u64 = 4096;
         const CONTEXT_TEST_HEAP: HeapSpec = HeapSpec {

--- a/lucet-runtime/lucet-runtime-internals/src/c_api.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/c_api.rs
@@ -140,6 +140,16 @@ pub struct lucet_alloc_limits {
     pub stack_size: u64,
     /// Size of the globals region in bytes; each global uses 8 bytes. (default 4K)
     pub globals_size: u64,
+    /// Size of the signal stack in bytes. (default SIGSTKSZ for Rust release builds, 12K for Rust
+    /// debug builds)
+    ///
+    /// This difference is to account for the greatly increased stack size usage in the signal
+    /// handler when running without optimizations.
+    ///
+    /// Note that debug vs. release mode is determined by `cfg(debug_assertions)`, so if you are
+    /// specifically enabling Rust debug assertions in your Cargo release builds, the default signal
+    /// stack will be larger.
+    pub signal_stack_size: u64,
 }
 
 impl From<Limits> for lucet_alloc_limits {
@@ -155,6 +165,7 @@ impl From<&Limits> for lucet_alloc_limits {
             heap_address_space_size: limits.heap_address_space_size as u64,
             stack_size: limits.stack_size as u64,
             globals_size: limits.globals_size as u64,
+            signal_stack_size: limits.signal_stack_size as u64,
         }
     }
 }
@@ -172,6 +183,7 @@ impl From<&lucet_alloc_limits> for Limits {
             heap_address_space_size: limits.heap_address_space_size as usize,
             stack_size: limits.stack_size as usize,
             globals_size: limits.globals_size as usize,
+            signal_stack_size: limits.signal_stack_size as usize,
         }
     }
 }

--- a/lucet-runtime/lucet-runtime-internals/src/instance/signals.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/instance/signals.rs
@@ -61,7 +61,7 @@ impl Instance {
         let guest_sigstack = SigStack::new(
             self.alloc.slot().sigstack,
             SigStackFlags::empty(),
-            libc::SIGSTKSZ,
+            self.alloc.slot().limits.signal_stack_size,
         );
         let previous_sigstack = unsafe { sigaltstack(Some(guest_sigstack)) }
             .expect("enabling or changing the signal stack succeeds");

--- a/lucet-runtime/lucet-runtime-internals/src/instance/signals.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/instance/signals.rs
@@ -218,10 +218,13 @@ extern "C" fn handle_signal(signum: c_int, siginfo_ptr: *mut siginfo_t, ucontext
                     // If the trap table lookup returned unknown, it is a fatal error
                     let unknown_fault = trapcode.is_none();
 
-                    // If the trap was a segv or bus fault and the addressed memory was outside the
-                    // guard pages, it is also a fatal error
+                    // If the trap was a segv or bus fault and the addressed memory was in the
+                    // signal stack guard page or outside the alloc entirely, the fault is fatal
                     let outside_guard = (siginfo.si_signo == SIGSEGV || siginfo.si_signo == SIGBUS)
-                        && !inst.alloc.addr_in_guard_page(siginfo.si_addr_ext());
+                        && inst
+                            .alloc
+                            .addr_location(siginfo.si_addr_ext())
+                            .is_fault_fatal();
 
                     // record the fault and jump back to the host context
                     inst.state = State::Faulted {

--- a/lucet-runtime/lucet-runtime-internals/src/region/mmap.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/region/mmap.rs
@@ -4,9 +4,9 @@ use crate::error::Error;
 use crate::instance::{new_instance_handle, Instance, InstanceHandle};
 use crate::module::Module;
 use crate::region::{Region, RegionCreate, RegionInternal};
+use libc::c_void;
 #[cfg(not(target_os = "linux"))]
 use libc::memset;
-use libc::{c_void, SIGSTKSZ};
 use nix::sys::mman::{madvise, mmap, munmap, MapFlags, MmapAdvise, ProtFlags};
 use std::ptr;
 use std::sync::{Arc, Mutex, Weak};
@@ -49,7 +49,7 @@ use std::sync::{Arc, Mutex, Weak};
 /// 0xXXXX: |                       |
 /// 0xXXXX  --- global guard page ---
 /// 0xS000: +-----------------------| <-- Sigstack (at globals_start + globals_size + PAGE_SIZE)
-/// 0xSXXX: |  ......sigstack....   | // sigstack is SIGSTKSZ bytes
+/// 0xSXXX: |  ......sigstack....   | // sigstack is governed by limits.signal_stack_size
 /// 0xSXXX: +-----------------------|
 /// ```
 pub struct MmapRegion {
@@ -87,7 +87,7 @@ impl RegionInternal for MmapRegion {
             // make the globals read/writable
             (slot.globals, limits.globals_size),
             // make the sigstack read/writable
-            (slot.sigstack, SIGSTKSZ),
+            (slot.sigstack, limits.signal_stack_size),
         ]
         .iter()
         {
@@ -136,7 +136,7 @@ impl RegionInternal for MmapRegion {
             (slot.heap, alloc.heap_accessible_size),
             (slot.stack, slot.limits.stack_size),
             (slot.globals, slot.limits.globals_size),
-            (slot.sigstack, SIGSTKSZ),
+            (slot.sigstack, slot.limits.signal_stack_size),
         ]
         .iter()
         {
@@ -272,10 +272,6 @@ impl MmapRegion {
     /// The region is returned in an `Arc`, because any instances created from it carry a reference
     /// back to the region.
     pub fn create(instance_capacity: usize, limits: &Limits) -> Result<Arc<Self>, Error> {
-        assert!(
-            SIGSTKSZ % host_page_size() == 0,
-            "signal stack size is a multiple of host page size"
-        );
         limits.validate()?;
 
         let region = Arc::new(MmapRegion {
@@ -305,10 +301,6 @@ impl MmapRegion {
         limits: &Limits,
         heap_alignment: usize,
     ) -> Result<Arc<Self>, Error> {
-        assert!(
-            SIGSTKSZ % host_page_size() == 0,
-            "signal stack size is a multiple of host page size"
-        );
         limits.validate()?;
 
         let is_power_of_2 = (heap_alignment & (heap_alignment - 1)) == 0;
@@ -374,7 +366,7 @@ impl MmapRegion {
         let heap = mem as usize + instance_heap_offset();
         let stack = heap + region.limits.heap_address_space_size + host_page_size();
         let globals = stack + region.limits.stack_size;
-        let sigstack = globals + host_page_size();
+        let sigstack = globals + region.limits.globals_size + host_page_size();
 
         Ok(Slot {
             start: mem,

--- a/lucet-runtime/lucet-runtime-macros/Cargo.toml
+++ b/lucet-runtime/lucet-runtime-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-runtime-macros"
-version = "0.5.0"
+version = "0.5.1"
 description = "Macros for the Lucet WebAssembly runtime"
 homepage = "https://github.com/bytecodealliance/lucet"
 repository = "https://github.com/bytecodealliance/lucet"

--- a/lucet-runtime/lucet-runtime-tests/Cargo.toml
+++ b/lucet-runtime/lucet-runtime-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-runtime-tests"
-version = "0.5.0"
+version = "0.5.1"
 description = "Pure Rust runtime for Lucet WebAssembly toolchain (tests)"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -18,10 +18,10 @@ test = false
 anyhow = "1"
 lazy_static = "1.1"
 tempfile = "3.0"
-lucet-module = { path = "../../lucet-module", version = "=0.5.0" }
-lucet-runtime-internals = { path = "../lucet-runtime-internals", version = "=0.5.0" }
-lucet-wasi-sdk = { path = "../../lucet-wasi-sdk", version = "=0.5.0" }
-lucetc = { path = "../../lucetc", version = "=0.5.0" }
+lucet-module = { path = "../../lucet-module", version = "=0.5.1" }
+lucet-runtime-internals = { path = "../lucet-runtime-internals", version = "=0.5.1" }
+lucet-wasi-sdk = { path = "../../lucet-wasi-sdk", version = "=0.5.1" }
+lucetc = { path = "../../lucetc", version = "=0.5.1" }
 
 [build-dependencies]
 cc = "1.0"

--- a/lucet-runtime/lucet-runtime-tests/src/guest_fault.rs
+++ b/lucet-runtime/lucet-runtime-tests/src/guest_fault.rs
@@ -127,8 +127,9 @@ macro_rules! guest_fault_tests {
         use libc::{c_void, pthread_kill, pthread_self, siginfo_t, SIGALRM, SIGSEGV};
         use lucet_runtime::vmctx::{lucet_vmctx, Vmctx};
         use lucet_runtime::{
-            lucet_hostcall, lucet_hostcall_terminate, DlModule, Error, FaultDetails, Instance,
-            Limits, Region, SignalBehavior, TerminationDetails, TrapCode,
+            lucet_hostcall, lucet_hostcall_terminate, lucet_internal_ensure_linked, DlModule,
+            Error, FaultDetails, Instance, Limits, Region, SignalBehavior, TerminationDetails,
+            TrapCode,
         };
         use nix::sys::mman::{mmap, MapFlags, ProtFlags};
         use nix::sys::signal::{sigaction, SaFlags, SigAction, SigHandler, SigSet, Signal};
@@ -577,6 +578,7 @@ macro_rules! guest_fault_tests {
 
         #[test]
         fn fatal_abort() {
+            lucet_internal_ensure_linked();
             fn handler(_inst: &Instance) -> ! {
                 std::process::abort()
             }

--- a/lucet-runtime/lucet-runtime-tests/src/guest_fault.rs
+++ b/lucet-runtime/lucet-runtime-tests/src/guest_fault.rs
@@ -41,6 +41,19 @@ pub fn mock_traps_module() -> Arc<dyn Module> {
         }
     }
 
+    extern "C" fn hit_sigstack_guard_page(vmctx: *mut lucet_vmctx) -> () {
+        extern "C" {
+            fn lucet_vmctx_get_globals(vmctx: *mut lucet_vmctx) -> *mut u8;
+        }
+
+        unsafe {
+            let globals_base = lucet_vmctx_get_globals(vmctx);
+
+            // Using the default limits, the globals are a page; try to write just off the end
+            *globals_base.offset(0x1000) = 0;
+        }
+    }
+
     extern "C" fn recoverable_fatal(_vmctx: *mut lucet_vmctx) -> () {
         use std::os::raw::c_char;
         extern "C" {
@@ -112,6 +125,10 @@ pub fn mock_traps_module() -> Arc<dyn Module> {
         .with_export_func(MockExportBuilder::new(
             "fatal",
             FunctionPointer::from_usize(fatal as usize),
+        ))
+        .with_export_func(MockExportBuilder::new(
+            "hit_sigstack_guard_page",
+            FunctionPointer::from_usize(hit_sigstack_guard_page as usize),
         ))
         .with_export_func(MockExportBuilder::new(
             "recoverable_fatal",
@@ -596,6 +613,43 @@ macro_rules! guest_fault_tests {
                         // cause the entire process to abort before returning from `run`
                         inst.set_fatal_handler(handler);
                         inst.run("fatal", &[]).expect("instance runs");
+                        // Show that we never get here:
+                        std::process::exit(1);
+                    }
+                    ForkResult::Parent { child } => {
+                        match waitpid(Some(child), None).expect("can wait on child") {
+                            WaitStatus::Signaled(_, sig, _) => {
+                                assert_eq!(sig, Signal::SIGABRT);
+                            }
+                            ws => panic!("unexpected wait status: {:?}", ws),
+                        }
+                    }
+                }
+            })
+        }
+
+        #[test]
+        fn hit_sigstack_guard_page() {
+            lucet_internal_ensure_linked();
+            fn handler(_inst: &Instance) -> ! {
+                std::process::abort()
+            }
+            test_ex(|| {
+                let module = mock_traps_module();
+                let region =
+                    TestRegion::create(1, &Limits::default()).expect("region can be created");
+                let mut inst = region
+                    .new_instance(module)
+                    .expect("instance can be created");
+
+                match fork().expect("can fork") {
+                    ForkResult::Child => {
+                        // Child code should run code that will hit the signal stack's guard
+                        // page. This will cause the entire process to abort before returning from
+                        // `run`
+                        inst.set_fatal_handler(handler);
+                        inst.run("hit_sigstack_guard_page", &[])
+                            .expect("instance runs");
                         // Show that we never get here:
                         std::process::exit(1);
                     }

--- a/lucet-runtime/tests/c_api.c
+++ b/lucet-runtime/tests/c_api.c
@@ -11,6 +11,7 @@ bool lucet_runtime_test_expand_heap(struct lucet_dl_module *mod)
         .heap_address_space_size = 8 * 1024 * 1024,
         .stack_size              = 64 * 1024,
         .globals_size            = 4096,
+        .signal_stack_size       = 12 * 1024,
     };
 
     enum lucet_error err;
@@ -97,6 +98,7 @@ bool lucet_runtime_test_yield_resume(struct lucet_dl_module *mod)
         .heap_address_space_size = 8 * 1024 * 1024,
         .stack_size              = 64 * 1024,
         .globals_size            = 4096,
+        .signal_stack_size       = 12 * 1024,
     };
 
     enum lucet_error err;

--- a/lucet-spectest/Cargo.toml
+++ b/lucet-spectest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-spectest"
-version = "0.5.0"
+version = "0.5.1"
 description = "Test harness to run WebAssembly spec tests (.wast) against the Lucet toolchain"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -17,10 +17,9 @@ name = "spec-test"
 path = "src/main.rs"
 
 [dependencies]
-anyhow = "1"
-lucetc = { path = "../lucetc", version = "=0.5.0" }
-lucet-module = { path = "../lucet-module", version = "=0.5.0" }
-lucet-runtime = { path = "../lucet-runtime", version = "=0.5.0" }
+lucetc = { path = "../lucetc", version = "=0.5.1" }
+lucet-module = { path = "../lucet-module", version = "=0.5.1" }
+lucet-runtime = { path = "../lucet-runtime", version = "=0.5.1" }
 wabt = "0.9.2"
 serde = "1.0"
 serde_json = "1.0"

--- a/lucet-validate/Cargo.toml
+++ b/lucet-validate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-validate"
-version = "0.5.0"
+version = "0.5.1"
 description = "Parse and validate webassembly files against witx interface"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -24,7 +24,7 @@ thiserror = "1.0.4"
 wasmparser = "0.39.1"
 
 [dev-dependencies]
-lucet-wasi-sdk = { path = "../lucet-wasi-sdk", version = "=0.5.0" }
+lucet-wasi-sdk = { path = "../lucet-wasi-sdk", version = "=0.5.1" }
 tempfile = "3.0"
 wabt = "0.9.2"
 

--- a/lucet-wasi-fuzz/Cargo.toml
+++ b/lucet-wasi-fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-wasi-fuzz"
-version = "0.5.0"
+version = "0.5.1"
 description = "Test the Lucet toolchain against native code execution using Csmith"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"

--- a/lucet-wasi-sdk/Cargo.toml
+++ b/lucet-wasi-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-wasi-sdk"
-version = "0.5.0"
+version = "0.5.1"
 description = "A Rust interface to the wasi-sdk compiler and linker"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -10,12 +10,13 @@ authors = ["Lucet team <lucet@fastly.com>"]
 edition = "2018"
 
 [dependencies]
-anyhow = "1"
-lucetc = { path = "../lucetc", version = "=0.5.0" }
-lucet-module = { path = "../lucet-module", version = "=0.5.0" }
-target-lexicon = "0.9"
+failure = "0.1"
+lucetc = { path = "../lucetc", version = "=0.5.1" }
+lucet-module = { path = "../lucet-module", version = "=0.5.1" }
 tempfile = "3.0"
 thiserror = "1.0.4"
 
 [dev-dependencies]
-lucet-validate = { path = "../lucet-validate", version  = "=0.5.0" }
+anyhow = "1"
+lucet-validate = { path = "../lucet-validate", version  = "=0.5.1" }
+target-lexicon = "0.9"

--- a/lucet-wasi/Cargo.toml
+++ b/lucet-wasi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-wasi"
-version = "0.5.0"
+version = "0.5.1"
 description = "Fastly's runtime for the WebAssembly System Interface (WASI)"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -28,17 +28,17 @@ anyhow = "1"
 cast = "0.2"
 clap = "2.23"
 human-size = "0.4"
-lucet-runtime = { path = "../lucet-runtime", version = "=0.5.0" }
-lucet-runtime-internals = { path = "../lucet-runtime/lucet-runtime-internals", version = "=0.5.0" }
-lucet-module = { path = "../lucet-module", version = "=0.5.0" }
+lucet-runtime = { path = "../lucet-runtime", version = "=0.5.1" }
+lucet-runtime-internals = { path = "../lucet-runtime/lucet-runtime-internals", version = "=0.5.1" }
+lucet-module = { path = "../lucet-module", version = "=0.5.1" }
 libc = "0.2.65"
 nix = "0.15"
 rand = "0.6"
 wasi-common = "0.7"
 
 [dev-dependencies]
-lucet-wasi-sdk = { path = "../lucet-wasi-sdk", version = "=0.5.0" }
-lucetc = { path = "../lucetc", version = "=0.5.0" }
+lucet-wasi-sdk = { path = "../lucet-wasi-sdk", version = "=0.5.1" }
+lucetc = { path = "../lucetc", version = "=0.5.1" }
 tempfile = "3.0"
 
 [build-dependencies]

--- a/lucet-wasi/src/main.rs
+++ b/lucet-wasi/src/main.rs
@@ -178,6 +178,7 @@ fn main() {
         heap_address_space_size,
         stack_size,
         globals_size: 0, // calculated from module
+        ..Limits::default()
     };
 
     let guest_args = matches

--- a/lucetc/Cargo.toml
+++ b/lucetc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucetc"
-version = "0.5.0"
+version = "0.5.1"
 description = "Fastly's WebAssembly to native code compiler"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -24,8 +24,8 @@ cranelift-module = { path = "../cranelift/cranelift-module", version = "0.51.0" 
 cranelift-faerie = { path = "../cranelift/cranelift-faerie", version = "0.51.0" }
 cranelift-wasm = { path = "../cranelift/cranelift-wasm", version = "0.51.0" }
 target-lexicon = "0.9"
-lucet-module = { path = "../lucet-module", version = "=0.5.0" }
-lucet-validate = { path = "../lucet-validate", version = "=0.5.0" }
+lucet-module = { path = "../lucet-module", version = "=0.5.1" }
+lucet-validate = { path = "../lucet-validate", version = "=0.5.1" }
 wasmparser = "0.39.1"
 clap="2.32"
 log = "0.4"


### PR DESCRIPTION
Most of this patch is actually to fix up the tests that were erroneously succeeding because of this bug. The core of the fix is here in `mmap.rs`:

```
-        let sigstack = globals + host_page_size();
+        let sigstack = globals + region.limits.globals_size + host_page_size();
```

This was causing the signal stack to begin one page after the start of the globals section, regardless of how big the globals are. This mostly wasn't causing problems because the default globals size is a page, and we _were_ still adding in a page for the guard, meaning the segments didn't actually overlap with default `Limits`. However, the guard page for the signal stack was missing, and configurations with larger globals sizes could end up overlapping the signal stack, potentially allowing guests to observe residual signal stack values.

The lack of a signal stack guard page was _also_ making it so that tests running in debug mode would succeed, even though the signal handler was overflowing its stack into the globals page. To make those tests pass with the correct memory layout, the signal stack size is now configurable and set higher by default on debug builds (`cfg(debug_assertions)`). On release mode, the stack use is fine as the problematic series of stack allocations get optimized into some straightforward copies, so we continue to use SIGSTKSZ as a default in that configuration.

Finally, I added a test that tries to write to the sigstack guard page, improved the "is this a fatal fault address?" method, and made sure that all tests run correctly in release mode.