### PR TITLE
Issue #417: Retain whether or not a module was compiled with --count-instructions.

### DIFF
--- a/lucet-module/src/module_data.rs
+++ b/lucet-module/src/module_data.rs
@@ -74,7 +74,7 @@ impl ModuleFeatures {
             bmi2: false,
             lzcnt: false,
             popcnt: false,
-	    icnt: false,  // TLC Instruction Count
+            icnt: false,
             _hidden: (),
         }
     }

--- a/lucet-module/src/module_data.rs
+++ b/lucet-module/src/module_data.rs
@@ -58,6 +58,7 @@ pub struct ModuleFeatures {
     pub bmi2: bool,
     pub lzcnt: bool,
     pub popcnt: bool,
+    pub icnt: bool,
     _hidden: (),
 }
 
@@ -73,6 +74,7 @@ impl ModuleFeatures {
             bmi2: false,
             lzcnt: false,
             popcnt: false,
+	    icnt: false,  // TLC Instruction Count
             _hidden: (),
         }
     }

--- a/lucet-module/src/module_data.rs
+++ b/lucet-module/src/module_data.rs
@@ -58,7 +58,7 @@ pub struct ModuleFeatures {
     pub bmi2: bool,
     pub lzcnt: bool,
     pub popcnt: bool,
-    pub icnt: bool,
+    pub instruction_count: bool,
     _hidden: (),
 }
 
@@ -74,7 +74,7 @@ impl ModuleFeatures {
             bmi2: false,
             lzcnt: false,
             popcnt: false,
-            icnt: false,
+            instruction_count: false,
             _hidden: (),
         }
     }

--- a/lucet-runtime/lucet-runtime-internals/src/instance.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/instance.rs
@@ -730,8 +730,11 @@ impl Instance {
     }
 
     #[inline]
-    pub fn get_instruction_count(&self) -> u64 {
-        self.get_instance_implicits().instruction_count
+    pub fn get_instruction_count(&self) -> Option<u64> {
+	if self.module.is_icnt_instrumented() {
+            return Some(self.get_instance_implicits().instruction_count);
+	}
+	None
     }
 
     #[inline]

--- a/lucet-runtime/lucet-runtime-internals/src/instance.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/instance.rs
@@ -731,10 +731,10 @@ impl Instance {
 
     #[inline]
     pub fn get_instruction_count(&self) -> Option<u64> {
-	if self.module.is_icnt_instrumented() {
+        if self.module.is_icnt_instrumented() {
             return Some(self.get_instance_implicits().instruction_count);
-	}
-	None
+        }
+        None
     }
 
     #[inline]

--- a/lucet-runtime/lucet-runtime-internals/src/instance.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/instance.rs
@@ -731,7 +731,7 @@ impl Instance {
 
     #[inline]
     pub fn get_instruction_count(&self) -> Option<u64> {
-        if self.module.is_icnt_instrumented() {
+        if self.module.is_instruction_count_instrumented() {
             return Some(self.get_instance_implicits().instruction_count);
         }
         None

--- a/lucet-runtime/lucet-runtime-internals/src/module.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/module.rs
@@ -41,7 +41,7 @@ pub trait ModuleInternal: Send + Sync {
     /// Determine whether this module has been instrumented with additional
     /// instructions that monitor the number of wasm operations executed
     /// during runtime.
-    fn is_icnt_instrumented(&self) -> bool;
+    fn is_instruction_count_instrumented(&self) -> bool;
 
     fn heap_spec(&self) -> Option<&HeapSpec>;
 

--- a/lucet-runtime/lucet-runtime-internals/src/module.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/module.rs
@@ -38,6 +38,11 @@ pub trait Module: ModuleInternal {
 }
 
 pub trait ModuleInternal: Send + Sync {
+    /// Determine whether this module has been instrumented with additional
+    /// instructions that monitor the number of wasm operations executed
+    /// during runtime.
+    fn is_icnt_instrumented(&self) -> bool;
+    
     fn heap_spec(&self) -> Option<&HeapSpec>;
 
     /// Get the WebAssembly globals of the module.

--- a/lucet-runtime/lucet-runtime-internals/src/module.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/module.rs
@@ -42,7 +42,7 @@ pub trait ModuleInternal: Send + Sync {
     /// instructions that monitor the number of wasm operations executed
     /// during runtime.
     fn is_icnt_instrumented(&self) -> bool;
-    
+
     fn heap_spec(&self) -> Option<&HeapSpec>;
 
     /// Get the WebAssembly globals of the module.

--- a/lucet-runtime/lucet-runtime-internals/src/module/dl.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/module/dl.rs
@@ -68,6 +68,16 @@ fn check_feature_support(module_features: &ModuleFeatures) -> Result<(), Error> 
         return Err(missing_feature("LZCNT"));
     }
 
+    // Given the module features, check the xxx to affirm
+    // whether or not
+    // We'd like to ask the question, does this module have
+    // instruction count?
+/*
+    if module_features.icnt {
+        return Err(missing_feature("ICNT"));
+    }
+*/
+    
     // Features are fine, we're compatible!
     Ok(())
 }
@@ -203,6 +213,10 @@ impl DlModule {
 impl Module for DlModule {}
 
 impl ModuleInternal for DlModule {
+    fn is_icnt_instrumented(&self) -> bool {
+	self.module.module_data.features().icnt
+    }
+	
     fn heap_spec(&self) -> Option<&HeapSpec> {
         self.module.module_data.heap_spec()
     }

--- a/lucet-runtime/lucet-runtime-internals/src/module/dl.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/module/dl.rs
@@ -203,8 +203,8 @@ impl DlModule {
 impl Module for DlModule {}
 
 impl ModuleInternal for DlModule {
-    fn is_icnt_instrumented(&self) -> bool {
-        self.module.module_data.features().icnt
+    fn is_instruction_count_instrumented(&self) -> bool {
+        self.module.module_data.features().instruction_count
     }
 
     fn heap_spec(&self) -> Option<&HeapSpec> {

--- a/lucet-runtime/lucet-runtime-internals/src/module/dl.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/module/dl.rs
@@ -68,16 +68,6 @@ fn check_feature_support(module_features: &ModuleFeatures) -> Result<(), Error> 
         return Err(missing_feature("LZCNT"));
     }
 
-    // Given the module features, check the xxx to affirm
-    // whether or not
-    // We'd like to ask the question, does this module have
-    // instruction count?
-/*
-    if module_features.icnt {
-        return Err(missing_feature("ICNT"));
-    }
-*/
-    
     // Features are fine, we're compatible!
     Ok(())
 }
@@ -214,9 +204,9 @@ impl Module for DlModule {}
 
 impl ModuleInternal for DlModule {
     fn is_icnt_instrumented(&self) -> bool {
-	self.module.module_data.features().icnt
+        self.module.module_data.features().icnt
     }
-	
+
     fn heap_spec(&self) -> Option<&HeapSpec> {
         self.module.module_data.heap_spec()
     }

--- a/lucet-runtime/lucet-runtime-internals/src/module/mock.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/module/mock.rs
@@ -261,7 +261,7 @@ impl Module for MockModule {}
 
 impl ModuleInternal for MockModule {
     fn is_icnt_instrumented(&self) -> bool {
-	self.module_data.features().icnt
+        self.module_data.features().icnt
     }
 
     fn heap_spec(&self) -> Option<&HeapSpec> {

--- a/lucet-runtime/lucet-runtime-internals/src/module/mock.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/module/mock.rs
@@ -260,8 +260,8 @@ unsafe impl Sync for MockModule {}
 impl Module for MockModule {}
 
 impl ModuleInternal for MockModule {
-    fn is_icnt_instrumented(&self) -> bool {
-        self.module_data.features().icnt
+    fn is_instruction_count_instrumented(&self) -> bool {
+        self.module_data.features().instruction_count
     }
 
     fn heap_spec(&self) -> Option<&HeapSpec> {

--- a/lucet-runtime/lucet-runtime-internals/src/module/mock.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/module/mock.rs
@@ -260,6 +260,10 @@ unsafe impl Sync for MockModule {}
 impl Module for MockModule {}
 
 impl ModuleInternal for MockModule {
+    fn is_icnt_instrumented(&self) -> bool {
+	self.module_data.features().icnt
+    }
+
     fn heap_spec(&self) -> Option<&HeapSpec> {
         self.module_data.heap_spec()
     }

--- a/lucet-runtime/tests/instruction_counting.rs
+++ b/lucet-runtime/tests/instruction_counting.rs
@@ -7,10 +7,10 @@ use std::path::Path;
 use std::sync::Arc;
 use tempfile::TempDir;
 
-pub fn wasm_test<P: AsRef<Path>>(wasm_file: P, icnt_option: bool) -> Result<Arc<DlModule>, Error> {
+pub fn wasm_test<P: AsRef<Path>>(wasm_file: P, icount_option: bool) -> Result<Arc<DlModule>, Error> {
     let workdir = TempDir::new().expect("create working directory");
 
-    let native_build = Lucetc::new(wasm_file).with_count_instructions(icnt_option);
+    let native_build = Lucetc::new(wasm_file).with_count_instructions(icount_option);
 
     let so_file = workdir.path().join("out.so");
 
@@ -21,7 +21,7 @@ pub fn wasm_test<P: AsRef<Path>>(wasm_file: P, icnt_option: bool) -> Result<Arc<
     Ok(dlmodule)
 }
 
-pub fn get_icnt_test_files() -> Vec<DirEntry> {
+pub fn get_instruction_count_test_files() -> Vec<DirEntry> {
     std::fs::read_dir("./tests/instruction_counting")
         .expect("can iterate test files")
         .map(|ent| {
@@ -36,8 +36,8 @@ pub fn get_icnt_test_files() -> Vec<DirEntry> {
 }
 
 #[test]
-pub fn check_icnt_off() {
-    let files: Vec<DirEntry> = get_icnt_test_files();
+pub fn check_instruction_count_off() {
+    let files: Vec<DirEntry> = get_instruction_count_test_files();
 
     assert!(
         files.len() > 0,
@@ -46,7 +46,8 @@ pub fn check_icnt_off() {
 
     files.par_iter().for_each(|ent| {
         let wasm_path = ent.path();
-        let module = wasm_test(&wasm_path, false).expect("can load module");
+	let do_not_instrument = false;
+        let module = wasm_test(&wasm_path, do_not_instrument).expect("can load module");
 
         let region = MmapRegion::create(1, &Limits::default()).expect("region can be created");
 
@@ -64,8 +65,8 @@ pub fn check_icnt_off() {
 }
 
 #[test]
-pub fn check_icnt() {
-    let files: Vec<DirEntry> = get_icnt_test_files();
+pub fn check_instruction_count() {
+    let files: Vec<DirEntry> = get_instruction_count_test_files();
 
     assert!(
         files.len() > 0,
@@ -74,7 +75,8 @@ pub fn check_icnt() {
 
     files.par_iter().for_each(|ent| {
         let wasm_path = ent.path();
-        let module = wasm_test(&wasm_path, true).expect("can load instrumented module");
+	let do_instrument = true;
+        let module = wasm_test(&wasm_path, do_instrument).expect("can load instrumented module");
 
         let region = MmapRegion::create(1, &Limits::default()).expect("region can be created");
 

--- a/lucet-runtime/tests/instruction_counting.rs
+++ b/lucet-runtime/tests/instruction_counting.rs
@@ -38,7 +38,7 @@ pub fn get_icnt_test_files() -> Vec<DirEntry> {
 #[test]
 pub fn check_icnt_off() {
     let files: Vec<DirEntry> = get_icnt_test_files();
-    
+
     assert!(
         files.len() > 0,
         "there are no test cases in the `instruction_counting` directory"
@@ -47,35 +47,7 @@ pub fn check_icnt_off() {
     files.par_iter().for_each(|ent| {
         let wasm_path = ent.path();
         let module = wasm_test(&wasm_path, false).expect("can load module");
-	
-        let region = MmapRegion::create(1, &Limits::default()).expect("region can be created");
 
-        let mut inst = region
-            .new_instance(module)
-            .expect("instance can be created");
-
-	inst.run("test_function", &[]).expect("instance runs");
-
-        let instruction_count = inst.get_instruction_count();
-	if let Some(_) = instruction_count {
-	    panic!("instruction count instrumentation was not expected from instance");
-	}
-    });
-}
-
-#[test]
-pub fn check_icnt() {
-    let files: Vec<DirEntry> = get_icnt_test_files();
-    
-    assert!(
-        files.len() > 0,
-        "there are no test cases in the `instruction_counting` directory"
-    );
-
-    files.par_iter().for_each(|ent| {
-        let wasm_path = ent.path();
-        let module = wasm_test(&wasm_path, true).expect("can load instrumented module");
-	
         let region = MmapRegion::create(1, &Limits::default()).expect("region can be created");
 
         let mut inst = region
@@ -85,9 +57,37 @@ pub fn check_icnt() {
         inst.run("test_function", &[]).expect("instance runs");
 
         let instruction_count = inst.get_instruction_count();
-	if let None = instruction_count {
-	    panic!("instruction count expected from instance");
-	}
+        if let Some(_) = instruction_count {
+            panic!("instruction count instrumentation was not expected from instance");
+        }
+    });
+}
+
+#[test]
+pub fn check_icnt() {
+    let files: Vec<DirEntry> = get_icnt_test_files();
+
+    assert!(
+        files.len() > 0,
+        "there are no test cases in the `instruction_counting` directory"
+    );
+
+    files.par_iter().for_each(|ent| {
+        let wasm_path = ent.path();
+        let module = wasm_test(&wasm_path, true).expect("can load instrumented module");
+
+        let region = MmapRegion::create(1, &Limits::default()).expect("region can be created");
+
+        let mut inst = region
+            .new_instance(module)
+            .expect("instance can be created");
+
+        inst.run("test_function", &[]).expect("instance runs");
+
+        let instruction_count = inst.get_instruction_count();
+        if let None = instruction_count {
+            panic!("instruction count expected from instance");
+        }
 
         assert_eq!(
             instruction_count.unwrap(),

--- a/lucet-runtime/tests/instruction_counting.rs
+++ b/lucet-runtime/tests/instruction_counting.rs
@@ -19,7 +19,7 @@ pub fn wasm_test<P: AsRef<Path>>(wasm_file: P, icnt_option: bool) -> Result<Arc<
     let dlmodule = DlModule::load(so_file)?;
 
     Ok(dlmodule)
-}    
+}
 
 pub fn get_icnt_test_files() -> Vec<DirEntry> {
     std::fs::read_dir("./tests/instruction_counting")

--- a/lucet-runtime/tests/instruction_counting.rs
+++ b/lucet-runtime/tests/instruction_counting.rs
@@ -7,7 +7,10 @@ use std::path::Path;
 use std::sync::Arc;
 use tempfile::TempDir;
 
-pub fn wasm_test<P: AsRef<Path>>(wasm_file: P, icount_option: bool) -> Result<Arc<DlModule>, Error> {
+pub fn wasm_test<P: AsRef<Path>>(
+    wasm_file: P,
+    icount_option: bool,
+) -> Result<Arc<DlModule>, Error> {
     let workdir = TempDir::new().expect("create working directory");
 
     let native_build = Lucetc::new(wasm_file).with_count_instructions(icount_option);
@@ -46,7 +49,7 @@ pub fn check_instruction_count_off() {
 
     files.par_iter().for_each(|ent| {
         let wasm_path = ent.path();
-	let do_not_instrument = false;
+        let do_not_instrument = false;
         let module = wasm_test(&wasm_path, do_not_instrument).expect("can load module");
 
         let region = MmapRegion::create(1, &Limits::default()).expect("region can be created");
@@ -75,7 +78,7 @@ pub fn check_instruction_count() {
 
     files.par_iter().for_each(|ent| {
         let wasm_path = ent.path();
-	let do_instrument = true;
+        let do_instrument = true;
         let module = wasm_test(&wasm_path, do_instrument).expect("can load instrumented module");
 
         let region = MmapRegion::create(1, &Limits::default()).expect("region can be created");

--- a/lucet-runtime/tests/instruction_counting.rs
+++ b/lucet-runtime/tests/instruction_counting.rs
@@ -61,7 +61,7 @@ pub fn check_instruction_count_off() {
         inst.run("test_function", &[]).expect("instance runs");
 
         let instruction_count = inst.get_instruction_count();
-        if let Some(_) = instruction_count {
+        if instruction_count.is_some() {
             panic!("instruction count instrumentation was not expected from instance");
         }
     });
@@ -89,13 +89,12 @@ pub fn check_instruction_count() {
 
         inst.run("test_function", &[]).expect("instance runs");
 
-        let instruction_count = inst.get_instruction_count();
-        if let None = instruction_count {
-            panic!("instruction count expected from instance");
-        }
+        let instruction_count = inst
+            .get_instruction_count()
+            .expect("instruction count expected from instance");
 
         assert_eq!(
-            instruction_count.unwrap(),
+            instruction_count,
             match inst
                 .run("instruction_count", &[])
                 .expect("instance still runs")

--- a/lucetc/src/compiler.rs
+++ b/lucetc/src/compiler.rs
@@ -132,7 +132,9 @@ impl<'a> Compiler<'a> {
 
     pub fn module_features(&self) -> ModuleFeatures {
         // This will grow in the future to encompass other options describing the compiled module.
-        (&self.cpu_features).into()
+        let mut mf: ModuleFeatures = (&self.cpu_features).into();
+	mf.icnt = self.count_instructions;
+	mf
     }
 
     pub fn module_data(&self) -> Result<ModuleData<'_>, Error> {

--- a/lucetc/src/compiler.rs
+++ b/lucetc/src/compiler.rs
@@ -132,8 +132,8 @@ impl<'a> Compiler<'a> {
 
     pub fn module_features(&self) -> ModuleFeatures {
         let mut mf: ModuleFeatures = (&self.cpu_features).into();
-	mf.icnt = self.count_instructions;
-	mf
+        mf.icnt = self.count_instructions;
+        mf
     }
 
     pub fn module_data(&self) -> Result<ModuleData<'_>, Error> {

--- a/lucetc/src/compiler.rs
+++ b/lucetc/src/compiler.rs
@@ -131,7 +131,6 @@ impl<'a> Compiler<'a> {
     }
 
     pub fn module_features(&self) -> ModuleFeatures {
-        // This will grow in the future to encompass other options describing the compiled module.
         let mut mf: ModuleFeatures = (&self.cpu_features).into();
 	mf.icnt = self.count_instructions;
 	mf

--- a/lucetc/src/compiler.rs
+++ b/lucetc/src/compiler.rs
@@ -132,7 +132,7 @@ impl<'a> Compiler<'a> {
 
     pub fn module_features(&self) -> ModuleFeatures {
         let mut mf: ModuleFeatures = (&self.cpu_features).into();
-        mf.icnt = self.count_instructions;
+        mf.instruction_count = self.count_instructions;
         mf
     }
 


### PR DESCRIPTION
This PR uses the `--count-instructions` option to set a new field in ModuleFeatures called `icnt`.  

**Notes:**
Leveraging the new field, the lucet-runtime call `get_instruction_count()` now returns an Option<u64>.  If the module was compiled with `--count-instructions`, the function returns the instruction count.  Otherwise, it returns None.

An extended set of tests affirm that get_instruction_count() appropriately returns Some(_) or None.

**See original issue at:**
https://github.com/bytecodealliance/lucet/issues/417

Fixes #417 