### PR TITLE
0.6.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 ### Unreleased
+### 0.6.1 (2020-02-14)
+
+- Modules record if instruction count instrumentation is present
+
+- The `LD` environment variable now takes a space-separated set of tokens the first of which
+  specifies the program to invoke, and the remaining tokens specifying arguments to be passed
+
+- LucetOpt now supports canonicalize_nans flag
 
 ### 0.6.0 (2020-02-05)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -773,15 +773,15 @@ dependencies = [
 
 [[package]]
 name = "lucet-benchmarks"
-version = "0.6.1"
+version = "0.6.2-dev"
 dependencies = [
  "criterion 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.6.1",
- "lucet-runtime 0.6.1",
- "lucet-runtime-internals 0.6.1",
- "lucet-wasi 0.6.1",
- "lucet-wasi-sdk 0.6.1",
- "lucetc 0.6.1",
+ "lucet-module 0.6.2-dev",
+ "lucet-runtime 0.6.2-dev",
+ "lucet-runtime-internals 0.6.2-dev",
+ "lucet-wasi 0.6.2-dev",
+ "lucet-wasi-sdk 0.6.2-dev",
+ "lucetc 0.6.2-dev",
  "nix 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "lucet-module"
-version = "0.6.1"
+version = "0.6.2-dev"
 dependencies = [
  "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -810,28 +810,28 @@ dependencies = [
 
 [[package]]
 name = "lucet-objdump"
-version = "0.6.1"
+version = "0.6.2-dev"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "colored 1.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "goblin 0.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.6.1",
+ "lucet-module 0.6.2-dev",
 ]
 
 [[package]]
 name = "lucet-runtime"
-version = "0.6.1"
+version = "0.6.2-dev"
 dependencies = [
  "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.6.1",
- "lucet-runtime-internals 0.6.1",
- "lucet-runtime-tests 0.6.1",
- "lucet-wasi-sdk 0.6.1",
- "lucetc 0.6.1",
+ "lucet-module 0.6.2-dev",
+ "lucet-runtime-internals 0.6.2-dev",
+ "lucet-runtime-tests 0.6.2-dev",
+ "lucet-wasi-sdk 0.6.2-dev",
+ "lucetc 0.6.2-dev",
  "nix 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -843,13 +843,13 @@ dependencies = [
 name = "lucet-runtime-example"
 version = "0.1.0"
 dependencies = [
- "lucet-runtime 0.6.1",
- "lucet-wasi 0.6.1",
+ "lucet-runtime 0.6.2-dev",
+ "lucet-wasi 0.6.2-dev",
 ]
 
 [[package]]
 name = "lucet-runtime-internals"
-version = "0.6.1"
+version = "0.6.2-dev"
 dependencies = [
  "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -860,8 +860,8 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.6.1",
- "lucet-runtime-macros 0.6.1",
+ "lucet-module 0.6.2-dev",
+ "lucet-runtime-macros 0.6.2-dev",
  "memoffset 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "lucet-runtime-macros"
-version = "0.6.1"
+version = "0.6.2-dev"
 dependencies = [
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -880,26 +880,26 @@ dependencies = [
 
 [[package]]
 name = "lucet-runtime-tests"
-version = "0.6.1"
+version = "0.6.2-dev"
 dependencies = [
  "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.6.1",
- "lucet-runtime-internals 0.6.1",
- "lucet-wasi-sdk 0.6.1",
- "lucetc 0.6.1",
+ "lucet-module 0.6.2-dev",
+ "lucet-runtime-internals 0.6.2-dev",
+ "lucet-wasi-sdk 0.6.2-dev",
+ "lucetc 0.6.2-dev",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "lucet-spectest"
-version = "0.6.1"
+version = "0.6.2-dev"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.6.1",
- "lucet-runtime 0.6.1",
- "lucetc 0.6.1",
+ "lucet-module 0.6.2-dev",
+ "lucet-runtime 0.6.2-dev",
+ "lucetc 0.6.2-dev",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "target-lexicon 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -910,11 +910,11 @@ dependencies = [
 
 [[package]]
 name = "lucet-validate"
-version = "0.6.1"
+version = "0.6.2-dev"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cranelift-entity 0.51.0",
- "lucet-wasi-sdk 0.6.1",
+ "lucet-wasi-sdk 0.6.2-dev",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "wabt 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "lucet-wasi"
-version = "0.6.1"
+version = "0.6.2-dev"
 dependencies = [
  "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "bindgen 0.51.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -932,11 +932,11 @@ dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "human-size 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.6.1",
- "lucet-runtime 0.6.1",
- "lucet-runtime-internals 0.6.1",
- "lucet-wasi-sdk 0.6.1",
- "lucetc 0.6.1",
+ "lucet-module 0.6.2-dev",
+ "lucet-runtime 0.6.2-dev",
+ "lucet-runtime-internals 0.6.2-dev",
+ "lucet-wasi-sdk 0.6.2-dev",
+ "lucetc 0.6.2-dev",
  "nix 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -945,16 +945,16 @@ dependencies = [
 
 [[package]]
 name = "lucet-wasi-fuzz"
-version = "0.6.1"
+version = "0.6.2-dev"
 dependencies = [
  "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.6.1",
- "lucet-runtime 0.6.1",
- "lucet-wasi 0.6.1",
- "lucet-wasi-sdk 0.6.1",
- "lucetc 0.6.1",
+ "lucet-module 0.6.2-dev",
+ "lucet-runtime 0.6.2-dev",
+ "lucet-wasi 0.6.2-dev",
+ "lucet-wasi-sdk 0.6.2-dev",
+ "lucetc 0.6.2-dev",
  "nix 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "progress 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -968,13 +968,13 @@ dependencies = [
 
 [[package]]
 name = "lucet-wasi-sdk"
-version = "0.6.1"
+version = "0.6.2-dev"
 dependencies = [
  "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.6.1",
- "lucet-validate 0.6.1",
- "lucetc 0.6.1",
+ "lucet-module 0.6.2-dev",
+ "lucet-validate 0.6.2-dev",
+ "lucetc 0.6.2-dev",
  "target-lexicon 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -982,7 +982,7 @@ dependencies = [
 
 [[package]]
 name = "lucetc"
-version = "0.6.1"
+version = "0.6.2-dev"
 dependencies = [
  "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "bimap 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1002,8 +1002,8 @@ dependencies = [
  "goblin 0.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "human-size 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.6.1",
- "lucet-validate 0.6.1",
+ "lucet-module 0.6.2-dev",
+ "lucet-validate 0.6.2-dev",
  "memoffset 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "minisign 0.5.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-wasm 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -773,15 +773,15 @@ dependencies = [
 
 [[package]]
 name = "lucet-benchmarks"
-version = "0.6.1-dev"
+version = "0.6.1"
 dependencies = [
  "criterion 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.6.1-dev",
- "lucet-runtime 0.6.1-dev",
- "lucet-runtime-internals 0.6.1-dev",
- "lucet-wasi 0.6.1-dev",
- "lucet-wasi-sdk 0.6.1-dev",
- "lucetc 0.6.1-dev",
+ "lucet-module 0.6.1",
+ "lucet-runtime 0.6.1",
+ "lucet-runtime-internals 0.6.1",
+ "lucet-wasi 0.6.1",
+ "lucet-wasi-sdk 0.6.1",
+ "lucetc 0.6.1",
  "nix 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "lucet-module"
-version = "0.6.1-dev"
+version = "0.6.1"
 dependencies = [
  "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -810,28 +810,28 @@ dependencies = [
 
 [[package]]
 name = "lucet-objdump"
-version = "0.6.1-dev"
+version = "0.6.1"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "colored 1.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "goblin 0.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.6.1-dev",
+ "lucet-module 0.6.1",
 ]
 
 [[package]]
 name = "lucet-runtime"
-version = "0.6.1-dev"
+version = "0.6.1"
 dependencies = [
  "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.6.1-dev",
- "lucet-runtime-internals 0.6.1-dev",
- "lucet-runtime-tests 0.6.1-dev",
- "lucet-wasi-sdk 0.6.1-dev",
- "lucetc 0.6.1-dev",
+ "lucet-module 0.6.1",
+ "lucet-runtime-internals 0.6.1",
+ "lucet-runtime-tests 0.6.1",
+ "lucet-wasi-sdk 0.6.1",
+ "lucetc 0.6.1",
  "nix 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -843,13 +843,13 @@ dependencies = [
 name = "lucet-runtime-example"
 version = "0.1.0"
 dependencies = [
- "lucet-runtime 0.6.1-dev",
- "lucet-wasi 0.6.1-dev",
+ "lucet-runtime 0.6.1",
+ "lucet-wasi 0.6.1",
 ]
 
 [[package]]
 name = "lucet-runtime-internals"
-version = "0.6.1-dev"
+version = "0.6.1"
 dependencies = [
  "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -860,8 +860,8 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.6.1-dev",
- "lucet-runtime-macros 0.6.1-dev",
+ "lucet-module 0.6.1",
+ "lucet-runtime-macros 0.6.1",
  "memoffset 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "lucet-runtime-macros"
-version = "0.6.1-dev"
+version = "0.6.1"
 dependencies = [
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -880,26 +880,26 @@ dependencies = [
 
 [[package]]
 name = "lucet-runtime-tests"
-version = "0.6.1-dev"
+version = "0.6.1"
 dependencies = [
  "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.6.1-dev",
- "lucet-runtime-internals 0.6.1-dev",
- "lucet-wasi-sdk 0.6.1-dev",
- "lucetc 0.6.1-dev",
+ "lucet-module 0.6.1",
+ "lucet-runtime-internals 0.6.1",
+ "lucet-wasi-sdk 0.6.1",
+ "lucetc 0.6.1",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "lucet-spectest"
-version = "0.6.1-dev"
+version = "0.6.1"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.6.1-dev",
- "lucet-runtime 0.6.1-dev",
- "lucetc 0.6.1-dev",
+ "lucet-module 0.6.1",
+ "lucet-runtime 0.6.1",
+ "lucetc 0.6.1",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "target-lexicon 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -910,11 +910,11 @@ dependencies = [
 
 [[package]]
 name = "lucet-validate"
-version = "0.6.1-dev"
+version = "0.6.1"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cranelift-entity 0.51.0",
- "lucet-wasi-sdk 0.6.1-dev",
+ "lucet-wasi-sdk 0.6.1",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "wabt 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "lucet-wasi"
-version = "0.6.1-dev"
+version = "0.6.1"
 dependencies = [
  "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "bindgen 0.51.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -932,11 +932,11 @@ dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "human-size 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.6.1-dev",
- "lucet-runtime 0.6.1-dev",
- "lucet-runtime-internals 0.6.1-dev",
- "lucet-wasi-sdk 0.6.1-dev",
- "lucetc 0.6.1-dev",
+ "lucet-module 0.6.1",
+ "lucet-runtime 0.6.1",
+ "lucet-runtime-internals 0.6.1",
+ "lucet-wasi-sdk 0.6.1",
+ "lucetc 0.6.1",
  "nix 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -945,16 +945,16 @@ dependencies = [
 
 [[package]]
 name = "lucet-wasi-fuzz"
-version = "0.6.1-dev"
+version = "0.6.1"
 dependencies = [
  "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.6.1-dev",
- "lucet-runtime 0.6.1-dev",
- "lucet-wasi 0.6.1-dev",
- "lucet-wasi-sdk 0.6.1-dev",
- "lucetc 0.6.1-dev",
+ "lucet-module 0.6.1",
+ "lucet-runtime 0.6.1",
+ "lucet-wasi 0.6.1",
+ "lucet-wasi-sdk 0.6.1",
+ "lucetc 0.6.1",
  "nix 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "progress 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -968,13 +968,13 @@ dependencies = [
 
 [[package]]
 name = "lucet-wasi-sdk"
-version = "0.6.1-dev"
+version = "0.6.1"
 dependencies = [
  "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.6.1-dev",
- "lucet-validate 0.6.1-dev",
- "lucetc 0.6.1-dev",
+ "lucet-module 0.6.1",
+ "lucet-validate 0.6.1",
+ "lucetc 0.6.1",
  "target-lexicon 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -982,7 +982,7 @@ dependencies = [
 
 [[package]]
 name = "lucetc"
-version = "0.6.1-dev"
+version = "0.6.1"
 dependencies = [
  "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "bimap 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1002,8 +1002,8 @@ dependencies = [
  "goblin 0.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "human-size 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "lucet-module 0.6.1-dev",
- "lucet-validate 0.6.1-dev",
+ "lucet-module 0.6.1",
+ "lucet-validate 0.6.1",
  "memoffset 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "minisign 0.5.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-wasm 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/benchmarks/lucet-benchmarks/Cargo.toml
+++ b/benchmarks/lucet-benchmarks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-benchmarks"
-version = "0.6.1"
+version = "0.6.2-dev"
 description = "Benchmarks for the Lucet runtime"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"

--- a/benchmarks/lucet-benchmarks/Cargo.toml
+++ b/benchmarks/lucet-benchmarks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-benchmarks"
-version = "0.6.1-dev"
+version = "0.6.1"
 description = "Benchmarks for the Lucet runtime"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"

--- a/lucet-module/Cargo.toml
+++ b/lucet-module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-module"
-version = "0.6.1"
+version = "0.6.2-dev"
 description = "A structured interface for Lucet modules"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"

--- a/lucet-module/Cargo.toml
+++ b/lucet-module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-module"
-version = "0.6.1-dev"
+version = "0.6.1"
 description = "A structured interface for Lucet modules"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"

--- a/lucet-objdump/Cargo.toml
+++ b/lucet-objdump/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-objdump"
-version = "0.6.1"
+version = "0.6.2-dev"
 description = "Analyze object files emitted by the Lucet compiler"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -13,7 +13,7 @@ edition = "2018"
 goblin="0.0.24"
 byteorder="1.2.1"
 colored="1.8.0"
-lucet-module = { path = "../lucet-module", version = "=0.6.1" }
+lucet-module = { path = "../lucet-module", version = "=0.6.2-dev" }
 
 [package.metadata.deb]
 name = "fst-lucet-objdump"

--- a/lucet-objdump/Cargo.toml
+++ b/lucet-objdump/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-objdump"
-version = "0.6.1-dev"
+version = "0.6.1"
 description = "Analyze object files emitted by the Lucet compiler"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -13,7 +13,7 @@ edition = "2018"
 goblin="0.0.24"
 byteorder="1.2.1"
 colored="1.8.0"
-lucet-module = { path = "../lucet-module", version = "=0.6.1-dev" }
+lucet-module = { path = "../lucet-module", version = "=0.6.1" }
 
 [package.metadata.deb]
 name = "fst-lucet-objdump"

--- a/lucet-runtime/Cargo.toml
+++ b/lucet-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-runtime"
-version = "0.6.1-dev"
+version = "0.6.1"
 description = "Pure Rust runtime for Lucet WebAssembly toolchain"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -11,17 +11,17 @@ edition = "2018"
 
 [dependencies]
 libc = "0.2.65"
-lucet-runtime-internals = { path = "lucet-runtime-internals", version = "=0.6.1-dev" }
-lucet-module = { path = "../lucet-module", version = "=0.6.1-dev" }
+lucet-runtime-internals = { path = "lucet-runtime-internals", version = "=0.6.1" }
+lucet-module = { path = "../lucet-module", version = "=0.6.1" }
 num-traits = "0.2"
 num-derive = "0.3.0"
 
 [dev-dependencies]
 byteorder = "1.2"
 lazy_static = "1.1"
-lucetc = { path = "../lucetc", version = "=0.6.1-dev" }
-lucet-runtime-tests = { path = "lucet-runtime-tests", version = "=0.6.1-dev" }
-lucet-wasi-sdk = { path = "../lucet-wasi-sdk", version = "=0.6.1-dev" }
+lucetc = { path = "../lucetc", version = "=0.6.1" }
+lucet-runtime-tests = { path = "lucet-runtime-tests", version = "=0.6.1" }
+lucet-wasi-sdk = { path = "../lucet-wasi-sdk", version = "=0.6.1" }
 nix = "0.15"
 rayon = "1.0"
 tempfile = "3.0"

--- a/lucet-runtime/Cargo.toml
+++ b/lucet-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-runtime"
-version = "0.6.1"
+version = "0.6.2-dev"
 description = "Pure Rust runtime for Lucet WebAssembly toolchain"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -11,17 +11,17 @@ edition = "2018"
 
 [dependencies]
 libc = "0.2.65"
-lucet-runtime-internals = { path = "lucet-runtime-internals", version = "=0.6.1" }
-lucet-module = { path = "../lucet-module", version = "=0.6.1" }
+lucet-runtime-internals = { path = "lucet-runtime-internals", version = "=0.6.2-dev" }
+lucet-module = { path = "../lucet-module", version = "=0.6.2-dev" }
 num-traits = "0.2"
 num-derive = "0.3.0"
 
 [dev-dependencies]
 byteorder = "1.2"
 lazy_static = "1.1"
-lucetc = { path = "../lucetc", version = "=0.6.1" }
-lucet-runtime-tests = { path = "lucet-runtime-tests", version = "=0.6.1" }
-lucet-wasi-sdk = { path = "../lucet-wasi-sdk", version = "=0.6.1" }
+lucetc = { path = "../lucetc", version = "=0.6.2-dev" }
+lucet-runtime-tests = { path = "lucet-runtime-tests", version = "=0.6.2-dev" }
+lucet-wasi-sdk = { path = "../lucet-wasi-sdk", version = "=0.6.2-dev" }
 nix = "0.15"
 rayon = "1.0"
 tempfile = "3.0"

--- a/lucet-runtime/lucet-runtime-internals/Cargo.toml
+++ b/lucet-runtime/lucet-runtime-internals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-runtime-internals"
-version = "0.6.1"
+version = "0.6.2-dev"
 description = "Pure Rust runtime for Lucet WebAssembly toolchain (internals)"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -10,8 +10,8 @@ authors = ["Lucet team <lucet@fastly.com>"]
 edition = "2018"
 
 [dependencies]
-lucet-module = { path = "../../lucet-module", version = "=0.6.1" }
-lucet-runtime-macros = { path = "../lucet-runtime-macros", version = "=0.6.1" }
+lucet-module = { path = "../../lucet-module", version = "=0.6.2-dev" }
+lucet-runtime-macros = { path = "../lucet-runtime-macros", version = "=0.6.2-dev" }
 
 anyhow = "1.0"
 bitflags = "1.0"

--- a/lucet-runtime/lucet-runtime-internals/Cargo.toml
+++ b/lucet-runtime/lucet-runtime-internals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-runtime-internals"
-version = "0.6.1-dev"
+version = "0.6.1"
 description = "Pure Rust runtime for Lucet WebAssembly toolchain (internals)"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -10,8 +10,8 @@ authors = ["Lucet team <lucet@fastly.com>"]
 edition = "2018"
 
 [dependencies]
-lucet-module = { path = "../../lucet-module", version = "=0.6.1-dev" }
-lucet-runtime-macros = { path = "../lucet-runtime-macros", version = "=0.6.1-dev" }
+lucet-module = { path = "../../lucet-module", version = "=0.6.1" }
+lucet-runtime-macros = { path = "../lucet-runtime-macros", version = "=0.6.1" }
 
 anyhow = "1.0"
 bitflags = "1.0"

--- a/lucet-runtime/lucet-runtime-macros/Cargo.toml
+++ b/lucet-runtime/lucet-runtime-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-runtime-macros"
-version = "0.6.1-dev"
+version = "0.6.1"
 description = "Macros for the Lucet WebAssembly runtime"
 homepage = "https://github.com/bytecodealliance/lucet"
 repository = "https://github.com/bytecodealliance/lucet"

--- a/lucet-runtime/lucet-runtime-macros/Cargo.toml
+++ b/lucet-runtime/lucet-runtime-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-runtime-macros"
-version = "0.6.1"
+version = "0.6.2-dev"
 description = "Macros for the Lucet WebAssembly runtime"
 homepage = "https://github.com/bytecodealliance/lucet"
 repository = "https://github.com/bytecodealliance/lucet"

--- a/lucet-runtime/lucet-runtime-tests/Cargo.toml
+++ b/lucet-runtime/lucet-runtime-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-runtime-tests"
-version = "0.6.1"
+version = "0.6.2-dev"
 description = "Pure Rust runtime for Lucet WebAssembly toolchain (tests)"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -18,10 +18,10 @@ test = false
 anyhow = "1"
 lazy_static = "1.1"
 tempfile = "3.0"
-lucet-module = { path = "../../lucet-module", version = "=0.6.1" }
-lucet-runtime-internals = { path = "../lucet-runtime-internals", version = "=0.6.1" }
-lucet-wasi-sdk = { path = "../../lucet-wasi-sdk", version = "=0.6.1" }
-lucetc = { path = "../../lucetc", version = "=0.6.1" }
+lucet-module = { path = "../../lucet-module", version = "=0.6.2-dev" }
+lucet-runtime-internals = { path = "../lucet-runtime-internals", version = "=0.6.2-dev" }
+lucet-wasi-sdk = { path = "../../lucet-wasi-sdk", version = "=0.6.2-dev" }
+lucetc = { path = "../../lucetc", version = "=0.6.2-dev" }
 
 [build-dependencies]
 cc = "1.0"

--- a/lucet-runtime/lucet-runtime-tests/Cargo.toml
+++ b/lucet-runtime/lucet-runtime-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-runtime-tests"
-version = "0.6.1-dev"
+version = "0.6.1"
 description = "Pure Rust runtime for Lucet WebAssembly toolchain (tests)"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -18,10 +18,10 @@ test = false
 anyhow = "1"
 lazy_static = "1.1"
 tempfile = "3.0"
-lucet-module = { path = "../../lucet-module", version = "=0.6.1-dev" }
-lucet-runtime-internals = { path = "../lucet-runtime-internals", version = "=0.6.1-dev" }
-lucet-wasi-sdk = { path = "../../lucet-wasi-sdk", version = "=0.6.1-dev" }
-lucetc = { path = "../../lucetc", version = "=0.6.1-dev" }
+lucet-module = { path = "../../lucet-module", version = "=0.6.1" }
+lucet-runtime-internals = { path = "../lucet-runtime-internals", version = "=0.6.1" }
+lucet-wasi-sdk = { path = "../../lucet-wasi-sdk", version = "=0.6.1" }
+lucetc = { path = "../../lucetc", version = "=0.6.1" }
 
 [build-dependencies]
 cc = "1.0"

--- a/lucet-spectest/Cargo.toml
+++ b/lucet-spectest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-spectest"
-version = "0.6.1"
+version = "0.6.2-dev"
 description = "Test harness to run WebAssembly spec tests (.wast) against the Lucet toolchain"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -17,9 +17,9 @@ name = "spec-test"
 path = "src/main.rs"
 
 [dependencies]
-lucetc = { path = "../lucetc", version = "=0.6.1" }
-lucet-module = { path = "../lucet-module", version = "=0.6.1" }
-lucet-runtime = { path = "../lucet-runtime", version = "=0.6.1" }
+lucetc = { path = "../lucetc", version = "=0.6.2-dev" }
+lucet-module = { path = "../lucet-module", version = "=0.6.2-dev" }
+lucet-runtime = { path = "../lucet-runtime", version = "=0.6.2-dev" }
 wabt = "0.9.2"
 serde = "1.0"
 serde_json = "1.0"

--- a/lucet-spectest/Cargo.toml
+++ b/lucet-spectest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-spectest"
-version = "0.6.1-dev"
+version = "0.6.1"
 description = "Test harness to run WebAssembly spec tests (.wast) against the Lucet toolchain"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -17,9 +17,9 @@ name = "spec-test"
 path = "src/main.rs"
 
 [dependencies]
-lucetc = { path = "../lucetc", version = "=0.6.1-dev" }
-lucet-module = { path = "../lucet-module", version = "=0.6.1-dev" }
-lucet-runtime = { path = "../lucet-runtime", version = "=0.6.1-dev" }
+lucetc = { path = "../lucetc", version = "=0.6.1" }
+lucet-module = { path = "../lucet-module", version = "=0.6.1" }
+lucet-runtime = { path = "../lucet-runtime", version = "=0.6.1" }
 wabt = "0.9.2"
 serde = "1.0"
 serde_json = "1.0"

--- a/lucet-validate/Cargo.toml
+++ b/lucet-validate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-validate"
-version = "0.6.1-dev"
+version = "0.6.1"
 description = "Parse and validate webassembly files against witx interface"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -24,7 +24,7 @@ thiserror = "1.0.4"
 wasmparser = "0.39.1"
 
 [dev-dependencies]
-lucet-wasi-sdk = { path = "../lucet-wasi-sdk", version = "=0.6.1-dev" }
+lucet-wasi-sdk = { path = "../lucet-wasi-sdk", version = "=0.6.1" }
 tempfile = "3.0"
 wabt = "0.9.2"
 

--- a/lucet-validate/Cargo.toml
+++ b/lucet-validate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-validate"
-version = "0.6.1"
+version = "0.6.2-dev"
 description = "Parse and validate webassembly files against witx interface"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -24,7 +24,7 @@ thiserror = "1.0.4"
 wasmparser = "0.39.1"
 
 [dev-dependencies]
-lucet-wasi-sdk = { path = "../lucet-wasi-sdk", version = "=0.6.1" }
+lucet-wasi-sdk = { path = "../lucet-wasi-sdk", version = "=0.6.2-dev" }
 tempfile = "3.0"
 wabt = "0.9.2"
 

--- a/lucet-wasi-fuzz/Cargo.toml
+++ b/lucet-wasi-fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-wasi-fuzz"
-version = "0.6.1"
+version = "0.6.2-dev"
 description = "Test the Lucet toolchain against native code execution using Csmith"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"

--- a/lucet-wasi-fuzz/Cargo.toml
+++ b/lucet-wasi-fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-wasi-fuzz"
-version = "0.6.1-dev"
+version = "0.6.1"
 description = "Test the Lucet toolchain against native code execution using Csmith"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"

--- a/lucet-wasi-sdk/Cargo.toml
+++ b/lucet-wasi-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-wasi-sdk"
-version = "0.6.1-dev"
+version = "0.6.1"
 description = "A Rust interface to the wasi-sdk compiler and linker"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -11,12 +11,12 @@ edition = "2018"
 
 [dependencies]
 failure = "0.1"
-lucetc = { path = "../lucetc", version = "=0.6.1-dev" }
-lucet-module = { path = "../lucet-module", version = "=0.6.1-dev" }
+lucetc = { path = "../lucetc", version = "=0.6.1" }
+lucet-module = { path = "../lucet-module", version = "=0.6.1" }
 tempfile = "3.0"
 thiserror = "1.0.4"
 
 [dev-dependencies]
 anyhow = "1"
-lucet-validate = { path = "../lucet-validate", version  = "=0.6.1-dev" }
+lucet-validate = { path = "../lucet-validate", version  = "=0.6.1" }
 target-lexicon = "0.9"

--- a/lucet-wasi-sdk/Cargo.toml
+++ b/lucet-wasi-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-wasi-sdk"
-version = "0.6.1"
+version = "0.6.2-dev"
 description = "A Rust interface to the wasi-sdk compiler and linker"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -11,12 +11,12 @@ edition = "2018"
 
 [dependencies]
 failure = "0.1"
-lucetc = { path = "../lucetc", version = "=0.6.1" }
-lucet-module = { path = "../lucet-module", version = "=0.6.1" }
+lucetc = { path = "../lucetc", version = "=0.6.2-dev" }
+lucet-module = { path = "../lucet-module", version = "=0.6.2-dev" }
 tempfile = "3.0"
 thiserror = "1.0.4"
 
 [dev-dependencies]
 anyhow = "1"
-lucet-validate = { path = "../lucet-validate", version  = "=0.6.1" }
+lucet-validate = { path = "../lucet-validate", version  = "=0.6.2-dev" }
 target-lexicon = "0.9"

--- a/lucet-wasi/Cargo.toml
+++ b/lucet-wasi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-wasi"
-version = "0.6.1-dev"
+version = "0.6.1"
 description = "Fastly's runtime for the WebAssembly System Interface (WASI)"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -28,17 +28,17 @@ anyhow = "1"
 cast = "0.2"
 clap = "2.23"
 human-size = "0.4"
-lucet-runtime = { path = "../lucet-runtime", version = "=0.6.1-dev" }
-lucet-runtime-internals = { path = "../lucet-runtime/lucet-runtime-internals", version = "=0.6.1-dev" }
-lucet-module = { path = "../lucet-module", version = "=0.6.1-dev" }
+lucet-runtime = { path = "../lucet-runtime", version = "=0.6.1" }
+lucet-runtime-internals = { path = "../lucet-runtime/lucet-runtime-internals", version = "=0.6.1" }
+lucet-module = { path = "../lucet-module", version = "=0.6.1" }
 libc = "0.2.65"
 nix = "0.15"
 rand = "0.6"
 wasi-common = "0.7"
 
 [dev-dependencies]
-lucet-wasi-sdk = { path = "../lucet-wasi-sdk", version = "=0.6.1-dev" }
-lucetc = { path = "../lucetc", version = "=0.6.1-dev" }
+lucet-wasi-sdk = { path = "../lucet-wasi-sdk", version = "=0.6.1" }
+lucetc = { path = "../lucetc", version = "=0.6.1" }
 tempfile = "3.0"
 
 [build-dependencies]

--- a/lucet-wasi/Cargo.toml
+++ b/lucet-wasi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucet-wasi"
-version = "0.6.1"
+version = "0.6.2-dev"
 description = "Fastly's runtime for the WebAssembly System Interface (WASI)"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -28,17 +28,17 @@ anyhow = "1"
 cast = "0.2"
 clap = "2.23"
 human-size = "0.4"
-lucet-runtime = { path = "../lucet-runtime", version = "=0.6.1" }
-lucet-runtime-internals = { path = "../lucet-runtime/lucet-runtime-internals", version = "=0.6.1" }
-lucet-module = { path = "../lucet-module", version = "=0.6.1" }
+lucet-runtime = { path = "../lucet-runtime", version = "=0.6.2-dev" }
+lucet-runtime-internals = { path = "../lucet-runtime/lucet-runtime-internals", version = "=0.6.2-dev" }
+lucet-module = { path = "../lucet-module", version = "=0.6.2-dev" }
 libc = "0.2.65"
 nix = "0.15"
 rand = "0.6"
 wasi-common = "0.7"
 
 [dev-dependencies]
-lucet-wasi-sdk = { path = "../lucet-wasi-sdk", version = "=0.6.1" }
-lucetc = { path = "../lucetc", version = "=0.6.1" }
+lucet-wasi-sdk = { path = "../lucet-wasi-sdk", version = "=0.6.2-dev" }
+lucetc = { path = "../lucetc", version = "=0.6.2-dev" }
 tempfile = "3.0"
 
 [build-dependencies]

--- a/lucetc/Cargo.toml
+++ b/lucetc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucetc"
-version = "0.6.1"
+version = "0.6.2-dev"
 description = "Fastly's WebAssembly to native code compiler"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -24,8 +24,8 @@ cranelift-module = { path = "../cranelift/cranelift-module", version = "0.51.0" 
 cranelift-faerie = { path = "../cranelift/cranelift-faerie", version = "0.51.0" }
 cranelift-wasm = { path = "../cranelift/cranelift-wasm", version = "0.51.0" }
 target-lexicon = "0.9"
-lucet-module = { path = "../lucet-module", version = "=0.6.1" }
-lucet-validate = { path = "../lucet-validate", version = "=0.6.1" }
+lucet-module = { path = "../lucet-module", version = "=0.6.2-dev" }
+lucet-validate = { path = "../lucet-validate", version = "=0.6.2-dev" }
 wasmparser = "0.39.1"
 clap="2.32"
 log = "0.4"

--- a/lucetc/Cargo.toml
+++ b/lucetc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lucetc"
-version = "0.6.1-dev"
+version = "0.6.1"
 description = "Fastly's WebAssembly to native code compiler"
 homepage = "https://github.com/fastly/lucet"
 repository = "https://github.com/fastly/lucet"
@@ -24,8 +24,8 @@ cranelift-module = { path = "../cranelift/cranelift-module", version = "0.51.0" 
 cranelift-faerie = { path = "../cranelift/cranelift-faerie", version = "0.51.0" }
 cranelift-wasm = { path = "../cranelift/cranelift-wasm", version = "0.51.0" }
 target-lexicon = "0.9"
-lucet-module = { path = "../lucet-module", version = "=0.6.1-dev" }
-lucet-validate = { path = "../lucet-validate", version = "=0.6.1-dev" }
+lucet-module = { path = "../lucet-module", version = "=0.6.1" }
+lucet-validate = { path = "../lucet-validate", version = "=0.6.1" }
 wasmparser = "0.39.1"
 clap="2.32"
 log = "0.4"


### PR DESCRIPTION
It'd be nice to get a 0.6.1 release when you guys have the time, so I've (hopefully) done some of the legwork for you.

First commit is for the release, second commit bumps all the versions to 0.6.2-dev.