### PR TITLE
Add methods to get the number of used/free slots from a region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Unreleased
 
+- Added `free_slots()`, `used_slots()`, and `capacity()` methods to the `Region` trait.
+
 ### 0.5.1 (2020-01-24)
 
 - Fixed a memory corruption bug that could arise in certain runtime

--- a/lucet-runtime/lucet-runtime-internals/src/alloc/tests.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/alloc/tests.rs
@@ -684,6 +684,35 @@ macro_rules! alloc_tests {
             drop(region);
             drop(inst);
         }
+
+        #[test]
+        fn slot_counts_work() {
+            let module = MockModuleBuilder::new()
+                .with_heap_spec(ONE_PAGE_HEAP)
+                .build();
+            let region = TestRegion::create(2, &LIMITS).expect("region created");
+            assert_eq!(region.capacity(), 2);
+            assert_eq!(region.free_slots(), 2);
+            assert_eq!(region.used_slots(), 0);
+            let inst1 = region
+                .new_instance(module.clone())
+                .expect("new_instance succeeds");
+            assert_eq!(region.capacity(), 2);
+            assert_eq!(region.free_slots(), 1);
+            assert_eq!(region.used_slots(), 1);
+            let inst2 = region.new_instance(module).expect("new_instance succeeds");
+            assert_eq!(region.capacity(), 2);
+            assert_eq!(region.free_slots(), 0);
+            assert_eq!(region.used_slots(), 2);
+            drop(inst1);
+            assert_eq!(region.capacity(), 2);
+            assert_eq!(region.free_slots(), 1);
+            assert_eq!(region.used_slots(), 1);
+            drop(inst2);
+            assert_eq!(region.capacity(), 2);
+            assert_eq!(region.free_slots(), 2);
+            assert_eq!(region.used_slots(), 0);
+        }
     };
 }
 

--- a/lucet-runtime/lucet-runtime-internals/src/region.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/region.rs
@@ -32,6 +32,23 @@ pub trait Region: RegionInternal {
     fn new_instance_builder<'a>(&'a self, module: Arc<dyn Module>) -> InstanceBuilder<'a> {
         InstanceBuilder::new(self.as_dyn_internal(), module)
     }
+
+    /// Return the number of instance slots that are currently free in the region.
+    ///
+    /// A value greater than zero does not guarantee that a subsequent call to
+    /// `Region::new_instance()` will succeed, as other threads may instantiate from the region in
+    /// the meantime.
+    fn free_slots(&self) -> usize;
+
+    /// Return the number of instance slots that are currently in use in the region.
+    ///
+    /// A value less than `self.capacity()` does not guarantee that a subsequent call to
+    /// `Region::new_instance()` will succeed, as other threads may instantiate from the region in
+    /// the meantime.
+    fn used_slots(&self) -> usize;
+
+    /// Return the total instance slot capacity of the region.
+    fn capacity(&self) -> usize;
 }
 
 /// A `RegionInternal` is a collection of `Slot`s which are managed as a whole.


### PR DESCRIPTION
These are not a substitute for checking for not-enough-slots errors when instantiating, but can be useful hints to embedders managing multiple regions.