### PR TITLE
Allow empty loop in `exit_guest_region`

### DIFF
--- a/lucet-runtime/lucet-runtime-internals/src/instance/execution.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/instance/execution.rs
@@ -138,7 +138,7 @@ pub unsafe extern "C" fn exit_guest_region(instance: *mut Instance) {
         // only signal-safe behavior.
         //
         // For now, hang indefinitely, waiting for the sigalrm to arrive.
-
+        #[allow(clippy::empty_loop)]
         loop {}
     }
 }


### PR DESCRIPTION
The comment above our empty loop explains why this is in fact a valid and reasoned thing to do.

["_they're good loops, Brent!_"](https://cdn.vox-cdn.com/thumbor/O0nPoKhrAvL3YSV_Vu_VgLShESM=/1400x0/filters:no_upscale()/cdn.vox-cdn.com/uploads/chorus_asset/file/11732213/Screen_Shot_2018_07_23_at_2.15.34_PM.png)