### PR TITLE
The lucet-module has an assumption about max_size that isn't checked when an instance is created.

### DIFF
--- a/lucet-runtime/lucet-runtime-internals/src/alloc/tests.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/alloc/tests.rs
@@ -726,29 +726,29 @@ macro_rules! alloc_tests {
             initial_size: REJECTMAX_INITIAL_SIZE,
             max_size: Some(REJECTMAX_MAX_SIZE),
         };
-	
-	#[test]
-	fn reject_max_larger_than_reserved() {
-            let region = TestRegion::create(1, &LIMITS).expect("region created");
-	    let res = region.new_instance(
-                    MockModuleBuilder::new()
-                        .with_heap_spec(REJECT_MAX_LIMIT_HEAP_SPEC)
-                        .build(),
-            );
-	    assert!(res.is_err(), "new_instance fails");
-	}
 
-	fn do_nothing_module() -> Arc<dyn Module> {
+        #[test]
+        fn reject_max_larger_than_reserved() {
+            let region = TestRegion::create(1, &LIMITS).expect("region created");
+            let res = region.new_instance(
+                MockModuleBuilder::new()
+                    .with_heap_spec(REJECT_MAX_LIMIT_HEAP_SPEC)
+                    .build(),
+            );
+            assert!(res.is_err(), "new_instance fails");
+        }
+
+        fn do_nothing_module() -> Arc<dyn Module> {
             extern "C" fn do_nothing(_vmctx: *mut lucet_vmctx) -> () {}
-	    
+
             MockModuleBuilder::new()
                 .with_export_func(MockExportBuilder::new(
                     "do_nothing",
                     FunctionPointer::from_usize(do_nothing as usize),
                 ))
                 .build()
-	}
-	
+        }
+
         #[test]
         fn reject_sigstack_smaller_than_min() {
             if MINSIGSTKSZ == 0 {

--- a/lucet-runtime/lucet-runtime-internals/src/module.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/module.rs
@@ -135,7 +135,7 @@ pub trait ModuleInternal: Send + Sync {
                 ));
             }
 
-	     if let Some(max_size) = heap.max_size {
+            if let Some(max_size) = heap.max_size {
                 if max_size > heap.reserved_size {
                     return Err(lucet_incorrect_module!(
                         "maximum heap size greater than reserved size: {:?}",
@@ -143,7 +143,6 @@ pub trait ModuleInternal: Send + Sync {
                     ));
                 }
             }
-
         }
 
         if self.globals().len() * std::mem::size_of::<u64>() > limits.globals_size {

--- a/lucet-runtime/lucet-runtime-internals/src/module.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/module.rs
@@ -134,6 +134,16 @@ pub trait ModuleInternal: Send + Sync {
                     heap
                 ));
             }
+
+	     if let Some(max_size) = heap.max_size {
+                if max_size > heap.reserved_size {
+                    return Err(lucet_incorrect_module!(
+                        "maximum heap size greater than reserved size: {:?}",
+                        heap
+                    ));
+                }
+            }
+
         }
 
         if self.globals().len() * std::mem::size_of::<u64>() > limits.globals_size {


### PR DESCRIPTION
As I'm introducing new kinds of `heap_memory_size` limits to an instance, I noticed a small inconsistency in assumption-checking that I'd like to discuss.  I realize that we may not necessarily merge this PR as I may be missing something regarding HeapSpec checks.  Always look forward to your comments to help me learn and be better.

A HeapSpec is defined here:  https://github.com/bytecodealliance/lucet/blob/master/lucet-module/src/linear_memory.rs#L37-L76

This assumption on a heap's `max_size` is recorded in the comments:

> The program may optionally define this value. If it does, it must be less than the `reserved_size`.

Furthermore, this assumption on a heap's `initial_size` is also recorded in the comments:

> [it] must be less than or equal to `reserved_size`.

I noticed that when an instance is created and its heap spec is validated, the latter assumptions is checked but the former is not.  This PR -- out of my healthy abundance of paranoia -- introduces a check on a heap's `max_size` to `validate_runtime_spec`.