### PR TITLE
Add APIs to optionally disable automatic signal handler and sigstack installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Unreleased
 
+- Added `install_lucet_signal_handler()` and `remove_lucet_signal_handler()`, along with `Instance::ensure_signal_handler_installed()` and `Instance::ensure_sigstack_installed()` options to control the automatic installation and removal of signal handlers and alternate signal stacks. The default behaviors have not changed.
+
 ### 0.6.1 (2020-02-18)
 
 - Added metadata to compiled modules that record whether instruction counting instrumentation is present.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -996,6 +996,7 @@ dependencies = [
  "num-traits",
  "raw-cpuid 6.1.0",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]
@@ -2229,6 +2230,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1721cc8cf7d770cc4257872507180f35a4797272f5962f24c806af9e7faf52ab"
+dependencies = [
+ "cfg-if",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fbad39da2f9af1cae3016339ad7f2c7a9e870f12e8fd04c4fd7ef35b30c0d2b"
+dependencies = [
+ "quote 1.0.3",
+ "syn 1.0.16",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa83a9a47081cd522c09c81b31aec2c9273424976f922ad61c053b58350b715"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -903,6 +903,7 @@ name = "lucet-benchmarks"
 version = "0.6.2-dev"
 dependencies = [
  "criterion",
+ "libc",
  "lucet-module",
  "lucet-runtime",
  "lucet-runtime-internals",

--- a/benchmarks/lucet-benchmarks/Cargo.toml
+++ b/benchmarks/lucet-benchmarks/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 
 [dependencies]
 criterion = "0.3.0"
+libc = "0.2.65"
 lucetc = { path = "../../lucetc" }
 lucet-module = { path = "../../lucet-module" }
 lucet-runtime = { path = "../../lucet-runtime" }

--- a/lucet-runtime/lucet-runtime-internals/Cargo.toml
+++ b/lucet-runtime/lucet-runtime-internals/Cargo.toml
@@ -26,6 +26,7 @@ num-derive = "0.3.0"
 num-traits = "0.2"
 raw-cpuid = "6.0.0"
 thiserror = "1.0.4"
+tracing = "0.1.12"
 
 # This is only a dependency to ensure that other crates don't pick a newer version as a transitive
 # dependency. `0.1.3 < getrandom <= 0.1.6` cause `lazy_static` to pull in spinlock implementations

--- a/lucet-runtime/lucet-runtime-internals/src/alloc/tests.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/alloc/tests.rs
@@ -8,9 +8,12 @@ macro_rules! alloc_tests {
         use $crate::context::{Context, ContextHandle};
         use $crate::error::Error;
         use $crate::instance::InstanceInternal;
-        use $crate::module::{GlobalValue, HeapSpec, MockModuleBuilder};
+        use $crate::module::{
+            FunctionPointer, GlobalValue, HeapSpec, MockExportBuilder, MockModuleBuilder, Module,
+        };
         use $crate::region::Region;
         use $crate::val::Val;
+        use $crate::vmctx::lucet_vmctx;
 
         const LIMITS_HEAP_MEM_SIZE: usize = 16 * 64 * 1024;
         const LIMITS_HEAP_ADDRSPACE_SIZE: usize = 8 * 1024 * 1024;
@@ -715,6 +718,17 @@ macro_rules! alloc_tests {
             assert_eq!(region.used_slots(), 0);
         }
 
+        fn do_nothing_module() -> Arc<dyn Module> {
+            extern "C" fn do_nothing(_vmctx: *mut lucet_vmctx) -> () {}
+
+            MockModuleBuilder::new()
+                .with_export_func(MockExportBuilder::new(
+                    "do_nothing",
+                    FunctionPointer::from_usize(do_nothing as usize),
+                ))
+                .build()
+        }
+
         #[test]
         fn reject_sigstack_smaller_than_min() {
             if MINSIGSTKSZ == 0 {
@@ -727,8 +741,11 @@ macro_rules! alloc_tests {
                     * host_page_size(),
                 ..Limits::default()
             };
-            let res = TestRegion::create(1, &limits);
-            match res {
+            let region = TestRegion::create(1, &limits).expect("region created");
+            let mut inst = region
+                .new_instance(do_nothing_module())
+                .expect("new_instance succeeds");
+            match inst.run("do_nothing", &[]) {
                 Err(Error::InvalidArgument(
                     "signal stack size must be at least MINSIGSTKSZ (defined in <signal.h>)",
                 )) => (),
@@ -750,8 +767,11 @@ macro_rules! alloc_tests {
                 signal_stack_size: 8192,
                 ..Limits::default()
             };
-            let res = TestRegion::create(1, &limits);
-            match res {
+            let region = TestRegion::create(1, &limits).expect("region created");
+            let mut inst = region
+                .new_instance(do_nothing_module())
+                .expect("new_instance succeeds");
+            match inst.run("do_nothing", &[]) {
                 Err(Error::InvalidArgument(
                     "signal stack size must be at least 12KiB for debug builds",
                 )) => (),

--- a/lucet-runtime/lucet-runtime-internals/src/instance.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/instance.rs
@@ -726,8 +726,8 @@ impl Instance {
     /// The automatically-installed signal stack uses space allocated in the instance's `Region`,
     /// sized according to the `signal_stack_size` field of the region's `Limits`.
     ///
-    /// If you wish to instead provide your own signal stack, the stack size must be at least as big
-    /// as `DEFAULT_SIGNAL_STACK_SIZE`, which varies depending on platform and optimization level.
+    /// If you wish to instead provide your own signal stack, we recommend using a stack of size
+    /// `DEFAULT_SIGNAL_STACK_SIZE`, which varies depending on platform and optimization level.
     ///
     /// Signal stacks are installed on a per-thread basis, so any thread that runs this instance
     /// must have a signal stack installed.

--- a/lucet-runtime/lucet-runtime-internals/src/instance.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/instance.rs
@@ -250,6 +250,12 @@ pub struct Instance {
         ) -> SignalBehavior,
     >,
 
+    /// Whether to ensure the Lucet signal handler is installed when running this instance.
+    ensure_signal_handler_installed: bool,
+
+    /// Whether to install an alternate signal stack while the instance is running.
+    ensure_sigstack_installed: bool,
+
     /// Pointer to the function used as the entrypoint (for use in backtraces)
     entrypoint: Option<FunctionPointer>,
 
@@ -690,6 +696,52 @@ impl Instance {
         self.c_fatal_handler = Some(handler);
     }
 
+    /// Set whether the Lucet signal handler is installed when running or resuming this instance
+    /// (`true` by default).
+    ///
+    /// If this is `true`, the Lucet runtime checks whether its signal handler is installed whenever
+    /// an instance runs, installing it if it is not present, and uninstalling it when there are no
+    /// longer any Lucet instances running. If this is `false`, that check is disabled, which can
+    /// improve performance when running or resuming an instance.
+    ///
+    /// Use `install_lucet_signal_handler()` and `remove_lucet_signal_handler()` to manually install
+    /// or remove the signal handler.
+    ///
+    /// # Safety
+    ///
+    /// If the Lucet signal handler is not installed when an instance runs, WebAssembly traps such
+    /// as division by zero, assertion failures, or out-of-bounds memory access will raise signals
+    /// to the default signal handlers, usually causing the entire process to crash.
+    pub fn ensure_signal_handler_installed(&mut self, ensure: bool) {
+        self.ensure_signal_handler_installed = ensure;
+    }
+
+    /// Set whether an alternate signal stack is installed for the current thread when running or
+    /// resuming this instance (`true` by default).
+    ///
+    /// If this is `true`, the Lucet runtime installs an alternate signal stack whenever an instance
+    /// runs, and uninstalls it afterwards. If this is `false`, the signal stack is not
+    /// automatically manipulated.
+    ///
+    /// The automatically-installed signal stack uses space allocated in the instance's `Region`,
+    /// sized according to the `signal_stack_size` field of the region's `Limits`.
+    ///
+    /// If you wish to instead provide your own signal stack, the stack size must be at least as big
+    /// as `DEFAULT_SIGNAL_STACK_SIZE`, which varies depending on platform and optimization level.
+    ///
+    /// Signal stacks are installed on a per-thread basis, so any thread that runs this instance
+    /// must have a signal stack installed.
+    ///
+    /// # Safety
+    ///
+    /// If an alternate signal stack is not installed when an instance runs, there may not be enough
+    /// stack space for the Lucet signal handler to run. If the signal handler runs out of stack
+    /// space, a double fault could occur and crash the entire process, or the program could
+    /// continue with corrupted memory.
+    pub fn ensure_sigstack_installed(&mut self, ensure: bool) {
+        self.ensure_sigstack_installed = ensure;
+    }
+
     pub fn kill_switch(&self) -> KillSwitch {
         KillSwitch::new(Arc::downgrade(&self.kill_state))
     }
@@ -759,6 +811,8 @@ impl Instance {
             fatal_handler: default_fatal_handler,
             c_fatal_handler: None,
             signal_handler: Box::new(signal_handler_none) as Box<SignalHandler>,
+            ensure_signal_handler_installed: true,
+            ensure_sigstack_installed: true,
             entrypoint: None,
             resumed_val: None,
             _padding: (),

--- a/lucet-runtime/lucet-runtime-internals/src/instance/signals.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/instance/signals.rs
@@ -12,12 +12,15 @@ use nix::sys::signal::{
     pthread_sigmask, raise, sigaction, SaFlags, SigAction, SigHandler, SigSet, SigmaskHow, Signal,
 };
 use std::mem::MaybeUninit;
+use std::ops::DerefMut;
 use std::panic;
 use std::sync::{Arc, Mutex};
 
 lazy_static! {
     // TODO: work out an alternative to this that is signal-safe for `reraise_host_signal_in_handler`
     static ref LUCET_SIGNAL_STATE: Mutex<Option<SignalState>> = Mutex::new(None);
+
+    static ref SIGNAL_HANDLER_MANUALLY_INSTALLED: Mutex<bool> = Mutex::new(false);
 }
 
 /// The value returned by
@@ -50,67 +53,139 @@ pub fn signal_handler_none(
     SignalBehavior::Default
 }
 
+/// Install the Lucet signal handler for the current process.
+///
+/// This happens automatically by default, but must be run manually before running instances where
+/// `instance.ensure_signal_handler_installed(false)` has been set.
+///
+/// Calling this function more than once without first calling `remove_lucet_signal_handler()` has
+/// no additional effect.
+pub fn install_lucet_signal_handler() {
+    let mut installed = SIGNAL_HANDLER_MANUALLY_INSTALLED.lock().unwrap();
+    if !*installed {
+        increment_lucet_signal_state();
+        *installed = true;
+    }
+}
+
+/// Increment the count of currently-running instances, and install the signal handler if it is
+/// currently missing.
+///
+/// The count only reflects running instances with `ensure_signal_handler_installed` set to `true`.
+fn increment_lucet_signal_state() {
+    let mut ostate = LUCET_SIGNAL_STATE.lock().unwrap();
+    if let Some(state) = ostate.deref_mut() {
+        state.counter += 1;
+    } else {
+        unsafe {
+            setup_guest_signal_state(&mut ostate);
+        }
+    }
+}
+
+/// Remove the Lucet signal handler for the current process, restoring the signal handler that was
+/// present when `install_lucet_signal_handler()` was called.
+///
+/// Calling this function without first calling `install_lucet_signal_handler()` has no effect.
+pub fn remove_lucet_signal_handler() {
+    let mut installed = SIGNAL_HANDLER_MANUALLY_INSTALLED.lock().unwrap();
+    if *installed {
+        decrement_lucet_signal_state();
+        *installed = false;
+    }
+}
+
+/// Decrement the count of currently-running instances, and remove the signal handler if the count
+/// reaches zero.
+///
+/// The count only reflects running instances with `ensure_signal_handler_installed` set to `true`.
+fn decrement_lucet_signal_state() {
+    let mut ostate = LUCET_SIGNAL_STATE.lock().unwrap();
+    let counter_zero = if let Some(state) = ostate.deref_mut() {
+        state.counter -= 1;
+        if state.counter == 0 {
+            unsafe {
+                restore_host_signal_state(state);
+            }
+            true
+        } else {
+            false
+        }
+    } else {
+        panic!("signal handlers weren't installed at decrement");
+    };
+    if counter_zero {
+        *ostate = None;
+    }
+}
+
 impl Instance {
     pub(crate) fn with_signals_on<F, R>(&mut self, f: F) -> Result<R, Error>
     where
         F: FnOnce(&mut Instance) -> Result<R, Error>,
     {
-        // Set up the signal stack for this thread. Note that because signal stacks are per-thread,
-        // rather than per-process, we do this for every run, while the signal handler is installed
-        // only once per process.
-        let guest_sigstack = SigStack::new(
-            self.alloc.slot().sigstack,
-            SigStackFlags::empty(),
-            self.alloc.slot().limits.signal_stack_size,
-        );
-        let previous_sigstack = unsafe { sigaltstack(Some(guest_sigstack)) }
-            .expect("enabling or changing the signal stack succeeds");
-        if let Some(previous_sigstack) = previous_sigstack {
-            assert!(
-                !previous_sigstack
-                    .flags()
-                    .contains(SigStackFlags::SS_ONSTACK),
-                "an instance was created with a signal stack"
+        let previous_sigstack = if self.ensure_sigstack_installed {
+            // Set up the signal stack for this thread. Note that because signal stacks are per-thread,
+            // rather than per-process, we do this for every run, while the signal handler is installed
+            // only once per process.
+            let guest_sigstack = SigStack::new(
+                self.alloc.slot().sigstack,
+                SigStackFlags::empty(),
+                self.alloc.slot().limits.signal_stack_size,
+            );
+            let previous_sigstack = unsafe { sigaltstack(Some(guest_sigstack)) }
+                .expect("enabling or changing the signal stack succeeds");
+            if let Some(previous_sigstack) = previous_sigstack {
+                assert!(
+                    !previous_sigstack
+                        .flags()
+                        .contains(SigStackFlags::SS_ONSTACK),
+                    "an instance was created with a signal stack"
+                );
+            }
+            previous_sigstack
+        } else {
+            // in debug mode only, make sure the installed sigstack is of sufficient size
+            if cfg!(debug_assertions) {
+                unsafe {
+                    let mut current_sigstack = MaybeUninit::<libc::stack_t>::uninit();
+                    libc::sigaltstack(std::ptr::null(), current_sigstack.as_mut_ptr());
+                    let current_sigstack = current_sigstack.assume_init();
+                    debug_assert!(
+                        current_sigstack.ss_size >= crate::alloc::DEFAULT_SIGNAL_STACK_SIZE,
+                        "signal stack must be large enough"
+                    );
+                }
+            }
+            None
+        };
+
+        if self.ensure_signal_handler_installed {
+            increment_lucet_signal_state();
+        } else if cfg!(debug_assertions) {
+            // in debug mode only, make sure the signal state is already present
+            debug_assert!(
+                LUCET_SIGNAL_STATE.lock().unwrap().is_some(),
+                "signal handler is installed"
             );
         }
-        let mut ostate = LUCET_SIGNAL_STATE.lock().unwrap();
-        if let Some(ref mut state) = *ostate {
-            state.counter += 1;
-        } else {
-            unsafe {
-                setup_guest_signal_state(&mut ostate);
-            }
-        }
-        drop(ostate);
 
         // run the body
         let res = f(self);
 
-        let mut ostate = LUCET_SIGNAL_STATE.lock().unwrap();
-        let counter_zero = if let Some(ref mut state) = *ostate {
-            state.counter -= 1;
-            if state.counter == 0 {
-                unsafe {
-                    restore_host_signal_state(state);
-                }
-                true
-            } else {
-                false
-            }
-        } else {
-            panic!("signal handlers weren't installed at instance exit");
-        };
-        if counter_zero {
-            *ostate = None;
+        if self.ensure_signal_handler_installed {
+            decrement_lucet_signal_state();
         }
 
-        unsafe {
-            // restore the host signal stack for this thread
-            if !altstack_flags()
-                .expect("the current stack flags could be retrieved")
-                .contains(SigStackFlags::SS_ONSTACK)
-            {
-                sigaltstack(previous_sigstack).expect("sigaltstack restoration succeeds");
+        if self.ensure_sigstack_installed {
+            unsafe {
+                // restore the host signal stack for this thread
+                if !altstack_flags()
+                    .expect("the current stack flags could be retrieved")
+                    .contains(SigStackFlags::SS_ONSTACK)
+                {
+                    sigaltstack(previous_sigstack).expect("sigaltstack restoration succeeds");
+                }
             }
         }
 
@@ -353,7 +428,7 @@ unsafe fn reraise_host_signal_in_handler(
     let saved_handler = {
         // TODO: avoid taking a mutex here, probably by having some static muts just for this
         // function
-        if let Some(ref state) = *LUCET_SIGNAL_STATE.lock().unwrap() {
+        if let Some(state) = LUCET_SIGNAL_STATE.lock().unwrap().as_ref() {
             match sig {
                 Signal::SIGBUS => state.saved_sigbus.clone(),
                 Signal::SIGFPE => state.saved_sigfpe.clone(),

--- a/lucet-runtime/lucet-runtime-tests/src/guest_fault.rs
+++ b/lucet-runtime/lucet-runtime-tests/src/guest_fault.rs
@@ -322,6 +322,9 @@ macro_rules! guest_fault_tests {
         #[test]
         /// Test that the Lucet signal handler runs correctly when the sigstack is provided by the
         /// caller, rather than from the `Region`.
+        ///
+        /// The `signal_stack_size` of the `Region`'s limits is also set to zero, to show that we no
+        /// longer validate the signal stack size on region creation.
         fn illegal_instr_manual_sigstack() {
             use libc::*;
             use std::mem::MaybeUninit;
@@ -340,8 +343,12 @@ macro_rules! guest_fault_tests {
                 };
 
                 let module = mock_traps_module();
+                let limits_no_sigstack = Limits {
+                    signal_stack_size: 0,
+                    ..Limits::default()
+                };
                 let region =
-                    TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    TestRegion::create(1, &limits_no_sigstack).expect("region can be created");
                 let mut inst = region
                     .new_instance(module)
                     .expect("instance can be created");

--- a/lucet-runtime/src/lib.rs
+++ b/lucet-runtime/src/lib.rs
@@ -335,11 +335,45 @@
 //! signal handler, you can use [`install_lucet_signal_handler()`][install-handler] and
 //! [`remove_lucet_signal_handler()`][remove-handler], and disable the automatic installation and
 //! removal on a per-instance basis by setting
-//! [instance.`ensure_signal_handler_installed(false)`][instance-ensure-installed]
+//! [instance.`ensure_signal_handler_installed(false)`][instance-ensure-handler]
 //!
 //! [install-handler]: fn.install_lucet_signal_handler.html
 //! [remove-handler]: fn.remove_lucet_signal_handler.html
-//! [instance-ensure-installed]: struct.Instance.html#method.ensure_signal_handler_installed.
+//! [instance-ensure-handler]: struct.Instance.html#method.ensure_signal_handler_installed
+//!
+//! ## Signal Handler Stacks
+//!
+//! Lucet instances must run on threads that have an [alternate signal stack][sigaltstack]
+//! installed, otherwise a WebAssembly program that overflows its stack will cause a double fault,
+//! crashing the entire process. By default, Lucet instances install an alternate signal stack on
+//! their thread before running, and reinstall the preëxisting signal stack on exit. Space for this
+//! stack is reserved within the Lucet `Region` as defined by the `signal_stack_size` field of
+//! `Limits`. If `signal_stack_size` isn't large enough (see below), the automatic installation will
+//! fail with an `Error::InvalidArgument` value.
+//!
+//! For advanced uses, the automatic signal stack installation can be disabled on a per-instance
+//! basis by setting [`instance::ensure_sigstack_installed(false)`][instance-ensure-sigstack]. In
+//! debug mode, the runtime will still check that an alternate signal stack is present and of
+//! sufficient size, but in release mode no checks or extra system calls will be performed.
+//!
+//! [sigaltstack]: http://man7.org/linux/man-pages/man2/sigaltstack.2.html
+//! [instance-ensure-sigstack]: struct.Instance.html#method.ensure_sigstack_installed
+//!
+//! ### Signal Stack Size
+//!
+//! The alternate signal stack must be of a sufficient size to avoid stack overflows when running
+//! the signal handler, and to satisfy [`sigaltstack`][sigaltstack]'s requirements. This library
+//! provides the constant [`DEFAULT_SIGNAL_STACK_SIZE`][default-sigstack-size] as a recommendation
+//! for signal stack size, and uses this value as the default when creating `Limits`.
+//!
+//! With Rust optimizations enabled, as with `cargo build --release`, the `sigaltstack` requirement
+//! of `MINSIGSTKSZ` (defined in `<signal.h>`) provides sufficient space for the signal handler.
+//!
+//! With no optimizations, as with `cargo build`, the signal stack size must be at least 12KiB
+//! according to our experiments; since this is dependent on compiler-defined memory layout choices,
+//! this number could change between Lucet releases or even Rust compiler versions.
+//!
+//! [default-sigstack-size]: constant.DEFAULT_SIGNAL_STACK_SIZE.html
 
 #![deny(bare_trait_objects)]
 

--- a/lucet-runtime/src/lib.rs
+++ b/lucet-runtime/src/lib.rs
@@ -330,6 +330,16 @@
 //! not currently running a Lucet instance, the saved host signal handler is called. This means
 //! that, for example, a `SIGSEGV` on a non-Lucet thread of a host program will still likely abort
 //! the entire process.
+//!
+//! For advanced uses that require manual control over the installation and removal of the Lucet
+//! signal handler, you can use [`install_lucet_signal_handler()`][install-handler] and
+//! [`remove_lucet_signal_handler()`][remove-handler], and disable the automatic installation and
+//! removal on a per-instance basis by setting
+//! [instance.`ensure_signal_handler_installed(false)`][instance-ensure-installed]
+//!
+//! [install-handler]: fn.install_lucet_signal_handler.html
+//! [remove-handler]: fn.remove_lucet_signal_handler.html
+//! [instance-ensure-installed]: struct.Instance.html#method.ensure_signal_handler_installed.
 
 #![deny(bare_trait_objects)]
 
@@ -340,8 +350,11 @@ extern crate self as lucet_runtime;
 pub mod c_api;
 
 pub use lucet_module::{PublicKey, TrapCode};
-pub use lucet_runtime_internals::alloc::Limits;
+pub use lucet_runtime_internals::alloc::{Limits, DEFAULT_SIGNAL_STACK_SIZE};
 pub use lucet_runtime_internals::error::Error;
+pub use lucet_runtime_internals::instance::signals::{
+    install_lucet_signal_handler, remove_lucet_signal_handler,
+};
 pub use lucet_runtime_internals::instance::{
     FaultDetails, Instance, InstanceHandle, KillError, KillSuccess, KillSwitch, RunResult,
     SignalBehavior, TerminationDetails, YieldedVal,


### PR DESCRIPTION
These new APIs allow advanced use cases to control the installation and removal of the signal handler and alternate signal stack manually. This can be useful for reducing the number of synchronization points and syscalls required when running an instance.

Adds some tests to everyone's favorite `guest_fault` to make sure signals can in fact still be handled under these manual regimes, and adds some variants to the parallel benchmarks to show that manual control does in fact speed things up ever so slightly.

This partially addresses #281, since `Instance::run()` is faster when this automation is disabled.