### PR TITLE
Conveying expectations:  Bad instances take up capacity.

### DIFF
--- a/lucet-runtime/lucet-runtime-internals/src/alloc/tests.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/alloc/tests.rs
@@ -689,7 +689,24 @@ macro_rules! alloc_tests {
             drop(inst);
         }
 
-        #[test]
+	#[test]
+	fn bad_instance_takes_up_capacity() {
+	    let module = MockModuleBuilder::new()
+                .with_heap_spec(LARGE_GUARD_HEAP)
+                .build();
+            let region = TestRegion::create(2, &LIMITS).expect("region created");
+            assert_eq!(region.capacity(), 2);
+            assert_eq!(region.free_slots(), 2);
+            assert_eq!(region.used_slots(), 0);
+            let bad_inst_res = region
+                .new_instance(module.clone());
+	    assert!(bad_inst_res.is_err());
+	    assert_eq!(region.capacity(), 2);
+            assert_eq!(region.free_slots(), 1);
+            assert_eq!(region.used_slots(), 1);
+	}
+	
+	#[test]
         fn slot_counts_work() {
             let module = MockModuleBuilder::new()
                 .with_heap_spec(ONE_PAGE_HEAP)

--- a/lucet-runtime/lucet-runtime-internals/src/alloc/tests.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/alloc/tests.rs
@@ -689,24 +689,23 @@ macro_rules! alloc_tests {
             drop(inst);
         }
 
-	#[test]
-	fn bad_instance_takes_up_capacity() {
-	    let module = MockModuleBuilder::new()
+        #[test]
+        fn bad_instance_takes_up_capacity() {
+            let module = MockModuleBuilder::new()
                 .with_heap_spec(LARGE_GUARD_HEAP)
                 .build();
             let region = TestRegion::create(2, &LIMITS).expect("region created");
             assert_eq!(region.capacity(), 2);
             assert_eq!(region.free_slots(), 2);
             assert_eq!(region.used_slots(), 0);
-            let bad_inst_res = region
-                .new_instance(module.clone());
-	    assert!(bad_inst_res.is_err());
-	    assert_eq!(region.capacity(), 2);
+            let bad_inst_res = region.new_instance(module.clone());
+            assert!(bad_inst_res.is_err());
+            assert_eq!(region.capacity(), 2);
             assert_eq!(region.free_slots(), 1);
             assert_eq!(region.used_slots(), 1);
-	}
-	
-	#[test]
+        }
+
+        #[test]
         fn slot_counts_work() {
             let module = MockModuleBuilder::new()
                 .with_heap_spec(ONE_PAGE_HEAP)


### PR DESCRIPTION
One of the things that surprised me in the `alloc` tests was that a failed instance still takes up the slot capacity of a region.  I've written a test that demonstrates this scenario.  

- If this behaviour is expected, then I'm glad to have a test to demonstrate that the behaviour is expected.  No other test seems to exercise this logic and I prefer not to leave things unsaid.
- If this behaviour is unexpected, then we can take other steps.