### PR TITLE
Lucetc: fix macOS detection

### DIFF
--- a/lucetc/src/lib.rs
+++ b/lucetc/src/lib.rs
@@ -416,7 +416,7 @@ fn ldflags_default(target: &Triple) -> String {
 
     match target.operating_system {
         OperatingSystem::Linux => "-shared",
-        OperatingSystem::MacOSX { .. } => {
+        OperatingSystem::Darwin | OperatingSystem::MacOSX { .. } => {
             "-dylib -dead_strip -export_dynamic -undefined dynamic_lookup"
         }
         _ => panic!(


### PR DESCRIPTION
Lucetc uses `target-lexicon` crate to detect the host OS.

On modern Macs, `target-lexicon` reports that the host is `Darwin`,
not `MacOSX`, at least I see this on my MacBook Pro running Catalina 10.15.2.

This leads to lucetc is not being able to set `LDFLAGS` correctly.

This change solves the issue by using the same LDFLAGS on both `Darwin` and `MacOSX`.