### PR TITLE
Delete incorrect assumption about the max_size in a HeapSpec.

### DIFF
--- a/lucet-module/src/linear_memory.rs
+++ b/lucet-module/src/linear_memory.rs
@@ -69,9 +69,8 @@ pub struct HeapSpec {
     /// This is not necessarily the same as `reserved_size` - we want to be able to tune the check
     /// bound there separately than the declaration of a max size in the client program.
     ///
-    /// The program may optionally define this value. If it does, it must be less than the
-    /// `reserved_size`. If it does not, the max size is left up to the runtime, and is allowed to
-    /// be less than `reserved_size`.
+    /// The program may optionally define this value. If it does not, the max size is left up to
+    /// the runtime, and is allowed to be less than `reserved_size`.
     pub max_size: Option<u64>,
 }
 


### PR DESCRIPTION
Following up from a recent conversation in https://github.com/bytecodealliance/lucet/pull/466.