### PR TITLE
be lenient in interpreting LD

### DIFF
--- a/lucetc/src/lib.rs
+++ b/lucetc/src/lib.rs
@@ -389,7 +389,16 @@ where
     Q: AsRef<Path>,
 {
     use std::process::Command;
-    let mut cmd_ld = Command::new(env::var("LD").unwrap_or(LD_DEFAULT.into()));
+
+    // Let `LD` be something like "clang --target=... ..." for convenience.
+    let env_ld = env::var("LD").unwrap_or(LD_DEFAULT.into());
+    let mut ld_iter = env_ld.split_whitespace();
+    let ld_prog = ld_iter.next().expect("LD must not be empty");
+    let mut cmd_ld = Command::new(ld_prog);
+    for flag in ld_iter {
+        cmd_ld.arg(flag);
+    }
+
     cmd_ld.arg(objpath.as_ref());
     let env_ldflags = env::var("LDFLAGS").unwrap_or_else(|_| ldflags_default(target));
     for flag in env_ldflags.split_whitespace() {


### PR DESCRIPTION
It's often more convenient to let the compiler figure out how to invoke
the linker, but setting `env LD="$CC" ... lucetc ...` poses a problem:
`$CC` can often be `"$COMPILER --option1 --option2 ..."`, e.g. `clang
--target=$TARGET`, and the current code assumes that `LD` is a single
string specifying a program, rather than some string specifying a
program along with options.

While you could require that `LD` be strictly limited to a single
string, it seems more flexible and more in line with other build systems
to interpret `LD` as space-separated tokens, the first of which
specifies the program to invoke, and the remaining tokens specifying
arguments to be passed.