### PR TITLE
lucetc: declare more things as local

### DIFF
--- a/lucetc/src/compiler.rs
+++ b/lucetc/src/compiler.rs
@@ -371,7 +371,7 @@ impl<'a> Compiler<'a> {
         function_manifest_ctx.define(function_manifest_bytes.into_inner().into());
         let manifest_data_id = self.clif_module.declare_data(
             FUNCTION_MANIFEST_SYM,
-            ClifLinkage::Export,
+            ClifLinkage::Local,
             false,
             false,
             None,
@@ -589,7 +589,7 @@ impl TrapSites {
         trap_sym_ctx.define(self.serialize());
 
         let trap_data_id =
-            module.declare_data(&trap_sym, ClifLinkage::Export, false, false, None)?;
+            module.declare_data(&trap_sym, ClifLinkage::Local, false, false, None)?;
 
         module.define_data(trap_data_id, &trap_sym_ctx)?;
 

--- a/lucetc/src/decls.rs
+++ b/lucetc/src/decls.rs
@@ -254,14 +254,14 @@ impl<'a> ModuleDecls<'a> {
         for ix in 0..info.tables.len() {
             let def_symbol = format!("guest_table_{}", ix);
             let def_data_id =
-                clif_module.declare_data(&def_symbol, Linkage::Export, false, false, None)?;
+                clif_module.declare_data(&def_symbol, Linkage::Local, false, false, None)?;
             let def_name = Name::new_data(def_symbol, def_data_id);
 
             table_names.push(def_name);
         }
 
         let tables_list_id =
-            clif_module.declare_data(TABLE_SYM, Linkage::Export, false, false, None)?;
+            clif_module.declare_data(TABLE_SYM, Linkage::Local, false, false, None)?;
         let tables_list = Name::new_data(TABLE_SYM.to_string(), tables_list_id);
 
         Ok((tables_list, table_names))


### PR DESCRIPTION
From a functionality standpoint, this is not strictly necessary.
However, it does two things: it exports less from the static library,
which seems like a good thing, and it encourages `cranelift-object` to
more closely match `cranelift-faerie` in terms of the relocations it
uses in the final output, which is good for #470.