### PR TITLE
🔧 limit compile-time table elements to the table's min

### DIFF
--- a/lucetc/src/error.rs
+++ b/lucetc/src/error.rs
@@ -72,6 +72,8 @@ pub enum Error {
     Signature(String),
     #[error("Table index is out of bounds: {0}")]
     TableIndexError(String),
+    #[error("Initializer {0:?} out of range for {1:?}")]
+    ElementInitializerOutOfRange(crate::module::TableElems, cranelift_wasm::Table),
     #[error("Trap records are present for function {0} but the function does not exist.")]
     TrapRecord(String),
     #[error("Unsupported: {0}")]

--- a/lucetc/tests/wasm.rs
+++ b/lucetc/tests/wasm.rs
@@ -355,6 +355,19 @@ mod module_data {
         });
     }
 
+    #[test]
+    fn element_out_of_range() {
+        use lucetc::Error as LucetcError;
+        let m = load_wat_module("element_out_of_range");
+        let b = Bindings::empty();
+        let builder = Compiler::builder();
+        let c = builder.create(&m, &b).unwrap();
+        match c.object_file() {
+            Err(LucetcError::ElementInitializerOutOfRange(_, _)) => (),
+            Ok(_) | Err(_) => panic!("unexpected result"),
+        }
+    }
+
     // XXX adding more negative tests like the one above is valuable - lets do it
 
     #[test]
@@ -419,7 +432,6 @@ mod compile {
     // Tests for compilation completion
     use super::load_wat_module;
     use lucetc::Compiler;
-    use target_lexicon::Triple;
     fn run_compile_test(file: &str) {
         let m = load_wat_module(file);
         let b = super::test_bindings();

--- a/lucetc/tests/wasm/element_out_of_range.wat
+++ b/lucetc/tests/wasm/element_out_of_range.wat
@@ -1,0 +1,6 @@
+(module
+  (type (;0;) (func (result i32)))
+  (func (;0;) (type 0) (result i32)
+    (i32.const 5))
+  (table (;0;) 1 funcref)
+  (elem (;0;) (i32.const 1) 0))


### PR DESCRIPTION
Key phrase from the [spec][spec]:

> The `min` size in the limits of the table type specifies the initial size of that table, while its `max`, if present, restricts the size to which it can grow later.

In other words, at compile time the largest a table is allowed to be is its `min` limit. The `max` limit, if present, only limits the size to which the table can grow via `table.grow` instructions at runtime.

Previously, if we found an element section that specified an index offset past the end of the table vector, we would obligingly grow it longer, even if it exceeded the `min` limit of the table (and possibly the `max` value as well?). This patch changes the behavior to allocate a vector of `min` length and return an error if any element initializers would overflow it.

There's a new test in the `lucetc/tests/wasm` suite to check that we enforce this limit. Distressingly, it does not appear that the spectests actually test this condition.

[spec]: https://webassembly.github.io/spec/core/syntax/modules.html#tables