### PR TITLE
upgrade to cranelift 0.60.0, lucetc error reporting fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,14 +327,14 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.59.0"
+version = "0.60.0"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.59.0"
+version = "0.60.0"
 dependencies = [
  "byteorder",
  "cranelift-bforest",
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.59.0"
+version = "0.60.0"
 dependencies = [
  "cranelift-codegen-shared",
  "cranelift-entity",
@@ -358,15 +358,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.59.0"
+version = "0.60.0"
 
 [[package]]
 name = "cranelift-entity"
-version = "0.59.0"
+version = "0.60.0"
 
 [[package]]
 name = "cranelift-faerie"
-version = "0.59.0"
+version = "0.60.0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -378,7 +378,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.59.0"
+version = "0.60.0"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -388,7 +388,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.59.0"
+version = "0.60.0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -399,7 +399,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.59.0"
+version = "0.60.0"
 dependencies = [
  "cranelift-codegen",
  "raw-cpuid 7.0.3",
@@ -408,7 +408,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.59.0"
+version = "0.60.0"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,6 +390,7 @@ dependencies = [
 name = "cranelift-module"
 version = "0.59.0"
 dependencies = [
+ "anyhow",
  "cranelift-codegen",
  "cranelift-entity",
  "log",
@@ -611,11 +612,10 @@ dependencies = [
 
 [[package]]
 name = "faerie"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74b9ed6159e4a6212c61d9c6a86bee01876b192a64accecf58d5b5ae3b667b52"
+checksum = "dfef65b0e94693295c5d2fe2506f0ee6f43465342d4b5331659936aee8b16084"
 dependencies = [
- "anyhow",
  "goblin 0.1.3",
  "indexmap",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1098,7 +1098,6 @@ name = "lucet-wasi-sdk"
 version = "0.6.2-dev"
 dependencies = [
  "anyhow",
- "failure",
  "lucet-module",
  "lucet-validate",
  "lucetc",

--- a/lucet-module/Cargo.toml
+++ b/lucet-module/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
-cranelift-entity = { path = "../wasmtime/cranelift/entity", version = "0.59.0" }
+cranelift-entity = { path = "../wasmtime/cranelift/entity", version = "0.60.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bincode = "1.1.4"

--- a/lucet-validate/Cargo.toml
+++ b/lucet-validate/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 [dependencies]
 clap = "2"
 witx = "0.8.3"
-cranelift-entity = { path = "../wasmtime/cranelift/entity", version = "0.59.0" }
+cranelift-entity = { path = "../wasmtime/cranelift/entity", version = "0.60.0" }
 thiserror = "1.0.4"
 wasmparser = "0.51.2"
 

--- a/lucet-wasi-sdk/Cargo.toml
+++ b/lucet-wasi-sdk/Cargo.toml
@@ -10,7 +10,6 @@ authors = ["Lucet team <lucet@fastly.com>"]
 edition = "2018"
 
 [dependencies]
-failure = "0.1"
 lucetc = { path = "../lucetc", version = "=0.6.2-dev" }
 lucet-module = { path = "../lucet-module", version = "=0.6.2-dev" }
 tempfile = "3.0"

--- a/lucetc/Cargo.toml
+++ b/lucetc/Cargo.toml
@@ -31,7 +31,7 @@ wasmparser = "0.51.2"
 clap="2.32"
 log = "0.4"
 env_logger = "0.6"
-faerie = "0.14.0"
+faerie = "0.15.0"
 goblin = "0.0.24"
 byteorder = "1.2"
 # precisely pin wasmonkey, because the shared dependency on parity-wasm is very sensitive

--- a/lucetc/Cargo.toml
+++ b/lucetc/Cargo.toml
@@ -16,13 +16,13 @@ path = "lucetc/main.rs"
 [dependencies]
 anyhow = "1"
 bincode = "1.1.4"
-cranelift-codegen = { path = "../wasmtime/cranelift/codegen", version = "0.59.0" }
-cranelift-entity = { path = "../wasmtime/cranelift/entity", version = "0.59.0" }
-cranelift-native = { path = "../wasmtime/cranelift/native", version = "0.59.0" }
-cranelift-frontend = { path = "../wasmtime/cranelift/frontend", version = "0.59.0" }
-cranelift-module = { path = "../wasmtime/cranelift/module", version = "0.59.0" }
-cranelift-faerie = { path = "../wasmtime/cranelift/faerie", version = "0.59.0" }
-cranelift-wasm = { path = "../wasmtime/cranelift/wasm", version = "0.59.0" }
+cranelift-codegen = { path = "../wasmtime/cranelift/codegen", version = "0.60.0" }
+cranelift-entity = { path = "../wasmtime/cranelift/entity", version = "0.60.0" }
+cranelift-native = { path = "../wasmtime/cranelift/native", version = "0.60.0" }
+cranelift-frontend = { path = "../wasmtime/cranelift/frontend", version = "0.60.0" }
+cranelift-module = { path = "../wasmtime/cranelift/module", version = "0.60.0" }
+cranelift-faerie = { path = "../wasmtime/cranelift/faerie", version = "0.60.0" }
+cranelift-wasm = { path = "../wasmtime/cranelift/wasm", version = "0.60.0" }
 target-lexicon = "0.10"
 lucet-module = { path = "../lucet-module", version = "=0.6.2-dev" }
 lucet-validate = { path = "../lucet-validate", version = "=0.6.2-dev" }

--- a/lucetc/src/error.rs
+++ b/lucetc/src/error.rs
@@ -27,12 +27,9 @@ pub enum Error {
     WasmValidation(#[from] wasmparser::BinaryReaderError),
     #[error("Wat input: {0}")]
     WatInput(#[from] wabt::Error),
-    //
+    #[error("Faerie artifact: {1}. {0:?}")]
+    FaerieArtifact(#[source] ArtifactError, String),
     // Cannot apply #[from] or #[source] to these error types due to missing traits.
-    #[error("Artifact: {1}. {0:?}")]
-    ArtifactError(ArtifactError, String),
-    #[error("Failure: {1}. {0:?}")]
-    Failure(anyhow::Error, String),
     #[error("Patcher: {0:?}")]
     Patcher(wasmonkey::WError),
     //

--- a/lucetc/src/output.rs
+++ b/lucetc/src/output.rs
@@ -115,7 +115,7 @@ impl ObjectFile {
             )
             .map_err(|source| {
                 let message = format!("Error declaring {}", stack_probe::STACK_PROBE_SYM);
-                Error::Failure(source, message)
+                Error::FaerieArtifact(source, message)
             })?;
 
         {
@@ -165,7 +165,7 @@ impl ObjectFile {
             .declare(FUNCTION_MANIFEST_SYM, Decl::data())
             .map_err(|source| {
                 let message = format!("Manifest error declaring {}", FUNCTION_MANIFEST_SYM);
-                Error::ArtifactError(source, message)
+                Error::FaerieArtifact(source, message)
             })?;
 
         let mut manifest_buf: Cursor<Vec<u8>> = Cursor::new(Vec::with_capacity(
@@ -210,7 +210,7 @@ impl ObjectFile {
             .define(FUNCTION_MANIFEST_SYM, manifest_buf.into_inner())
             .map_err(|source| {
                 let message = format!("Manifest error declaring {}", FUNCTION_MANIFEST_SYM);
-                Error::ArtifactError(source, message)
+                Error::FaerieArtifact(source, message)
             })?;
 
         Ok(())
@@ -225,7 +225,7 @@ impl ObjectFile {
                 .declare(&trap_sym, Decl::data())
                 .map_err(|source| {
                     let message = format!("Trap table error declaring {}", trap_sym);
-                    Error::ArtifactError(source, message)
+                    Error::FaerieArtifact(source, message)
                 })?;
 
             // write the actual function-level trap table
@@ -250,7 +250,7 @@ impl ObjectFile {
                 .define(&trap_sym, trap_site_bytes.to_vec())
                 .map_err(|source| {
                     let message = format!("Trap table error defining {}", trap_sym);
-                    Error::ArtifactError(source, message)
+                    Error::FaerieArtifact(source, message)
                 })?;
         }
 
@@ -265,7 +265,7 @@ impl ObjectFile {
         let file = File::create(path)?;
         self.artifact
             .write(file)
-            .map_err(|source| Error::Failure(source, "Write error".to_owned()))?;
+            .map_err(|source| Error::FaerieArtifact(source, "Write error".to_owned()))?;
         Ok(())
     }
 }
@@ -280,7 +280,7 @@ fn write_module(
     obj.declare(LUCET_MODULE_SYM, Decl::data().global())
         .map_err(|source| {
             let message = format!("Manifest error declaring {}", FUNCTION_MANIFEST_SYM);
-            Error::ArtifactError(source, message)
+            Error::FaerieArtifact(source, message)
         })?;
 
     let version =
@@ -313,7 +313,7 @@ fn write_module(
     obj.define(LUCET_MODULE_SYM, native_data.into_inner())
         .map_err(|source| {
             let message = format!("Manifest error defining {}", FUNCTION_MANIFEST_SYM);
-            Error::ArtifactError(source, message)
+            Error::FaerieArtifact(source, message)
         })?;
 
     Ok(())
@@ -351,7 +351,7 @@ pub(crate) fn write_relocated_slice(
             )
             .map_err(|source| {
                 let message = format!("Manifest error linking {}", to);
-                Error::Failure(source, message)
+                Error::FaerieArtifact(source, message)
             })?;
         }
         (Some(to), _len) => {
@@ -363,7 +363,7 @@ pub(crate) fn write_relocated_slice(
             })
             .map_err(|source| {
                 let message = format!("Manifest error linking {}", to);
-                Error::Failure(source, message)
+                Error::FaerieArtifact(source, message)
             })?;
         }
         (None, len) => {


### PR DESCRIPTION
Good news! `failure` is no longer used in Lucet. Most of this work was done by @froydnj in #447 .

This PR cleans up one straggler dependency in wasi-sdk that isnt needed, and points at some upstream improvements to `faerie` and `cranelift-module`'s error messages.

Along with that, we point wasmtime at the just-released `cranelift-v0.60.0` tag.