### PR TITLE
use object instead of goblin in lucet-objdump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -847,8 +847,8 @@ version = "0.6.2-dev"
 dependencies = [
  "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "colored 1.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "goblin 0.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "lucet-module 0.6.2-dev",
+ "object 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/lucet-objdump/Cargo.toml
+++ b/lucet-objdump/Cargo.toml
@@ -10,7 +10,7 @@ authors = ["Lucet team <lucet@fastly.com>"]
 edition = "2018"
 
 [dependencies]
-goblin="0.0.24"
+object = "0.18"
 byteorder="1.2.1"
 colored="1.8.0"
 lucet-module = { path = "../lucet-module", version = "=0.6.2-dev" }


### PR DESCRIPTION
Over in #470, we discovered that `object` and `faerie` have different
approaches to writing relocations in shared objects.  In a nutshell,
`object`'s approach requires applying relocations to the shared object's
data whereas `faerie`'s does not (at least for the current structure of
`lucet-objdump`).

This change represents an intermediate step towards accommodating
`object`'s relocation approach by rewriting `lucet-objdump` to use
`object` instead of `goblin` for reading files.  `object` is a little
easier to work with, a little more abstract than `goblin`, and various
other bits of Lucet already use `object` anyway.

There are no differences in `lucet-objdump`'s output on a representative
file when `lucet-objdump` is compiled with and without this patch.