### PR TITLE
Specify default ld_flags for Mac (darwin) OS

### DIFF
--- a/lucetc/src/lib.rs
+++ b/lucetc/src/lib.rs
@@ -411,7 +411,7 @@ fn ldflags_default(target: &Triple) -> String {
 
     match target.operating_system {
         OperatingSystem::Linux => "-shared",
-        OperatingSystem::MacOSX { .. } => {
+        OperatingSystem::MacOSX { .. } | OperatingSystem::Darwin => {
             "-dylib -dead_strip -export_dynamic -undefined dynamic_lookup"
         }
         _ => panic!(


### PR DESCRIPTION
Mac's operating system field is listed as Darwin, so default ld flags are not included