### PR TITLE
Check sigstack size against MINSIGSTKSZ and use a larger sigstack in debug mode on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 - Added `free_slots()`, `used_slots()`, and `capacity()` methods to the `Region` trait.
 
+- Added a check to ensure the `Limits` signal stack size is at least `MINSIGSTKSZ`, and increased
+  the default signal stack size on macOS debug builds to fit this constraint.
+
 ### 0.5.1 (2020-01-24)
 
 - Fixed a memory corruption bug that could arise in certain runtime

--- a/lucet-runtime/include/lucet_types.h
+++ b/lucet-runtime/include/lucet_types.h
@@ -124,7 +124,7 @@ struct lucet_alloc_limits {
      */
     uint64_t globals_size;
     /**
-     * Size of the signal stack region in bytes.
+     * Size of the signal stack region in bytes. (minimum MINSIGSTKSZ)
      *
      * SIGSTKSZ from <signals.h> is a good default when linking against a Rust release build of
      * lucet-runtime, but 12K or more is recommended when using a Rust debug build.

--- a/lucet-runtime/lucet-runtime-internals/src/c_api.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/c_api.rs
@@ -140,15 +140,15 @@ pub struct lucet_alloc_limits {
     pub stack_size: u64,
     /// Size of the globals region in bytes; each global uses 8 bytes. (default 4K)
     pub globals_size: u64,
-    /// Size of the signal stack in bytes. (default SIGSTKSZ for Rust release builds, 12K for Rust
-    /// debug builds)
+    /// Size of the signal stack in bytes. (default SIGSTKSZ for release builds, at least 12K for
+    /// debug builds; minimum MINSIGSTKSZ)
     ///
     /// This difference is to account for the greatly increased stack size usage in the signal
     /// handler when running without optimizations.
     ///
     /// Note that debug vs. release mode is determined by `cfg(debug_assertions)`, so if you are
-    /// specifically enabling Rust debug assertions in your Cargo release builds, the default signal
-    /// stack will be larger.
+    /// specifically enabling debug assertions in your release builds, the default signal stack may
+    /// be larger.
     pub signal_stack_size: u64,
 }
 


### PR DESCRIPTION
The Mac `MINSIGSTKSZ` is 32KiB, which is much larger than Linux and was causing the hardcoded debug mode default to be too small. We now special-case for Mac, and check that the sigstack size is at least `MINSIGSTKSZ` on all platforms.

Fixes #412.