### PR TITLE
Check extended CPU features only when necessary as querying flags fail on some AMD CPUs.

### DIFF
--- a/lucet-runtime/lucet-runtime-internals/src/module/dl.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/module/dl.rs
@@ -48,24 +48,28 @@ fn check_feature_support(module_features: &ModuleFeatures) -> Result<(), Error> 
         return Err(missing_feature("POPCNT"));
     }
 
-    let info = cpuid.get_extended_feature_info().ok_or_else(|| {
-        Error::Unsupported("Unable to obtain host CPU extended feature info!".to_string())
-    })?;
+    if module_features.bmi1 || module_features.bmi2 {
+        let info = cpuid.get_extended_feature_info().ok_or_else(|| {
+            Error::Unsupported("Unable to obtain host CPU extended feature info!".to_string())
+        })?;
 
-    if module_features.bmi1 && !info.has_bmi1() {
-        return Err(missing_feature("BMI1"));
+        if module_features.bmi1 && !info.has_bmi1() {
+            return Err(missing_feature("BMI1"));
+        }
+
+        if module_features.bmi2 && !info.has_bmi2() {
+            return Err(missing_feature("BMI2"));
+        }
     }
 
-    if module_features.bmi2 && !info.has_bmi2() {
-        return Err(missing_feature("BMI2"));
-    }
+    if module_features.lzcnt {
+        let info = cpuid.get_extended_function_info().ok_or_else(|| {
+            Error::Unsupported("Unable to obtain host CPU extended function info!".to_string())
+        })?;
 
-    let info = cpuid.get_extended_function_info().ok_or_else(|| {
-        Error::Unsupported("Unable to obtain host CPU extended function info!".to_string())
-    })?;
-
-    if module_features.lzcnt && !info.has_lzcnt() {
-        return Err(missing_feature("LZCNT"));
+        if module_features.lzcnt && !info.has_lzcnt() {
+            return Err(missing_feature("LZCNT"));
+        }
     }
 
     // Features are fine, we're compatible!


### PR DESCRIPTION
Some AMD CPUs fail on querying CPUID extended flags. See https://bugzilla.mozilla.org/show_bug.cgi?id=1615786. Performing this check only when actually required, allows wasm modules that don't rely on extended features to be run.