### PR TITLE
fix parsing of trap manifests in lucet-objdump

### DIFF
--- a/lucet-objdump/src/main.rs
+++ b/lucet-objdump/src/main.rs
@@ -146,7 +146,7 @@ fn parse_trap_manifest<'a>(
     if let Some(faulty_trap_manifest) = f.traps() {
         let trap_ptr = faulty_trap_manifest.traps.as_ptr();
         let traps_count = faulty_trap_manifest.traps.len();
-        let traps_byte_count = traps_count * std::mem::size_of::<TrapManifest<'_>>();
+        let traps_byte_count = traps_count * std::mem::size_of::<TrapSite>();
         if let Some(traps_byte_slice) =
             summary.read_memory(trap_ptr as u64, traps_byte_count as u64)
         {


### PR DESCRIPTION
Computing the total number of bytes in the trap manifest was using the
wrong thing, which resulted in too much data being read.  This might or
might not manifest as a problem, depending on how the trap sites were
laid out with respect to other data in the binary.