### PR TITLE
lucetc: don't use define_zeroinit for guest_start data

### DIFF
--- a/lucetc/src/compiler.rs
+++ b/lucetc/src/compiler.rs
@@ -291,7 +291,7 @@ fn write_startfunc_data<B: ClifBackend>(
             .declare_data("guest_start", Linkage::Export, false, None)
             .map_err(Error::MetadataSerializer)?;
         let mut ctx = DataContext::new();
-        ctx.define_zeroinit(8);
+        ctx.define(vec![0u8; 8].into_boxed_slice());
 
         let start_func = decls
             .get_func(func_ix)


### PR DESCRIPTION
After bytecodealliance/cranelift#1209, the semantics of
`DataContext::define_zeroinit` appear to only be for truly
zero-initialized data that won't have any relocations applied to it.
Since `guest_start` is clearly not that kind of data, move to using
`DataContext::define` instead.