### PR TITLE
KillSwitch terminates pending instance

### DIFF
--- a/lucet-runtime/lucet-runtime-internals/src/context/context_asm.S
+++ b/lucet-runtime/lucet-runtime-internals/src/context/context_asm.S
@@ -80,7 +80,7 @@ _lucet_context_backstop:
     jz no_backstop_callback
 #endif
 
-    // load `backstop_data`, arg 1
+    // load `callback_data`, arg 1
     mov (10*8 + 8*16 + 8*2 + 16 + 8 + 8)(%rbp), %rdi
     // call `backstop_callback`
     call *%rsi
@@ -199,14 +199,18 @@ _lucet_context_set:
 .globl _lucet_context_activate
 #endif
 .align 16
-// lucet_context_activate is essentially a function with three arguments:
-//     * `rdi`  -  the data for the activation setup function.
-//     * `rsi`  -  the address of the activation setup function.
-//     * `rbx`  -  the address of the guest code to resume at.
+// `lucet_context_activate` is essentially a function with three arguments:
+//   * rdi: the data for the entry function.
+//   * rsi: the address of the entry function.
+//   * rbx: the address of the guest code to resume at.
+//
+// First, we the function whose address is stored in `rsi`, passing along the
+// value of `rdi` as the first argument. Then, jump to the guest code at the
+// address in `rbx`.
 lucet_context_activate:
 _lucet_context_activate:
-    call *%rsi /* call `enter_guest_region`, passing along `rdi` */
-    jmp *%rbx /* jump to the guest code */
+    call *%rsi
+    jmp *%rbx
 #ifdef __ELF__
 .size lucet_context_activate,.-lucet_context_activate
 #endif

--- a/lucet-runtime/lucet-runtime-internals/src/context/context_asm.S
+++ b/lucet-runtime/lucet-runtime-internals/src/context/context_asm.S
@@ -204,9 +204,13 @@ _lucet_context_set:
 //   * rsi: the address of the entry function.
 //   * rbx: the address of the guest code to resume at.
 //
-// First, we the function whose address is stored in `rsi`, passing along the
-// value of `rdi` as the first argument. Then, jump to the guest code at the
-// address in `rbx`.
+// First, we call the function whose address is stored in `rsi`, passing along
+// the value of `rdi` as the first argument. Then, jump to the guest code at
+// the address in `rbx`.
+//
+// Note that `rbx` is used to store the address of the guest code because it is
+// a callee-saved register in the System V calling convention. It is also a
+// non-violatile register on Windows, which is a nice benefit.
 lucet_context_activate:
 _lucet_context_activate:
     call *%rsi

--- a/lucet-runtime/lucet-runtime-internals/src/context/context_asm.S
+++ b/lucet-runtime/lucet-runtime-internals/src/context/context_asm.S
@@ -204,16 +204,17 @@ _lucet_context_set:
 //   * rsi: the address of the entry function.
 //   * rbx: the address of the guest code to resume at.
 //
-// First, we call the function whose address is stored in `rsi`, passing along
-// the value of `rdi` as the first argument. Then, jump to the guest code at
-// the address in `rbx`.
+// See `lucet_runtime_internals::context::lucet_context_activate` for more info.
 //
 // Note that `rbx` is used to store the address of the guest code because it is
 // a callee-saved register in the System V calling convention. It is also a
 // non-violatile register on Windows, which is a nice benefit.
 lucet_context_activate:
 _lucet_context_activate:
+    // First, we call the entry function whose address is stored in `rsi`,
+    // passing along the value of `rdi` as the first argument.
     call *%rsi
+    // Now, jump to the guest code at the address in `rbx`.
     jmp *%rbx
 #ifdef __ELF__
 .size lucet_context_activate,.-lucet_context_activate

--- a/lucet-runtime/lucet-runtime-internals/src/context/context_asm.S
+++ b/lucet-runtime/lucet-runtime-internals/src/context/context_asm.S
@@ -199,13 +199,14 @@ _lucet_context_set:
 .globl _lucet_context_activate
 #endif
 .align 16
-// lucet_context_activate is essentially a function with two arguments:
-// in rdi, the address of this guest's "running" flag.
-// in rsi, the address of the guest code to resume at.
+// lucet_context_activate is essentially a function with three arguments:
+//     * `rdi`  -  the data for the activation setup function.
+//     * `rsi`  -  the address of the activation setup function.
+//     * `rbx`  -  the address of the guest code to resume at.
 lucet_context_activate:
 _lucet_context_activate:
-    movb $1, (%rdi)
-    jmp *%rsi
+    call *%rsi /* call `enter_guest_region`, passing along `rdi` */
+    jmp *%rbx /* jump to the guest code */
 #ifdef __ELF__
 .size lucet_context_activate,.-lucet_context_activate
 #endif

--- a/lucet-runtime/lucet-runtime-internals/src/context/context_asm.S
+++ b/lucet-runtime/lucet-runtime-internals/src/context/context_asm.S
@@ -200,9 +200,9 @@ _lucet_context_set:
 #endif
 .align 16
 // `lucet_context_activate` is essentially a function with three arguments:
-//   * rdi: the data for the entry function.
-//   * rsi: the address of the entry function.
-//   * rbx: the address of the guest code to resume at.
+//   * rdi: the data for the entry callback.
+//   * rsi: the address of the entry callback.
+//   * rbx: the address of the guest code to execute.
 //
 // See `lucet_runtime_internals::context::lucet_context_activate` for more info.
 //
@@ -211,7 +211,7 @@ _lucet_context_set:
 // non-violatile register on Windows, which is a nice benefit.
 lucet_context_activate:
 _lucet_context_activate:
-    // First, we call the entry function whose address is stored in `rsi`,
+    // First, we call the entry callback whose address is stored in `rsi`,
     // passing along the value of `rdi` as the first argument.
     call *%rsi
     // Now, jump to the guest code at the address in `rbx`.

--- a/lucet-runtime/lucet-runtime-internals/src/context/mod.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/context/mod.rs
@@ -121,8 +121,8 @@ pub struct Context {
     retval_fp: __m128,
     parent_ctx: *mut Context,
     // TODO ACF 2019-10-23: make Instance into a generic parameter?
-    backstop_callback: *const unsafe extern "C" fn(*mut Instance),
-    callback_data: *mut Instance,
+    backstop_callback: *const unsafe extern "C" fn(*const Instance),
+    callback_data: *const Instance,
     sigset: signal::SigSet,
 }
 
@@ -142,7 +142,7 @@ impl Context {
     }
 
     /// Get a raw pointer to the instance's callback data.
-    pub(crate) fn callback_data_ptr(&self) -> *mut Instance {
+    pub(crate) fn callback_data_ptr(&self) -> *const Instance {
         self.callback_data
     }
 }
@@ -382,7 +382,7 @@ impl Context {
     }
 
     /// The default backstop callback does nothing, and is just a marker.
-    extern "C" fn default_backstop_callback(_: *mut Instance) {}
+    extern "C" fn default_backstop_callback(_: *const Instance) {}
 
     /// Similar to `Context::init()`, but allows setting a callback function to be run when the
     /// guest entrypoint returns.
@@ -392,8 +392,8 @@ impl Context {
     pub fn init_with_callback(
         stack: &mut [u64],
         child: &mut Context,
-        backstop_callback: unsafe extern "C" fn(*mut Instance),
-        callback_data: *mut Instance,
+        backstop_callback: unsafe extern "C" fn(*const Instance),
+        callback_data: *const Instance,
         fptr: usize,
         args: &[Val],
     ) -> Result<(), Error> {

--- a/lucet-runtime/lucet-runtime-internals/src/context/mod.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/context/mod.rs
@@ -26,7 +26,7 @@ use thiserror::Error;
 /// `u64`, this should be fine?
 #[repr(C)]
 pub(crate) struct GpRegs {
-    rbx: u64,
+    pub(crate) rbx: u64,
     pub(crate) rsp: u64,
     rbp: u64,
     pub(crate) rdi: u64,
@@ -122,7 +122,8 @@ pub struct Context {
     parent_ctx: *mut Context,
     // TODO ACF 2019-10-23: make Instance into a generic parameter?
     backstop_callback: *const unsafe extern "C" fn(*mut Instance),
-    backstop_data: *mut Instance,
+    // FIXME KTM 2020-02-14: this should NOT be pub(crate)
+    pub(crate) backstop_data: *mut Instance,
     sigset: signal::SigSet,
 }
 

--- a/lucet-runtime/lucet-runtime-internals/src/context/mod.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/context/mod.rs
@@ -142,8 +142,6 @@ impl Context {
     }
 
     /// Get a raw pointer to the instance's callback data.
-    ///
-    /// REVIEW QUESTION: Should this be `unsafe fn` ? Can aliasing `*mut` lead to UB?
     pub(crate) fn callback_data_ptr(&self) -> *mut Instance {
         self.callback_data
     }

--- a/lucet-runtime/lucet-runtime-internals/src/context/mod.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/context/mod.rs
@@ -728,15 +728,15 @@ extern "C" {
     /// Never returns because the current context is discarded.
     fn lucet_context_set(to: *const Context) -> !;
 
-    /// Runs an activation function after performing a context switch. Implemented in assembly.
+    /// Runs an entry callback after performing a context switch. Implemented in assembly.
     ///
     /// In practice, this is used with `enter_guest_region` so that the guest will appropriately
     /// set itself to be terminable upon entry before continuing to any guest code.
     ///
     /// `lucet_context_activate` is essentially a function with three arguments:
-    ///   * rdi: the data for the entry function.
-    ///   * rsi: the address of the entry function.
-    ///   * rbx: the address of the guest code to resume at.
+    ///   * rdi: the data for the entry callback.
+    ///   * rsi: the address of the entry callback.
+    ///   * rbx: the address of the guest code to execute.
     ///
     /// We do not actually define `lucet_context_activate` as having these arguments because we
     /// manually load these arguments, as well as a pointer to this function, into the context's

--- a/lucet-runtime/lucet-runtime-internals/src/context/mod.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/context/mod.rs
@@ -121,8 +121,8 @@ pub struct Context {
     retval_fp: __m128,
     parent_ctx: *mut Context,
     // TODO ACF 2019-10-23: make Instance into a generic parameter?
-    backstop_callback: *const unsafe extern "C" fn(*const Instance),
-    callback_data: *const Instance,
+    backstop_callback: *const unsafe extern "C" fn(*mut Instance),
+    callback_data: *mut Instance,
     sigset: signal::SigSet,
 }
 
@@ -142,7 +142,7 @@ impl Context {
     }
 
     /// Get a raw pointer to the instance's callback data.
-    pub(crate) fn callback_data_ptr(&self) -> *const Instance {
+    pub(crate) fn callback_data_ptr(&self) -> *mut Instance {
         self.callback_data
     }
 }
@@ -382,7 +382,7 @@ impl Context {
     }
 
     /// The default backstop callback does nothing, and is just a marker.
-    extern "C" fn default_backstop_callback(_: *const Instance) {}
+    extern "C" fn default_backstop_callback(_: *mut Instance) {}
 
     /// Similar to `Context::init()`, but allows setting a callback function to be run when the
     /// guest entrypoint returns.
@@ -392,8 +392,8 @@ impl Context {
     pub fn init_with_callback(
         stack: &mut [u64],
         child: &mut Context,
-        backstop_callback: unsafe extern "C" fn(*const Instance),
-        callback_data: *const Instance,
+        backstop_callback: unsafe extern "C" fn(*mut Instance),
+        callback_data: *mut Instance,
         fptr: usize,
         args: &[Val],
     ) -> Result<(), Error> {

--- a/lucet-runtime/lucet-runtime-internals/src/instance.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/instance.rs
@@ -870,9 +870,9 @@ impl Instance {
     /// terminable before continuing to whatever guest code we want to run.
     ///
     /// `lucet_context_activate` takes three arguments in the following registers:
-    ///   * rdi: the data for the entry function
-    ///   * rsi: the address of the entry function
-    ///   * rbx: the address of guest code to execute
+    ///   * rdi: the data for the entry callback.
+    ///   * rsi: the address of the entry callback.
+    ///   * rbx: the address of the guest code to execute.
     ///
     /// The appropriate value for `rbx` is the top of the guest stack, which we would otherwise
     /// return to and start executing immediately. For `rdi`, we want to pass our callback data

--- a/lucet-runtime/lucet-runtime-internals/src/instance.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/instance.rs
@@ -867,8 +867,9 @@ impl Instance {
         //   * rbx: the address of guest code to execute
         //
         // The appropriate value for `rbx` is the top of the guest stack, which we would otherwise
-        // return to and start executing immediately. For `rdi`, we want to pass a raw pointer to
-        // the instance, which will be pass
+        // return to and start executing immediately. For `rdi`, we want to pass our callback data
+        // (a raw pointer to the instance). This will be passed as the first argument to the entry
+        // function, whose address is given in `rsi`.
         //
         // once we've set up arguments, swap out the guest return address with
         // `lucet_context_activate` so we start execution there.
@@ -880,7 +881,7 @@ impl Instance {
             *top_of_stack = crate::context::lucet_context_activate as u64;
             // store a pointer to pass to the context activation function
             self.ctx.gpr.rdi = self.ctx.callback_data_ptr() as u64;
-            // DEV KTM: Let's try and pass a function pointer!
+            // pass a pointer to the guest-side entrypoint bootstrap code
             self.ctx.gpr.rsi = execution::enter_guest_region as u64;
         }
 

--- a/lucet-runtime/lucet-runtime-internals/src/instance.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/instance.rs
@@ -535,7 +535,7 @@ impl Instance {
     ///
     /// This will also reinitialize the kill state, which means that any outstanding
     /// [`KillSwitch`](struct.KillSwitch.html) objects will be unable to terminate this instance.
-    /// It is the embedder's responsibility to initialize new killswitches after resetting an
+    /// It is the embedder's responsibility to initialize new `KillSwitch`es after resetting an
     /// instance.
     ///
     /// # Safety

--- a/lucet-runtime/lucet-runtime-internals/src/instance.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/instance.rs
@@ -954,10 +954,12 @@ impl Instance {
         match st {
             State::Running => {
                 let retval = self.ctx.get_untyped_retval();
+                self.kill_state = Arc::new(KillState::default());
                 self.state = State::Ready;
                 Ok(RunResult::Returned(retval))
             }
             State::Terminating { details, .. } => {
+                self.kill_state = Arc::new(KillState::default());
                 self.state = State::Terminated;
                 Err(Error::RuntimeTerminated(details))
             }
@@ -978,6 +980,8 @@ impl Instance {
                 details.rip_addr_details = self
                     .module
                     .addr_details(details.rip_addr as *const c_void)?;
+
+                self.kill_state = Arc::new(KillState::default());
 
                 // fill the state back in with the updated details in case fatal handlers need it
                 self.state = State::Faulted {

--- a/lucet-runtime/lucet-runtime-internals/src/instance.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/instance.rs
@@ -954,12 +954,10 @@ impl Instance {
         match st {
             State::Running => {
                 let retval = self.ctx.get_untyped_retval();
-                self.kill_state = Arc::new(KillState::default());
                 self.state = State::Ready;
                 Ok(RunResult::Returned(retval))
             }
             State::Terminating { details, .. } => {
-                self.kill_state = Arc::new(KillState::default());
                 self.state = State::Terminated;
                 Err(Error::RuntimeTerminated(details))
             }
@@ -980,8 +978,6 @@ impl Instance {
                 details.rip_addr_details = self
                     .module
                     .addr_details(details.rip_addr as *const c_void)?;
-
-                self.kill_state = Arc::new(KillState::default());
 
                 // fill the state back in with the updated details in case fatal handlers need it
                 self.state = State::Faulted {

--- a/lucet-runtime/lucet-runtime-internals/src/instance/execution.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/instance/execution.rs
@@ -286,11 +286,21 @@ impl KillState {
     }
 }
 
+/// Instance execution domains.
+///
+/// This enum allow us to distinguish what an appropriate mechanism to signal termination is.
+#[derive(Debug, PartialEq)]
 pub enum Domain {
+    /// Represents an instance that is not currently running.
+    /// FIXME KTM 2020-02-20: Maybe we should call this `Ready` or `Paused`.
     Pending,
+    /// Represents an instance that is executing guest code.
     Guest,
+    /// Represents an instance that is executing host code.
     Hostcall,
+    /// Represents an instance that has been signalled to terminate while running code.
     Terminated,
+    /// Represents an instance that has been cancelled before it began running code.
     Cancelled,
 }
 

--- a/lucet-runtime/lucet-runtime-internals/src/instance/execution.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/instance/execution.rs
@@ -107,7 +107,7 @@
 use libc::{pthread_kill, pthread_t, SIGALRM};
 use std::mem;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Condvar, Mutex, Weak};
+use std::sync::{Condvar, Mutex, Weak};
 
 use crate::instance::{Instance, TerminationDetails};
 
@@ -226,7 +226,7 @@ pub unsafe extern "C" fn enter_guest_region(instance: *mut Instance) {
 /// This function will panic if the `Instance`'s execution domain is marked as pending, currently
 /// in a hostcall, or as cancelled.  Any of these domains mean that something has gone seriously
 /// wrong, and leaving the execution domain mutex in a poisoned state is the least of our concerns.
-pub unsafe extern "C" fn exit_guest_region(instance: *mut Instance) {
+pub unsafe extern "C" fn exit_guest_region(instance: *const Instance) {
     let terminable = (*instance)
         .kill_state
         .terminable
@@ -243,11 +243,8 @@ pub unsafe extern "C" fn exit_guest_region(instance: *mut Instance) {
         let current_domain = (*instance).kill_state.execution_domain.lock().unwrap();
         match *current_domain {
             Domain::Guest => {
-                // We finished executing the code in our guest region normally! We should reset
-                // the kill state, invalidating any existing killswitches' weak references. We
-                // forget the mutex guard so that we don't invoke its destructor and segfault.
-                (*instance).kill_state = Arc::new(KillState::default());
-                mem::forget(current_domain);
+                // We finished executing the code in our guest region normally!
+                // Nothing to do, we can return the host now.
             }
             ref domain @ Domain::Pending
             | ref domain @ Domain::Cancelled

--- a/lucet-runtime/lucet-runtime-internals/src/instance/execution.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/instance/execution.rs
@@ -54,7 +54,7 @@
 //!     `NotTerminable` when the instance has already been terminated.
 //! * `Instance::run returns`
 //!   - terminable: `true`
-//!   - execution_domain: `Guest, Hostcall, or Terminated`
+//!   - execution_domain: `Pending, Hostcall, or Terminated`
 //!   - termination result: `Err(KillError::Invalid)`
 //!   - `execution_domain` will be `Pending` when the initial guest function returns, `Hostcall`
 //!     when terminated by `lucet_hostcall_terminate!`, and `Terminated` when exiting due to a

--- a/lucet-runtime/lucet-runtime-internals/src/instance/execution.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/instance/execution.rs
@@ -204,17 +204,7 @@ pub unsafe extern "C" fn exit_guest_region(instance: *mut Instance) {
             panic!("Invalid state: Instance marked as in a hostcall while exiting a guest region.");
         }
         Domain::Terminated => {
-            // Something else has indicated that we must stop, so it's not safe to actually exit
-            // the guest context yet. Because this is called when exiting a guest context, the
-            // termination mechanism will be a signal, delivered at some point (hopefully soon!).
-            // Further, because the termination mechanism will be a signal, we are constrained to
-            // only signal-safe behavior.
-            //
-            // For now, release our lock on the execution domain, and hang indefinitely, waiting
-            // for the sigalrm to arrive. So yes, clippy, we know that this loop is empty :)
-            mem::drop(current_domain);
-            #[allow(clippy::empty_loop)]
-            loop {}
+            panic!("Invalid state: Instance marked as terminated while exiting a guest region.");
         }
         Domain::Cancelled => {
             panic!("Invalid state: Instance marked as cancelled while exiting a guest region.");

--- a/lucet-runtime/lucet-runtime-internals/src/instance/signals.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/instance/signals.rs
@@ -180,7 +180,7 @@ extern "C" fn handle_signal(signum: c_int, siginfo_ptr: *mut siginfo_t, ucontext
                 details: TerminationDetails::Remote,
             };
             return true;
-        };
+        }
 
         let trapcode = inst.module.lookup_trapcode(rip);
 

--- a/lucet-runtime/lucet-runtime-internals/src/instance/signals.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/instance/signals.rs
@@ -167,8 +167,6 @@ extern "C" fn handle_signal(signum: c_int, siginfo_ptr: *mut siginfo_t, ucontext
 
         if signal == Signal::SIGALRM {
             // set the state before jumping back to the host context
-            // TODO: once we have a notion of logging in `lucet-runtime`, this should be a logged
-            // error.
             inst.state = State::Terminating {
                 details: TerminationDetails::Remote,
             };

--- a/lucet-runtime/lucet-runtime-tests/src/timeout.rs
+++ b/lucet-runtime/lucet-runtime-tests/src/timeout.rs
@@ -121,7 +121,7 @@ macro_rules! timeout_tests {
                 })
                 .expect("can spawn a thread");
 
-            // Begin running the instance, which should be terminated remotely by the KillSwitch.
+            // Begin running the instance, which will be terminated remotely by the KillSwitch.
             match inst.run("infinite_loop", &[]) {
                 Err(Error::RuntimeTerminated(TerminationDetails::Remote)) => {
                     // this is what we want to see
@@ -130,7 +130,7 @@ macro_rules! timeout_tests {
             }
             t.join().unwrap();
 
-            // Another attempt to terminate the instance should fail.
+            // Another attempt to terminate the instance will fail.
             assert_eq!(
                 inst.kill_switch().terminate(),
                 Err(KillError::NotTerminable)
@@ -153,7 +153,7 @@ macro_rules! timeout_tests {
             // If terminated before running, the guest will be cancelled.
             assert_eq!(kill_switch.terminate(), Ok(KillSuccess::Cancelled));
 
-            // Another attempt to terminate the instance should fail.
+            // Another attempt to terminate the instance will fail.
             assert_eq!(
                 inst.kill_switch().terminate(),
                 Err(KillError::NotTerminable)
@@ -179,14 +179,14 @@ macro_rules! timeout_tests {
                 .expect("instance can be created");
             let kill_switch = inst.kill_switch();
 
-            // The killswitch should fail if the instance has already finished running.
+            // The killswitch will fail if the instance has already finished running.
             match inst.run("do_nothing", &[]) {
                 Ok(_) => {}
                 res => panic!("unexpected result: {:?}", res),
             }
             assert_eq!(kill_switch.terminate(), Ok(KillSuccess::Cancelled)); // FIXME -> Invalid
 
-            // If terminated after running, the guest should not run again.
+            // If terminated after running, the guest will not run again.
             match inst.run("onetwothree", &[]) {
                 Err(Error::RuntimeTerminated(TerminationDetails::Remote)) => {}
                 res => panic!("unexpected result: {:?}", res),
@@ -240,14 +240,14 @@ macro_rules! timeout_tests {
                 })
                 .expect("can spawn a thread");
 
-            // Begin running the instance, which should be terminated remotely by the KillSwitch
+            // Begin running the instance, which will be terminated remotely by the KillSwitch
             // while inside a hostcall. See `slow_hostcall` above for more information.
             match inst.run("run_slow_hostcall", &[]) {
                 Err(Error::RuntimeTerminated(TerminationDetails::Remote)) => {}
                 res => panic!("unexpected result: {:?}", res),
             }
 
-            // Another attempt to terminate the instance should fail.
+            // Another attempt to terminate the instance will fail.
             assert_eq!(
                 inst.kill_switch().terminate(),
                 Err(KillError::NotTerminable)
@@ -353,7 +353,7 @@ macro_rules! timeout_tests {
                 })
                 .expect("can spawn a thread");
 
-            // Start the instance, which should return an error having been remotely terminated.
+            // Start the instance, which will return an error having been remotely terminated.
             match inst.run("infinite_loop", &[]) {
                 Err(Error::RuntimeTerminated(TerminationDetails::Remote)) => {}
                 res => panic!("unexpected result: {:?}", res),

--- a/lucet-runtime/lucet-runtime-tests/src/timeout.rs
+++ b/lucet-runtime/lucet-runtime-tests/src/timeout.rs
@@ -169,7 +169,6 @@ macro_rules! timeout_tests {
             run_onetwothree(&mut inst);
         }
 
-        /// FIXME: This needs a subtle change.
         #[test]
         fn timeout_after_guest_runs() {
             let module = mock_timeout_module();
@@ -184,11 +183,12 @@ macro_rules! timeout_tests {
                 Ok(_) => {}
                 res => panic!("unexpected result: {:?}", res),
             }
-            assert_eq!(kill_switch.terminate(), Ok(KillSuccess::Cancelled));
 
-            // If terminated after running, the guest will not run again.
-            match inst.run("onetwothree", &[]) {
-                Err(Error::RuntimeTerminated(TerminationDetails::Remote)) => {}
+            // If we try to terminate after the instance ran, the kill switch will fail, and the
+            // the instance will run normally the next time around.
+            assert_eq!(kill_switch.terminate(), Err(KillError::Invalid));
+            match inst.run("do_nothing", &[]) {
+                Ok(_) => {}
                 res => panic!("unexpected result: {:?}", res),
             }
 

--- a/lucet-runtime/lucet-runtime-tests/src/timeout.rs
+++ b/lucet-runtime/lucet-runtime-tests/src/timeout.rs
@@ -307,6 +307,20 @@ macro_rules! timeout_tests {
             run_onetwothree(&mut inst);
         }
 
+        /// This test ensures that we see an `Invalid` kill error if we are attempting to terminate
+        /// an instance that has since been dropped.
+        #[test]
+        fn timeout_after_drop() {
+            let module = mock_timeout_module();
+            let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+            let mut inst = region
+                .new_instance(module)
+                .expect("instance can be created");
+            let kill_switch = inst.kill_switch();
+            std::mem::drop(inst);
+            assert_eq!(kill_switch.terminate(), Err(KillError::Invalid));
+        }
+
         #[test]
         fn double_timeout() {
             let module = mock_timeout_module();

--- a/lucet-runtime/lucet-runtime-tests/src/timeout.rs
+++ b/lucet-runtime/lucet-runtime-tests/src/timeout.rs
@@ -1,3 +1,8 @@
+//! Termination tests.
+//!
+//! This macro tests that instances within some kind of memory region can be terminated properly
+//! using a remote kill switch. See
+//! [`KillSwitch::terminate`](struct.KillSwitch.html#method.terminate) for more information.
 #[macro_export]
 macro_rules! timeout_tests {
     ( $TestRegion:path ) => {
@@ -19,6 +24,9 @@ macro_rules! timeout_tests {
         use $crate::build::test_module_c;
         use $crate::helpers::{FunctionPointer, MockExportBuilder, MockModuleBuilder};
 
+        /// Return a mock module so that we can test termination behavior.
+        ///
+        /// See `lucet_runtime_internals::module::mock::MockModuleBuilder` for more information.
         pub fn mock_timeout_module() -> Arc<dyn Module> {
             extern "C" fn onetwothree(_vmctx: *mut lucet_vmctx) -> std::os::raw::c_int {
                 123
@@ -68,20 +76,25 @@ macro_rules! timeout_tests {
                 .build()
         }
 
+        /// This test hostcall will wait for 200 milliseconds before returning `true`.
+        /// This is used to make a window of time so we can timeout inside of a hostcall.
         #[lucet_hostcall]
         #[no_mangle]
         pub fn slow_hostcall(vmctx: &mut Vmctx) -> bool {
-            // make a window of time so we can timeout in a hostcall
             thread::sleep(Duration::from_millis(200));
             true
         }
 
+        /// This test hostcall will immediately yield. This is used to test termination of a
+        /// yielded instance.
         #[lucet_hostcall]
         #[no_mangle]
         pub fn yielding_hostcall(vmctx: &mut Vmctx) {
             vmctx.yield_();
         }
 
+        /// A convenience wrapper around running our mock timeout module's `onetwothree` function,
+        /// and asserting that it returned the expected result.
         fn run_onetwothree(inst: &mut Instance) {
             let retval = inst
                 .run("onetwothree", &[])
@@ -97,71 +110,89 @@ macro_rules! timeout_tests {
             let mut inst = region
                 .new_instance(module)
                 .expect("instance can be created");
-
             let kill_switch = inst.kill_switch();
 
-            thread::Builder::new()
-                .name("helper".to_owned())
+            // Spawn a thread to terminate the instance after waiting for 100ms.
+            let t = thread::Builder::new()
+                .name("killswitch".to_owned())
                 .spawn(move || {
                     thread::sleep(Duration::from_millis(100));
                     assert_eq!(kill_switch.terminate(), Ok(KillSuccess::Signalled));
                 })
                 .expect("can spawn a thread");
 
+            // Begin running the instance, which should be terminated remotely by the KillSwitch.
             match inst.run("infinite_loop", &[]) {
                 Err(Error::RuntimeTerminated(TerminationDetails::Remote)) => {
                     // this is what we want to see
                 }
                 res => panic!("unexpected result: {:?}", res),
             }
+            t.join().unwrap();
 
-            // after a timeout, can reset and run a normal function
+            // Another attempt to terminate the instance should fail.
+            assert_eq!(
+                inst.kill_switch().terminate(),
+                Err(KillError::NotTerminable)
+            );
+
+            // Check that we can reset the instance and run a normal function.
             inst.reset().expect("instance resets");
-
             run_onetwothree(&mut inst);
         }
 
         #[test]
-        fn timeout_before_guest() {
+        fn timeout_before_guest_runs() {
             let module = mock_timeout_module();
             let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
             let mut inst = region
                 .new_instance(module)
                 .expect("instance can be created");
-
             let kill_switch = inst.kill_switch();
+
+            // If terminated before running, the guest will be cancelled.
             assert_eq!(kill_switch.terminate(), Ok(KillSuccess::Cancelled));
 
-            // if terminated before running, the guest should not start at all
+            // Another attempt to terminate the instance should fail.
+            assert_eq!(
+                inst.kill_switch().terminate(),
+                Err(KillError::NotTerminable)
+            );
+
             match inst.run("onetwothree", &[]) {
                 Err(Error::RuntimeTerminated(TerminationDetails::Remote)) => {}
                 res => panic!("unexpected result: {:?}", res),
             }
+
+            // Check that we can reset the instance and run a normal function.
+            inst.reset().expect("instance resets");
+            run_onetwothree(&mut inst);
         }
 
+        /// FIXME: This needs a subtle change.
         #[test]
-        fn timeout_after_guest() {
+        fn timeout_after_guest_runs() {
             let module = mock_timeout_module();
             let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
             let mut inst = region
                 .new_instance(module)
                 .expect("instance can be created");
+            let kill_switch = inst.kill_switch();
 
+            // The killswitch should fail if the instance has already finished running.
             match inst.run("do_nothing", &[]) {
                 Ok(_) => {}
                 res => panic!("unexpected result: {:?}", res),
             }
+            assert_eq!(kill_switch.terminate(), Ok(KillSuccess::Cancelled)); // FIXME -> Invalid
 
-            let kill_switch = inst.kill_switch();
-            assert_eq!(kill_switch.terminate(), Ok(KillSuccess::Cancelled));
-
-            // if terminated after running, the guest should not run again
+            // If terminated after running, the guest should not run again.
             match inst.run("onetwothree", &[]) {
                 Err(Error::RuntimeTerminated(TerminationDetails::Remote)) => {}
                 res => panic!("unexpected result: {:?}", res),
             }
 
-            // after a timeout, can still reset and run a normal function
+            // Check that we can reset the instance and run a normal function.
             inst.reset().expect("instance resets");
             run_onetwothree(&mut inst);
         }
@@ -173,7 +204,9 @@ macro_rules! timeout_tests {
             let mut inst = region
                 .new_instance(module)
                 .expect("instance can be created");
+            let kill_switch = inst.kill_switch();
 
+            // Run the faulting guest.
             match inst.run("main", &[0u32.into(), 0u32.into()]) {
                 Err(Error::RuntimeFault(details)) => {
                     assert_eq!(details.trapcode, Some(TrapCode::HeapOutOfBounds));
@@ -181,12 +214,11 @@ macro_rules! timeout_tests {
                 res => panic!("unexpected result: {:?}", res),
             }
 
-            let kill_switch = inst.kill_switch();
+            // An instance that has faulted is not terminable.
             assert_eq!(kill_switch.terminate(), Err(KillError::NotTerminable));
 
-            // after a timeout, can reset and run a normal function
+            // Check that we can reset the instance and run a normal function.
             inst.reset().expect("instance resets");
-
             run_onetwothree(&mut inst);
         }
 
@@ -197,25 +229,32 @@ macro_rules! timeout_tests {
             let mut inst = region
                 .new_instance(module)
                 .expect("instance can be created");
-
             let kill_switch = inst.kill_switch();
 
+            // Spawn a thread to terminate the instance after waiting for 100ms.
             thread::Builder::new()
-                .name("helper".to_owned())
+                .name("killswitch".to_owned())
                 .spawn(move || {
                     thread::sleep(Duration::from_millis(100));
                     assert_eq!(kill_switch.terminate(), Ok(KillSuccess::Pending));
                 })
                 .expect("can spawn a thread");
 
+            // Begin running the instance, which should be terminated remotely by the KillSwitch
+            // while inside a hostcall. See `slow_hostcall` above for more information.
             match inst.run("run_slow_hostcall", &[]) {
                 Err(Error::RuntimeTerminated(TerminationDetails::Remote)) => {}
                 res => panic!("unexpected result: {:?}", res),
             }
 
-            // after a timeout, can reset and run a normal function
-            inst.reset().expect("instance resets");
+            // Another attempt to terminate the instance should fail.
+            assert_eq!(
+                inst.kill_switch().terminate(),
+                Err(KillError::NotTerminable)
+            );
 
+            // Check that we can reset the instance and run a normal function.
+            inst.reset().expect("instance resets");
             run_onetwothree(&mut inst);
         }
 
@@ -226,76 +265,38 @@ macro_rules! timeout_tests {
             let mut inst = region
                 .new_instance(module)
                 .expect("instance can be created");
-
             let kill_switch = inst.kill_switch();
 
-            thread::Builder::new()
-                .name("helper".to_owned())
-                .spawn(move || {
-                    thread::sleep(Duration::from_millis(100));
-                    assert_eq!(kill_switch.terminate(), Ok(KillSuccess::Pending));
-                })
-                .expect("can spawn a thread");
-
+            // Start the instance, running a function that will yield.
             match inst.run("run_yielding_hostcall", &[]) {
                 Ok(RunResult::Yielded(EmptyYieldVal)) => {}
                 res => panic!("unexpected result: {:?}", res),
             }
 
-            println!("waiting......");
+            // A yielded instance can only be scheduled for termination.
+            assert_eq!(kill_switch.terminate(), Ok(KillSuccess::Pending));
 
-            // wait for the timeout to expire
-            thread::sleep(Duration::from_millis(200));
+            // A second attempt to terminate a yielded instance will fail.
+            assert_eq!(
+                inst.kill_switch().terminate(),
+                Err(KillError::NotTerminable)
+            );
 
+            // Once resumed, the terminated instance will be terminated.
             match inst.resume() {
                 Err(Error::RuntimeTerminated(TerminationDetails::Remote)) => {}
                 res => panic!("unexpected result: {:?}", res),
             }
 
-            // after a timeout, can reset and run a normal function
+            // Check that we can reset the instance and run a normal function.
             inst.reset().expect("instance resets");
-
             run_onetwothree(&mut inst);
-        }
-
-        #[test]
-        fn timeout_killswitch_reuse() {
-            let module = test_module_c("timeout", "inf_loop.c").expect("build and load module");
-
-            let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
-            let mut inst = region
-                .new_instance(module)
-                .expect("instance can be created");
-
-            let kill_switch = inst.kill_switch();
-
-            let helper = thread::Builder::new()
-                .name("helper".to_owned())
-                .spawn(move || {
-                    // This fires first, and will work properly, terminating the instance.
-                    assert_eq!(kill_switch.terminate(), Ok(KillSuccess::Cancelled));
-                    // Next, we will delay for 100ms and try to terminate the instance again.
-                    // This should fail, because we have already terminated the instance.
-                    thread::sleep(Duration::from_millis(100));
-                    assert_eq!(kill_switch.terminate(), Err(KillError::NotTerminable));
-                })
-                .expect("can spawn a thread");
-
-            thread::sleep(Duration::from_millis(10));
-
-            match inst.run("main", &[0u32.into(), 0u32.into()]) {
-                // the result we're expecting - the guest has been terminated!
-                Err(Error::RuntimeTerminated(TerminationDetails::Remote)) => {}
-                res => panic!("unexpected result: {:?}", res),
-            };
-
-            helper.join().unwrap();
         }
 
         /// This test ensures that we see a more informative kill error than `NotTerminable` when
         /// attempting to terminate an instance that has been reset since issuing a kill switch.
         #[test]
-        fn timeout_after_reset() {
+        fn timeout_after_guest_reset() {
             let module = mock_timeout_module();
             let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
             let mut inst = region
@@ -310,7 +311,7 @@ macro_rules! timeout_tests {
         /// This test ensures that we see an `Invalid` kill error if we are attempting to terminate
         /// an instance that has since been dropped.
         #[test]
-        fn timeout_after_drop() {
+        fn timeout_after_guest_drop() {
             let module = mock_timeout_module();
             let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
             let mut inst = region
@@ -329,9 +330,8 @@ macro_rules! timeout_tests {
                 .new_instance(module)
                 .expect("instance can be created");
 
+            // Spawn a thread to terminate the instance after waiting for 100ms.
             let kill_switch = inst.kill_switch();
-            let second_kill_switch = inst.kill_switch();
-
             let helper_1 = thread::Builder::new()
                 .name("helper-1".to_owned())
                 .spawn(move || {
@@ -340,6 +340,8 @@ macro_rules! timeout_tests {
                 })
                 .expect("can spawn a thread");
 
+            // Spawn a thread to terminate the instance after waiting for 200ms.
+            let second_kill_switch = inst.kill_switch();
             let helper_2 = thread::Builder::new()
                 .name("helper-2".to_owned())
                 .spawn(move || {
@@ -351,13 +353,13 @@ macro_rules! timeout_tests {
                 })
                 .expect("can spawn a thread");
 
+            // Start the instance, which should return an error having been remotely terminated.
             match inst.run("infinite_loop", &[]) {
-                // the result we're expecting - the guest has been terminated!
                 Err(Error::RuntimeTerminated(TerminationDetails::Remote)) => {}
                 res => panic!("unexpected result: {:?}", res),
             }
 
-            // Check that neither helper thread panicked.
+            // Explicitly check that each helper thread's assertions succeeded.
             helper_1.join().expect("helper_1 did not panic");
             helper_2.join().expect("helper_2 did not panic");
 

--- a/lucet-runtime/lucet-runtime-tests/src/timeout.rs
+++ b/lucet-runtime/lucet-runtime-tests/src/timeout.rs
@@ -184,7 +184,7 @@ macro_rules! timeout_tests {
                 Ok(_) => {}
                 res => panic!("unexpected result: {:?}", res),
             }
-            assert_eq!(kill_switch.terminate(), Ok(KillSuccess::Cancelled)); // FIXME -> Invalid
+            assert_eq!(kill_switch.terminate(), Ok(KillSuccess::Cancelled));
 
             // If terminated after running, the guest will not run again.
             match inst.run("onetwothree", &[]) {
@@ -332,8 +332,8 @@ macro_rules! timeout_tests {
 
             // Spawn a thread to terminate the instance after waiting for 100ms.
             let kill_switch = inst.kill_switch();
-            let helper_1 = thread::Builder::new()
-                .name("helper-1".to_owned())
+            let t1 = thread::Builder::new()
+                .name("killswitch_1".to_owned())
                 .spawn(move || {
                     thread::sleep(Duration::from_millis(100));
                     assert_eq!(kill_switch.terminate(), Ok(KillSuccess::Signalled));
@@ -342,8 +342,8 @@ macro_rules! timeout_tests {
 
             // Spawn a thread to terminate the instance after waiting for 200ms.
             let second_kill_switch = inst.kill_switch();
-            let helper_2 = thread::Builder::new()
-                .name("helper-2".to_owned())
+            let t2 = thread::Builder::new()
+                .name("killswitch_2".to_owned())
                 .spawn(move || {
                     thread::sleep(Duration::from_millis(200));
                     assert_eq!(
@@ -360,8 +360,8 @@ macro_rules! timeout_tests {
             }
 
             // Explicitly check that each helper thread's assertions succeeded.
-            helper_1.join().expect("helper_1 did not panic");
-            helper_2.join().expect("helper_2 did not panic");
+            t1.join().expect("killswitch_1 did not panic");
+            t2.join().expect("killswitch_2 did not panic");
 
             // Check that we can reset the instance and run a function.
             inst.reset().expect("instance resets");

--- a/lucet-runtime/lucet-runtime-tests/src/timeout.rs
+++ b/lucet-runtime/lucet-runtime-tests/src/timeout.rs
@@ -279,8 +279,8 @@ macro_rules! timeout_tests {
             t.join().unwrap();
         }
 
-        // after resetting, existing kill swtiches will not work. we can still run a function.
-        // FIXME KTM 2020-02-19: I did not see a way around this behavior. Bring this up in review.
+        /// This test ensures that we see a more informative kill error than `NotTerminable` when
+        /// attempting to terminate an instance that has been reset since issuing a kill switch.
         #[test]
         fn timeout_after_reset() {
             let module = mock_timeout_module();
@@ -290,7 +290,7 @@ macro_rules! timeout_tests {
                 .expect("instance can be created");
             let kill_switch = inst.kill_switch();
             inst.reset().expect("instance resets");
-            assert_eq!(kill_switch.terminate(), Err(KillError::NotTerminable));
+            assert_eq!(kill_switch.terminate(), Err(KillError::Invalid));
             run_onetwothree(&mut inst);
         }
 


### PR DESCRIPTION
## KillSwitch Terminates Pending Instances :no_good_woman: :x: 

### Overview

This updates the `lucet_runtime_internals::instance::execution` module so that `KillSwitch::terminate` will also terminate pending instances.

_Before_ if an instance was remotely terminated _before_ running, the result would be a `KillError::NotTerminable` error. Moreover, the instance would still run a guest context if `run` was called afterwards.

_Now_ if an instance is remotely terminated _before_ running, the result will now be `Ok(KillSuccess::Cancelled)` rather than a `KillError::NotTerminable` error. The instance will then enter a `Domain::Cancelled` state, and will not enter a guest region when `run` is called.

### Example

This is best summarized in a small snippet, assuming an initialized instance `inst`:

```rust
let inst: Instance = // ...
let kill_switch = inst.kill_switch();
assert_eq!(kill_switch.terminate(), Ok(KillSuccess::Cancelled));

// if terminated before running, the guest should not start at all
match inst.run("onetwothree", &[]) {
    Err(Error::RuntimeTerminated(TerminationDetails::Remote)) => {}
    res => panic!("unexpected result: {:?}", res),
}
```

### Implementation

In order for this to happen, it means that an instance is _now_ considered terminable when it is not running. In the original implementation, `terminable` was _really_ a flag that meant that the instance could be safely signalled. (_Recall: Depending on the current execution domain, it may or may not be safe to signal the instance to terminate_)

If the instance is now terminable when the guest context is not active (i.e. it has not yet started), we now need to indicate whether or not the instance can be safely signalled using the execution domain. This means touching some of the :ghost: fun :ghost: parts of `lucet`.

The **TLDR** of the changes here is:
* `Domain` now has two additional variants: `Pending`, and `Cancelled`. A new instance will be in the `Pending` state. If a kill switch calls its `terminate` method before the instance runs, that instance will be left in the `Cancelled` domain.
* Signal behavior now depends on `KillState::execution_domain`.
  * The `terminability` member is no longer semantically useful. (_This_ part, is the :hot_pepper: spicy part.) 
  * `lucet_context_activate` should call a Rust function to lock the domain `Mutex`, and update the execution domain before jumping to guest code. This means we now have a `enter_guest_region` that corresponds to the `exit_guest_region` that we use as a backstop callback.