### PR TITLE
Faulted guests can run!

### DIFF
--- a/lucet-runtime/lucet-runtime-internals/src/instance/execution.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/instance/execution.rs
@@ -244,6 +244,11 @@ pub unsafe extern "C" fn exit_guest_region(instance: *mut Instance) {
                 // We finished executing the code in our guest region normally! We should reset
                 // the kill state, invalidating any existing killswitches' weak references.
                 mem::drop(current_domain);
+                // There should be only one strong reference to `kill_state`, so as a consistency
+                // check ensure that's still true. This is necessary so that when we drop this
+                // `Arc`, weak refs are no longer valid. If this assert fails, something cloned
+                // `KillState`, or a `KillSwitch` has upgraded it's ref - both of these are errors!
+                assert_eq!(Arc::strong_count(&instance.kill_state), 1);
                 instance.kill_state = Arc::new(KillState::default());
             }
             ref domain @ Domain::Pending

--- a/lucet-runtime/lucet-runtime-tests/src/guest_fault.rs
+++ b/lucet-runtime/lucet-runtime-tests/src/guest_fault.rs
@@ -401,6 +401,29 @@ macro_rules! guest_fault_tests {
             });
         }
 
+        // Ensure that guests can be successfully run after an instance faults, but without
+        // resetting the guest.
+        #[test]
+        fn guest_after_fault_without_reset() {
+            test_nonex(|| {
+                let module = mock_traps_module();
+                let region =
+                    TestRegion::create(1, &Limits::default()).expect("region can be created");
+                let mut inst = region
+                    .new_instance(module)
+                    .expect("instance can be created");
+
+                match inst.run("oob", &[]) {
+                    Err(Error::RuntimeFault(details)) => {
+                        assert_eq!(details.trapcode, Some(TrapCode::HeapOutOfBounds));
+                    }
+                    res => panic!("unexpected result: {:?}", res),
+                }
+
+                run_onetwothree(&mut inst);
+            });
+        }
+
         #[test]
         fn hostcall_error() {
             test_nonex(|| {

--- a/lucet-runtime/lucet-runtime-tests/src/timeout.rs
+++ b/lucet-runtime/lucet-runtime-tests/src/timeout.rs
@@ -184,8 +184,9 @@ macro_rules! timeout_tests {
                 res => panic!("unexpected result: {:?}", res),
             }
 
-            // If we try to terminate after the instance ran, the kill switch will fail, and the
-            // the instance will run normally the next time around.
+            // If we try to terminate after the instance ran, the kill switch will fail - the
+            // function we called is no longer running - and the the instance will run normally the
+            // next time around.
             assert_eq!(kill_switch.terminate(), Err(KillError::Invalid));
             match inst.run("do_nothing", &[]) {
                 Ok(_) => {}
@@ -215,7 +216,7 @@ macro_rules! timeout_tests {
             }
 
             // An instance that has faulted is not terminable.
-            assert_eq!(kill_switch.terminate(), Err(KillError::NotTerminable));
+            assert_eq!(kill_switch.terminate(), Err(KillError::Invalid));
 
             // Check that we can reset the instance and run a normal function.
             inst.reset().expect("instance resets");


### PR DESCRIPTION
Over in #429 we adjusted `KillSwitch` to be useful in that a timeout before a guest begins is upheld, rather than ignored. As it turns out, our tests didn't cover one of the expectations we have around instance lifetimes: after a fault, instances _can_ be run without reset. Consequently, users of lucet-runtime that ran instances post-fault without reset (such as `lucet-spectest`) caught a bug: rerunning after a fault could cause us to panic in a way that aborts the process.

In normal guest exits we disable termination on the instance's `KillState`, then reset it to a new one so new `KillSwitch` can cancel execution for some eventual function call. To avoid the bad `KillState` state, we just needed to do the same when exiting through a signal handler, too.

The first commit here introduces a test that fails like
```
error: test failed, to rerun pass '-p lucet-runtime --test guest_fault'
                                                                     
Caused by:                                                                                
  process didn't exit successfully: `/home/iximeow/lucet/target/debug/deps/guest_fault-88464978bc082788` (signal: 6, SIGABRT: process abort signal)
```
(`SIGABRT` because we panic where there isn't full unwind information, and libunwind falls over)

where the second commit fixes this issue, and gets us back to passing all but five spectests: `data`, `elem`, `globals`, `imports`, `linking`!