### PR TITLE
Added a flag to canonicalize_nans

### DIFF
--- a/lucet-spectest/src/script.rs
+++ b/lucet-spectest/src/script.rs
@@ -73,6 +73,7 @@ impl ScriptEnv {
             HeapSettings::default(),
             true,
             &None,
+            false,
         )
         .map_err(program_error)?;
 

--- a/lucet-wasi-sdk/tests/lucetc.rs
+++ b/lucet-wasi-sdk/tests/lucetc.rs
@@ -54,6 +54,7 @@ mod lucetc_tests {
             h,
             false,
             &Some(v),
+            false,
         )
         .expect("compile empty");
         let mdata = c.module_data().unwrap();
@@ -99,6 +100,7 @@ mod lucetc_tests {
             h,
             false,
             &Some(v),
+            false,
         )
         .expect("compile c");
         let mdata = c.module_data().unwrap();
@@ -130,6 +132,7 @@ mod lucetc_tests {
             h,
             false,
             &Some(v),
+            false,
         )
         .expect("compile d");
         let mdata = c.module_data().unwrap();
@@ -157,6 +160,7 @@ mod lucetc_tests {
             h,
             false,
             &Some(v),
+            false,
         )
         .expect("compile c & d");
         let mdata = c.module_data().unwrap();
@@ -208,6 +212,7 @@ mod lucetc_tests {
             h,
             false,
             &Some(v),
+            false,
         )
         .expect("compile empty");
         let mdata = c.module_data().unwrap();

--- a/lucetc/src/compiler.rs
+++ b/lucetc/src/compiler.rs
@@ -233,7 +233,12 @@ impl<'a> Compiler<'a> {
         }
         Ok(CraneliftFuncs::new(
             funcs,
-            Self::target_isa(self.target, self.opt_level, &self.cpu_features, self.canonicalize_nans)?,
+            Self::target_isa(
+                self.target,
+                self.opt_level,
+                &self.cpu_features,
+                self.canonicalize_nans,
+            )?,
         ))
     }
 
@@ -241,7 +246,7 @@ impl<'a> Compiler<'a> {
         target: Triple,
         opt_level: OptLevel,
         cpu_features: &CpuFeatures,
-        canonicalize_nans: bool
+        canonicalize_nans: bool,
     ) -> Result<Box<dyn TargetIsa>, Error> {
         let mut flags_builder = settings::builder();
         let isa_builder = cpu_features.isa_builder(target)?;

--- a/lucetc/src/compiler.rs
+++ b/lucetc/src/compiler.rs
@@ -55,6 +55,7 @@ pub struct Compiler<'a> {
     cpu_features: CpuFeatures,
     count_instructions: bool,
     module_translation_state: ModuleTranslationState,
+    canonicalize_nans: bool,
 }
 
 impl<'a> Compiler<'a> {
@@ -67,8 +68,9 @@ impl<'a> Compiler<'a> {
         heap_settings: HeapSettings,
         count_instructions: bool,
         validator: &Option<Validator>,
+        canonicalize_nans: bool,
     ) -> Result<Self, Error> {
-        let isa = Self::target_isa(target.clone(), opt_level, &cpu_features)?;
+        let isa = Self::target_isa(target.clone(), opt_level, &cpu_features, canonicalize_nans)?;
 
         let frontend_config = isa.frontend_config();
         let mut module_info = ModuleInfo::new(frontend_config.clone());
@@ -124,6 +126,7 @@ impl<'a> Compiler<'a> {
             count_instructions,
             module_translation_state,
             target,
+            canonicalize_nans,
         })
     }
 
@@ -230,7 +233,7 @@ impl<'a> Compiler<'a> {
         }
         Ok(CraneliftFuncs::new(
             funcs,
-            Self::target_isa(self.target, self.opt_level, &self.cpu_features)?,
+            Self::target_isa(self.target, self.opt_level, &self.cpu_features, self.canonicalize_nans)?,
         ))
     }
 
@@ -238,12 +241,16 @@ impl<'a> Compiler<'a> {
         target: Triple,
         opt_level: OptLevel,
         cpu_features: &CpuFeatures,
+        canonicalize_nans: bool
     ) -> Result<Box<dyn TargetIsa>, Error> {
         let mut flags_builder = settings::builder();
         let isa_builder = cpu_features.isa_builder(target)?;
         flags_builder.enable("enable_verifier").unwrap();
         flags_builder.enable("is_pic").unwrap();
         flags_builder.set("opt_level", opt_level.to_flag()).unwrap();
+        if canonicalize_nans {
+            flags_builder.enable("enable_nan_canonicalization").unwrap();
+        }
         Ok(isa_builder.finish(settings::Flags::new(flags_builder)))
     }
 }

--- a/lucetc/src/lib.rs
+++ b/lucetc/src/lib.rs
@@ -55,6 +55,7 @@ pub struct Lucetc {
     sign: bool,
     verify: bool,
     count_instructions: bool,
+    canonicalize_nans: bool,
 }
 
 pub trait AsLucetc {
@@ -273,6 +274,7 @@ impl Lucetc {
             sign: false,
             verify: false,
             count_instructions: false,
+            canonicalize_nans: false,
         }
     }
 
@@ -292,6 +294,7 @@ impl Lucetc {
             sign: false,
             verify: false,
             count_instructions: false,
+            canonicalize_nans: false,
         })
     }
 
@@ -335,6 +338,7 @@ impl Lucetc {
             self.heap.clone(),
             self.count_instructions,
             &self.validator,
+            self.canonicalize_nans
         )?;
         let obj = compiler.object_file()?;
         obj.write(output.as_ref())?;
@@ -354,6 +358,7 @@ impl Lucetc {
             self.heap.clone(),
             self.count_instructions,
             &self.validator,
+            self.canonicalize_nans,
         )?;
 
         compiler.cranelift_funcs()?.write(&output)?;

--- a/lucetc/src/lib.rs
+++ b/lucetc/src/lib.rs
@@ -338,7 +338,7 @@ impl Lucetc {
             self.heap.clone(),
             self.count_instructions,
             &self.validator,
-            self.canonicalize_nans
+            self.canonicalize_nans,
         )?;
         let obj = compiler.object_file()?;
         obj.write(output.as_ref())?;

--- a/lucetc/tests/wasm.rs
+++ b/lucetc/tests/wasm.rs
@@ -57,6 +57,7 @@ mod module_data {
             h,
             false,
             &None,
+            false,
         )
         .expect("compiling exported_import");
         let mdata = c.module_data().unwrap();
@@ -86,6 +87,7 @@ mod module_data {
             h,
             false,
             &None,
+            false,
         )
         .expect("compiling multiple_import");
         let mdata = c.module_data().unwrap();
@@ -111,6 +113,7 @@ mod module_data {
             h,
             false,
             &None,
+            false,
         )
         .expect("compiling globals_export");
         let mdata = c.module_data().unwrap();
@@ -137,6 +140,7 @@ mod module_data {
             h,
             false,
             &None,
+            false,
         )
         .expect("compiling fibonacci");
         let mdata = c.module_data().unwrap();
@@ -161,6 +165,7 @@ mod module_data {
             h,
             false,
             &None,
+            false,
         )
         .expect("compiling arith");
         let mdata = c.module_data().unwrap();
@@ -188,6 +193,7 @@ mod module_data {
             h,
             false,
             &None,
+            false,
         )
         .expect("compile duplicate_imports");
         let mdata = c.module_data().unwrap();
@@ -224,6 +230,7 @@ mod module_data {
             h,
             false,
             &None,
+            false,
         )
         .expect("compile icall");
         let mdata = c.module_data().unwrap();
@@ -270,6 +277,7 @@ mod module_data {
             h,
             false,
             &None,
+            false,
         )
         .expect("compile icall");
         let _module_data = c.module_data().unwrap();
@@ -305,6 +313,7 @@ mod module_data {
             h,
             false,
             &None,
+            false,
         )
         .expect("compile icall_sparse");
         let _module_data = c.module_data().unwrap();
@@ -354,6 +363,7 @@ mod module_data {
             h,
             false,
             &None,
+            false,
         )
         .expect("compile globals_import");
         let module_data = c.module_data().unwrap();
@@ -385,6 +395,7 @@ mod module_data {
             h.clone(),
             false,
             &None,
+            false,
         )
         .expect("compiling heap_spec_import");
 
@@ -417,6 +428,7 @@ mod module_data {
             h.clone(),
             false,
             &None,
+            false,
         )
         .expect("compiling heap_spec_definition");
 
@@ -448,6 +460,7 @@ mod module_data {
             h,
             false,
             &None,
+            false,
         )
         .expect("compiling heap_spec_none");
         assert_eq!(c.module_data().unwrap().heap_spec(), None,);
@@ -468,6 +481,7 @@ mod module_data {
             h,
             false,
             &None,
+            false,
         );
         assert!(
             c.is_err(),
@@ -505,6 +519,7 @@ mod module_data {
             h,
             false,
             &None,
+            false,
         );
         assert!(
             c.is_err(),
@@ -531,6 +546,7 @@ mod module_data {
             h,
             false,
             &None,
+            false,
         )
         .expect("compile start_section");
         /*
@@ -555,6 +571,7 @@ mod module_data {
             h,
             false,
             &None,
+            false,
         )
         .expect("compile names_local");
         let mdata = c.module_data().unwrap();
@@ -587,6 +604,7 @@ mod compile {
             h,
             false,
             &None,
+            false,
         )
         .expect(&format!("compile {}", file));
         let _obj = c.object_file().expect(&format!("codegen {}", file));
@@ -647,6 +665,7 @@ mod validate {
             h,
             false,
             &Some(v),
+            false,
         )
         .expect("compile");
         let _obj = c.object_file().expect("codegen");
@@ -675,6 +694,7 @@ mod validate {
             h,
             false,
             &Some(v),
+            false,
         )
         .expect("compile");
         let _obj = c.object_file().expect("codegen");
@@ -705,6 +725,7 @@ mod validate {
             h,
             false,
             &Some(v),
+            false,
         )
         .expect("compile");
         let _obj = c.object_file().expect("codegen");
@@ -733,6 +754,7 @@ mod validate {
             h,
             false,
             &Some(v),
+            false,
         )
         .expect("compile");
         let _obj = c.object_file().expect("codegen");
@@ -761,6 +783,7 @@ mod validate {
             h,
             false,
             &Some(v),
+            false,
         )
         .expect("compile");
         let _obj = c.object_file().expect("codegen");
@@ -791,6 +814,7 @@ mod validate {
             h,
             false,
             &Some(v),
+            false,
         )
         .expect("compile");
         let _obj = c.object_file().expect("codegen");
@@ -816,6 +840,7 @@ mod validate {
             h,
             false,
             &Some(v),
+            false,
         )
         .expect("compile");
         let _obj = c.object_file().expect("codegen");


### PR DESCRIPTION
I'd like to be able to run Lucet deterministically across machines and to do this I need canonicalized NaNs. I couldn't see a good existing data structure that was an argument for this constructor that this would slot in to, but I'm very open to suggestions! 9 arguments might be too many.