### PR TITLE
move to using cranelift-module to emit structures rather than faerie

### DIFF
--- a/lucetc/src/compiler.rs
+++ b/lucetc/src/compiler.rs
@@ -290,7 +290,13 @@ impl<'a> Compiler<'a> {
                 })?;
         }
 
-        stack_probe::declare_metadata(&mut self.decls, &mut self.clif_module).unwrap();
+        let probe_id = stack_probe::declare(&mut self.decls, &mut self.clif_module)?;
+        let probe_func = self.decls.get_func(probe_id).unwrap();
+        self.clif_module.define_function_bytes(
+            probe_func.name.as_funcid().unwrap(),
+            stack_probe::STACK_PROBE_BINARY,
+            stack_probe::trap_sites(),
+        )?;
 
         let module_data_bytes = self.module_data()?.serialize()?;
 

--- a/lucetc/src/output.rs
+++ b/lucetc/src/output.rs
@@ -40,9 +40,7 @@ pub struct ObjectFile {
     artifact: Artifact,
 }
 impl ObjectFile {
-    pub fn new(
-        product: FaerieProduct,
-    ) -> Result<Self, Error> {
+    pub fn new(product: FaerieProduct) -> Result<Self, Error> {
         let obj = Self {
             artifact: product.artifact,
         };

--- a/lucetc/src/output.rs
+++ b/lucetc/src/output.rs
@@ -1,18 +1,12 @@
 use crate::error::Error;
 use crate::name::Name;
-use crate::table::TABLE_SYM;
-use byteorder::{LittleEndian, WriteBytesExt};
 use cranelift_codegen::{ir, isa};
 use cranelift_faerie::FaerieProduct;
-use faerie::{Artifact, Decl, Link};
-use lucet_module::{
-    SerializedModule, VersionInfo, LUCET_MODULE_SYM, MODULE_DATA_SYM,
-};
+use faerie::Artifact;
 use std::collections::HashMap;
 use std::fs::File;
-use std::io::{Cursor, Write};
+use std::io::Write;
 use std::path::Path;
-use target_lexicon::BinaryFormat;
 
 pub(crate) const FUNCTION_MANIFEST_SYM: &str = "lucet_function_manifest";
 
@@ -48,21 +42,10 @@ pub struct ObjectFile {
 impl ObjectFile {
     pub fn new(
         product: FaerieProduct,
-        module_data_len: usize,
-        function_manifest_len: usize,
-        table_manifest_len: usize,
     ) -> Result<Self, Error> {
-        let mut obj = Self {
+        let obj = Self {
             artifact: product.artifact,
         };
-
-        // And now write out the actual structure tying together all the data in this module.
-        write_module(
-            module_data_len,
-            table_manifest_len,
-            function_manifest_len,
-            &mut obj.artifact,
-        )?;
 
         Ok(obj)
     }
@@ -78,117 +61,4 @@ impl ObjectFile {
             .map_err(|source| Error::FaerieArtifact(source, "Write error".to_owned()))?;
         Ok(())
     }
-}
-
-fn write_module(
-    module_data_len: usize,
-    table_manifest_len: usize,
-    function_manifest_len: usize,
-    obj: &mut Artifact,
-) -> Result<(), Error> {
-    let mut native_data = Cursor::new(Vec::with_capacity(std::mem::size_of::<SerializedModule>()));
-    obj.declare(LUCET_MODULE_SYM, Decl::data().global())
-        .map_err(|source| {
-            let message = format!("Manifest error declaring {}", FUNCTION_MANIFEST_SYM);
-            Error::FaerieArtifact(source, message)
-        })?;
-
-    let version =
-        VersionInfo::current(include_str!(concat!(env!("OUT_DIR"), "/commit_hash")).as_bytes());
-
-    version.write_to(&mut native_data)?;
-
-    write_relocated_slice(
-        obj,
-        &mut native_data,
-        LUCET_MODULE_SYM,
-        Some(MODULE_DATA_SYM),
-        module_data_len as u64,
-    )?;
-    write_relocated_slice(
-        obj,
-        &mut native_data,
-        LUCET_MODULE_SYM,
-        Some(TABLE_SYM),
-        table_manifest_len as u64,
-    )?;
-    write_relocated_slice(
-        obj,
-        &mut native_data,
-        LUCET_MODULE_SYM,
-        Some(FUNCTION_MANIFEST_SYM),
-        function_manifest_len as u64,
-    )?;
-
-    obj.define(LUCET_MODULE_SYM, native_data.into_inner())
-        .map_err(|source| {
-            let message = format!("Manifest error defining {}", FUNCTION_MANIFEST_SYM);
-            Error::FaerieArtifact(source, message)
-        })?;
-
-    Ok(())
-}
-
-pub(crate) fn write_relocated_slice(
-    obj: &mut Artifact,
-    buf: &mut Cursor<Vec<u8>>,
-    from: &str,
-    to: Option<&str>,
-    len: u64,
-) -> Result<(), Error> {
-    match (to, len) {
-        (Some(to), 0) => {
-            // This is an imported slice of unknown size
-            let absolute_reloc = match obj.target.binary_format {
-                BinaryFormat::Elf => faerie::artifact::Reloc::Raw {
-                    reloc: goblin::elf::reloc::R_X86_64_64,
-                    addend: 0,
-                },
-                BinaryFormat::Macho => faerie::artifact::Reloc::Raw {
-                    reloc: goblin::mach::relocation::X86_64_RELOC_UNSIGNED as u32,
-                    addend: 0,
-                },
-                _ => panic!("Unsupported target format!"),
-            };
-
-            obj.link_with(
-                Link {
-                    from,
-                    to,
-                    at: buf.position(),
-                },
-                absolute_reloc,
-            )
-            .map_err(|source| {
-                let message = format!("Manifest error linking {}", to);
-                Error::FaerieArtifact(source, message)
-            })?;
-        }
-        (Some(to), _len) => {
-            // This is a local buffer of known size
-            obj.link(Link {
-                from, // the data at `from` + `at` (eg. FUNCTION_MANIFEST_SYM)
-                to,   // is a reference to `to`    (eg. fn_name)
-                at: buf.position(),
-            })
-            .map_err(|source| {
-                let message = format!("Manifest error linking {}", to);
-                Error::FaerieArtifact(source, message)
-            })?;
-        }
-        (None, len) => {
-            // There's actually no relocation to add, because there's no slice to put here.
-            //
-            // Since there's no slice, its length must be zero.
-            assert!(
-                len == 0,
-                "Invalid slice: no data, but there are more than zero bytes of it"
-            );
-        }
-    }
-
-    buf.write_u64::<LittleEndian>(0).unwrap();
-    buf.write_u64::<LittleEndian>(len).unwrap();
-
-    Ok(())
 }

--- a/lucetc/src/output.rs
+++ b/lucetc/src/output.rs
@@ -1,14 +1,14 @@
 use crate::error::Error;
 use crate::name::Name;
 use crate::table::TABLE_SYM;
-use crate::traps::{translate_trapcode, trap_sym_for_func};
+use crate::traps::trap_sym_for_func;
 use byteorder::{LittleEndian, WriteBytesExt};
 use cranelift_codegen::{ir, isa};
 use cranelift_faerie::traps::FaerieTrapManifest;
 use cranelift_faerie::FaerieProduct;
 use faerie::{Artifact, Decl, Link};
 use lucet_module::{
-    FunctionSpec, SerializedModule, TrapSite, VersionInfo, LUCET_MODULE_SYM, MODULE_DATA_SYM,
+    FunctionSpec, SerializedModule, VersionInfo, LUCET_MODULE_SYM, MODULE_DATA_SYM,
 };
 use std::collections::HashMap;
 use std::fs::File;
@@ -85,7 +85,6 @@ impl ObjectFile {
             }
         }
 
-        obj.write_trap_tables(&trap_manifest)?;
         obj.write_function_manifest(function_manifest.as_slice())?;
 
         // And now write out the actual structure tying together all the data in this module.
@@ -157,47 +156,6 @@ impl ObjectFile {
                 let message = format!("Manifest error declaring {}", FUNCTION_MANIFEST_SYM);
                 Error::FaerieArtifact(source, message)
             })?;
-
-        Ok(())
-    }
-
-    fn write_trap_tables(&mut self, manifest: &FaerieTrapManifest) -> Result<(), Error> {
-        for sink in manifest.sinks.iter() {
-            let func_sym = &sink.name;
-            let trap_sym = trap_sym_for_func(func_sym);
-
-            self.artifact
-                .declare(&trap_sym, Decl::data())
-                .map_err(|source| {
-                    let message = format!("Trap table error declaring {}", trap_sym);
-                    Error::FaerieArtifact(source, message)
-                })?;
-
-            // write the actual function-level trap table
-            let traps: Vec<TrapSite> = sink
-                .sites
-                .iter()
-                .map(|site| TrapSite {
-                    offset: site.offset,
-                    code: translate_trapcode(site.code),
-                })
-                .collect();
-
-            let trap_site_bytes = unsafe {
-                std::slice::from_raw_parts(
-                    traps.as_ptr() as *const u8,
-                    traps.len() * std::mem::size_of::<TrapSite>(),
-                )
-            };
-
-            // and write the function trap table into the object
-            self.artifact
-                .define(&trap_sym, trap_site_bytes.to_vec())
-                .map_err(|source| {
-                    let message = format!("Trap table error defining {}", trap_sym);
-                    Error::FaerieArtifact(source, message)
-                })?;
-        }
 
         Ok(())
     }

--- a/lucetc/src/table.rs
+++ b/lucetc/src/table.rs
@@ -133,7 +133,9 @@ pub fn write_table_data<B: ClifBackend>(
 
     table_ctx.define(inner.into_boxed_slice());
 
-    let table_id = decls.get_tables_list_name().as_dataid()
+    let table_id = decls
+        .get_tables_list_name()
+        .as_dataid()
         .expect("lucet_tables is declared as data");
     clif_module.define_data(table_id, &table_ctx)?;
     Ok((table_id, table_len))

--- a/lucetc/src/table.rs
+++ b/lucetc/src/table.rs
@@ -4,7 +4,7 @@ use crate::module::UniqueFuncIndex;
 use crate::pointer::NATIVE_POINTER_SIZE;
 use byteorder::{LittleEndian, WriteBytesExt};
 use cranelift_codegen::entity::EntityRef;
-use cranelift_module::{Backend as ClifBackend, DataContext, Module as ClifModule};
+use cranelift_module::{Backend as ClifBackend, DataContext, DataId, Module as ClifModule};
 use cranelift_wasm::{TableElementType, TableIndex};
 use std::io::Cursor;
 
@@ -52,7 +52,7 @@ fn table_elements(decl: &TableDecl<'_>) -> Result<Vec<Elem>, Error> {
 pub fn write_table_data<B: ClifBackend>(
     clif_module: &mut ClifModule<B>,
     decls: &ModuleDecls<'_>,
-) -> Result<usize, Error> {
+) -> Result<(DataId, usize), Error> {
     let mut tables_vec = Cursor::new(Vec::new());
     let mut table_ctx = DataContext::new();
     let mut table_len = 0;
@@ -133,12 +133,8 @@ pub fn write_table_data<B: ClifBackend>(
 
     table_ctx.define(inner.into_boxed_slice());
 
-    clif_module.define_data(
-        decls
-            .get_tables_list_name()
-            .as_dataid()
-            .expect("lucet_tables is declared as data"),
-        &table_ctx,
-    )?;
-    Ok(table_len)
+    let table_id = decls.get_tables_list_name().as_dataid()
+        .expect("lucet_tables is declared as data");
+    clif_module.define_data(table_id, &table_ctx)?;
+    Ok((table_id, table_len))
 }


### PR DESCRIPTION
This doesn't completely move to using `object`, but it seems like a good stopping point for discussion.

The only real ugliness is the `traps_to_module_traps`/`write_trap_table` division.  Ideally, these would be a single function, but the borrow checker says that the `ModuleCompiledFunction` that comes out of `Module::define_function` represents a borrow on the `Module` itself, so you can't have a single function that takes `&mut Module` and `&ModuleCompiledFunction`.  (`ModuleCompiledFunction` isn't actually exported, either, which seems like an oversight.) Ergo, we have to do a dance to satisfy the borrow checker.  Maybe it would have been a good idea to just make `Module::define_function` take a trap sink instead of trying to have `cranelift-module` backends manage the traps themselves, as suggested in @bytecodealliance/wasmtime#1184.