### PR TITLE
Add blank Github issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank-issue.md
+++ b/.github/ISSUE_TEMPLATE/blank-issue.md
@@ -1,0 +1,10 @@
+---
+name: Blank Issue
+about: Create a blank issue.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+


### PR DESCRIPTION
This creates a basic "Blank Issue" [Github issue template](https://help.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository) along the lines of the one [used by wasmtime](https://github.com/bytecodealliance/wasmtime/issues/new/choose). My primary motivation for this initial change is to prompt an alternative of private reporting of security issues, but over time we could add more templates that will help structure general reports.