### PR TITLE
Fix lucetc reporting the number of tables incorrectly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ test-except-fuzz: test-packages
 	# run the benchmarks in debug mode
 	cargo test --benches -p lucet-benchmarks -- --test
 	helpers/lucet-toolchain-tests/signature.sh
+	helpers/lucet-toolchain-tests/objdump.sh
 
 # run a single seed through the fuzzer to stave off bitrot
 .PHONY: test-fuzz

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ test-except-fuzz: test-packages
 	# run the benchmarks in debug mode
 	cargo test --benches -p lucet-benchmarks -- --test
 	helpers/lucet-toolchain-tests/signature.sh
+	cargo build -p lucet-objdump
 	helpers/lucet-toolchain-tests/objdump.sh
 
 # run a single seed through the fuzzer to stave off bitrot

--- a/helpers/lucet-toolchain-tests/objdump.sh
+++ b/helpers/lucet-toolchain-tests/objdump.sh
@@ -1,0 +1,36 @@
+#! /bin/sh
+
+LUCET_DIR="."
+TMPDIR="$(mktemp -d)"
+
+if [ -x "${LUCET_DIR}/target/release/lucetc" ]; then
+    LUCETC="${LUCET_DIR}/target/release/lucetc"
+elif [ -x "${LUCET_DIR}/target/debug/lucetc" ]; then
+    LUCETC="${LUCET_DIR}/target/debug/lucetc"
+else
+    echo "lucetc not found" >&2
+    exit 1
+fi
+
+if [ -x "${LUCET_DIR}/target/release/lucet-objdump" ]; then
+    LUCET_OBJDUMP="${LUCET_DIR}/target/release/lucet-objdump"
+elif [ -x "${LUCET_DIR}/target/debug/lucet-objdump" ]; then
+    LUCET_OBJDUMP="${LUCET_DIR}/target/debug/lucet-objdump"
+else
+    echo "lucet-objdump not found" >&2
+    exit 1
+fi
+
+OBJ="$TMPDIR/objdump_test.so"
+
+echo "Compiling a test WebAssembly module"
+
+"$LUCETC" -o "$OBJ" lucetc/tests/wasm/icall_sparse.wat
+
+echo "objdump'ing the compiled module"
+if ! "$LUCET_OBJDUMP" "$OBJ" > /dev/null; then
+  echo "lucet-objdump exited with $?"
+  exit 1
+fi
+
+rm -rf "$TMPDIR"

--- a/lucetc/src/table.rs
+++ b/lucetc/src/table.rs
@@ -55,7 +55,7 @@ pub fn write_table_data<B: ClifBackend>(
 ) -> Result<(DataId, usize), Error> {
     let mut tables_vec = Cursor::new(Vec::new());
     let mut table_ctx = DataContext::new();
-    let mut table_len = 0;
+    let mut tables_count = 0;
 
     if let Ok(table_decl) = decls.get_table(TableIndex::new(0)) {
         // Indirect calls are performed by looking up the callee function and type in a table that
@@ -123,10 +123,10 @@ pub fn write_table_data<B: ClifBackend>(
         tables_vec.write_u64::<LittleEndian>(0).unwrap();
 
         // Define the length of the table as a u64:
-        table_len = elements.len();
         tables_vec
-            .write_u64::<LittleEndian>(table_len as u64)
+            .write_u64::<LittleEndian>(elements.len() as u64)
             .unwrap();
+        tables_count += 1;
     }
 
     let inner = tables_vec.into_inner();
@@ -138,5 +138,5 @@ pub fn write_table_data<B: ClifBackend>(
         .as_dataid()
         .expect("lucet_tables is declared as data");
     clif_module.define_data(table_id, &table_ctx)?;
-    Ok((table_id, table_len))
+    Ok((table_id, tables_count))
 }


### PR DESCRIPTION
A little while ago one of the changes to `lucetc` resulted in the field for "number of tables" instead holding "number of entries in the first table, or zero". This would be a bigger issue* if wasm ever used tables other than 0, but it doesn't for the time being, so the next likely place to run afoul of this is in `lucet-objdump` which crashes trying to read more tables than there really are, following stray pointers.

This change switches back to reporting the number of tables as the [length of the list of tables](https://github.com/bytecodealliance/lucet/blob/master/lucet-module/src/module.rs#L27), and includes a smoke-test through `lucet-objdump` to catch issues like this in the future.

* a longer description of why this isn't a severe issue for `lucet-runtime`: either there are zero tables, in which case this field will hold `0` anyway and no stray reads will happen, or there are >0 tables and `lucet-runtime` will care only about the first one, regardless of how many other tables are reported. If the number of entries is non-zero, there must be a table they exist in, and the first table in the list of tables will be valid. The concerning case I can imagine is where there is one table of zero entries, which would result in a `lucet-runtime` error [trying to get table entries](https://github.com/bytecodealliance/lucet/blob/master/lucet-runtime/lucet-runtime-internals/src/module/dl.rs#L241). So in the worst case `lucet-runtime` might fail with an error on a well-formed wasm.