### PR TITLE
Add instrumentation to force specific forms of races

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -822,6 +822,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lucet-concurrency-tests"
+version = "0.6.2-dev"
+dependencies = [
+ "lucet-module 0.6.2-dev",
+ "lucet-runtime 0.6.2-dev",
+ "lucet-runtime-internals 0.6.2-dev",
+]
+
+[[package]]
 name = "lucet-module"
 version = "0.6.2-dev"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@
 members = [
   "benchmarks/lucet-benchmarks",
   "docs/lucet-runtime-example",
+  "lucet-concurrency-tests",
   "lucet-module",
   "lucet-objdump",
   "lucet-runtime",

--- a/lucet-concurrency-tests/Cargo.toml
+++ b/lucet-concurrency-tests/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "lucet-concurrency-tests"
+version = "0.6.2-dev"
+description = "Tests for lucet-runtime that depend on conditionally-defined locks to force timing permutations."
+homepage = "https://github.com/fastly/lucet"
+repository = "https://github.com/fastly/lucet"
+license = "Apache-2.0 WITH LLVM-exception"
+categories = ["wasm"]
+authors = ["Lucet team <lucet@fastly.com>"]
+edition = "2018"
+
+[dependencies]
+lucet-module = { path = "../lucet-module", version = "=0.6.2-dev" }
+lucet-runtime = { path = "../lucet-runtime", version = "=0.6.2-dev", features = ["concurrent_testpoints"] }
+lucet-runtime-internals = { path = "../lucet-runtime/lucet-runtime-internals", version = "=0.6.2-dev", features = ["concurrent_testpoints"] }

--- a/lucet-concurrency-tests/tests/killswitch.rs
+++ b/lucet-concurrency-tests/tests/killswitch.rs
@@ -1,0 +1,114 @@
+use lucet_runtime::{Error, KillSuccess, Limits, Region, TerminationDetails};
+use std::sync::Arc;
+use std::thread;
+
+use lucet_module::FunctionPointer;
+use lucet_runtime::MmapRegion;
+use lucet_runtime_internals::lock_testpoints::Syncpoint;
+use lucet_runtime_internals::module::Module;
+use lucet_runtime_internals::module::{MockExportBuilder, MockModuleBuilder};
+use lucet_runtime_internals::vmctx::lucet_vmctx;
+
+static mut ENTERING_GUEST: Option<Syncpoint> = None;
+
+pub fn mock_traps_module() -> Arc<dyn Module> {
+    extern "C" fn onetwothree(_vmctx: *mut lucet_vmctx) -> std::os::raw::c_int {
+        123
+    }
+
+    extern "C" fn infinite_loop(_vmctx: *mut lucet_vmctx) {
+        unsafe {
+            ENTERING_GUEST.as_ref().unwrap().check();
+        }
+        loop {}
+    }
+
+    extern "C" fn fatal(vmctx: *mut lucet_vmctx) {
+        extern "C" {
+            fn lucet_vmctx_get_heap(vmctx: *mut lucet_vmctx) -> *mut u8;
+        }
+
+        unsafe {
+            let heap_base = lucet_vmctx_get_heap(vmctx);
+
+            // Using the default limits, each instance as of this writing takes up 0x200026000 bytes
+            // worth of virtual address space. We want to access a point beyond all the instances,
+            // so that memory is unmapped. We assume no more than 16 instances are mapped
+            // concurrently. This may change as the library, test configuration, linker, phase of
+            // moon, etc change, but for now it works.
+            *heap_base.offset(0x0002_0002_6000 * 16) = 0;
+        }
+    }
+
+    extern "C" fn hit_sigstack_guard_page(vmctx: *mut lucet_vmctx) {
+        extern "C" {
+            fn lucet_vmctx_get_globals(vmctx: *mut lucet_vmctx) -> *mut u8;
+        }
+
+        unsafe {
+            let globals_base = lucet_vmctx_get_globals(vmctx);
+
+            // Using the default limits, the globals are a page; try to write just off the end
+            *globals_base.offset(0x1000) = 0;
+        }
+    }
+
+    MockModuleBuilder::new()
+        .with_export_func(MockExportBuilder::new(
+            "onetwothree",
+            FunctionPointer::from_usize(onetwothree as usize),
+        ))
+        .with_export_func(MockExportBuilder::new(
+            "infinite_loop",
+            FunctionPointer::from_usize(infinite_loop as usize),
+        ))
+        .with_export_func(MockExportBuilder::new(
+            "fatal",
+            FunctionPointer::from_usize(fatal as usize),
+        ))
+        .with_export_func(MockExportBuilder::new(
+            "hit_sigstack_guard_page",
+            FunctionPointer::from_usize(hit_sigstack_guard_page as usize),
+        ))
+        .build()
+}
+
+// Test that a timeout occurring in guest code is handled cleanly for both the KillSwitch and Lucet
+// embedder.
+#[test]
+fn timeout_in_guest() {
+    unsafe {
+        ENTERING_GUEST = Some(Syncpoint::new());
+    }
+    let module = mock_traps_module();
+    let region = MmapRegion::create(1, &Limits::default()).expect("region can be created");
+
+    let mut inst = region
+        .new_instance(module)
+        .expect("instance can be created");
+
+    let in_guest = unsafe { ENTERING_GUEST.as_ref().unwrap().wait_at() };
+
+    let kill_switch = inst.kill_switch();
+
+    let t = thread::Builder::new()
+        .name("guest".to_owned())
+        .spawn(move || {
+            match inst.run("infinite_loop", &[]) {
+                Err(Error::RuntimeTerminated(TerminationDetails::Remote)) => {
+                    // this is what we want!
+                }
+                res => panic!("unexpected result: {:?}", res),
+            }
+        })
+        .expect("can spawn a thread");
+
+    let terminator = in_guest.wait_and_then(move || {
+        thread::spawn(move || {
+            assert_eq!(kill_switch.terminate(), Ok(KillSuccess::Signalled));
+        })
+    });
+
+    t.join().unwrap();
+    terminator.join().unwrap();
+}

--- a/lucet-runtime/Cargo.toml
+++ b/lucet-runtime/Cargo.toml
@@ -46,3 +46,8 @@ assets = [
     ["target/release/liblucet_runtime.so", "/opt/fst-lucet-runtime/lib/", "755"],
     ["include/*.h", "/opt/fst-lucet-runtime/include/", "644"],
 ]
+
+[features]
+default = []
+
+concurrent_testpoints = []

--- a/lucet-runtime/lucet-runtime-internals/Cargo.toml
+++ b/lucet-runtime/lucet-runtime-internals/Cargo.toml
@@ -40,3 +40,8 @@ byteorder = "1.2"
 
 [build-dependencies]
 cc = "1.0"
+
+[features]
+default = []
+
+concurrent_testpoints = []

--- a/lucet-runtime/lucet-runtime-internals/src/instance.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/instance.rs
@@ -11,6 +11,8 @@ use crate::alloc::{Alloc, HOST_PAGE_SIZE_EXPECTED};
 use crate::context::Context;
 use crate::embed_ctx::CtxMap;
 use crate::error::Error;
+#[cfg(feature = "concurrent_testpoints")]
+use crate::lock_testpoints::LockTestpoints;
 use crate::module::{self, FunctionHandle, FunctionPointer, Global, GlobalValue, Module, TrapCode};
 use crate::region::RegionInternal;
 use crate::val::{UntypedRetVal, Val};
@@ -228,6 +230,10 @@ pub struct Instance {
 
     /// Small mutexed state used for remote kill switch functionality
     pub(crate) kill_state: Arc<KillState>,
+
+    #[cfg(feature = "concurrent_testpoints")]
+    /// Conditionally-present helpers to force permutations of possible races in testing.
+    pub lock_testpoints: Arc<LockTestpoints>,
 
     /// The memory allocated for this instance
     alloc: Alloc,
@@ -565,7 +571,16 @@ impl Instance {
         }
 
         self.state = State::Ready;
-        self.kill_state = Arc::new(KillState::new());
+
+        #[cfg(feature = "concurrent_testpoints")]
+        {
+            self.kill_state = Arc::new(KillState::new(Arc::clone(&self.lock_testpoints)));
+        }
+        #[cfg(not(feature = "concurrent_testpoints"))]
+        {
+            self.kill_state = Arc::new(KillState::new());
+        }
+
         self.run_start()?;
         Ok(())
     }
@@ -804,13 +819,23 @@ impl Instance {
     fn new(alloc: Alloc, module: Arc<dyn Module>, embed_ctx: CtxMap) -> Self {
         let globals_ptr = alloc.slot().globals as *mut i64;
 
+        #[cfg(feature = "concurrent_testpoints")]
+        let lock_testpoints = Arc::new(LockTestpoints::new());
+
+        #[cfg(feature = "concurrent_testpoints")]
+        let kill_state = Arc::new(KillState::new(Arc::clone(&lock_testpoints)));
+        #[cfg(not(feature = "concurrent_testpoints"))]
+        let kill_state = Arc::new(KillState::new());
+
         let mut inst = Instance {
             magic: LUCET_INSTANCE_MAGIC,
             embed_ctx,
             module,
             ctx: Context::new(),
             state: State::Ready,
-            kill_state: Arc::new(KillState::new()),
+            kill_state,
+            #[cfg(feature = "concurrent_testpoints")]
+            lock_testpoints,
             alloc,
             fatal_handler: default_fatal_handler,
             c_fatal_handler: None,

--- a/lucet-runtime/lucet-runtime-internals/src/lib.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/lib.rs
@@ -19,6 +19,8 @@ pub mod c_api;
 pub mod context;
 pub mod embed_ctx;
 pub mod instance;
+#[cfg(feature = "concurrent_testpoints")]
+pub mod lock_testpoints;
 pub mod module;
 pub mod region;
 pub mod sysdeps;

--- a/lucet-runtime/lucet-runtime-internals/src/lock_testpoints.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/lock_testpoints.rs
@@ -1,0 +1,91 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+pub struct SyncWaiter {
+    arrived: Arc<AtomicBool>,
+    proceed: Arc<AtomicBool>,
+}
+
+impl SyncWaiter {
+    pub fn wait_and_then<U, F: FnOnce() -> U>(&self, f: F) -> U {
+        while !self.arrived.load(Ordering::SeqCst) {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+
+        let res = f();
+
+        self.proceed.store(true, Ordering::SeqCst);
+
+        res
+    }
+}
+
+pub struct Syncpoint {
+    arrived: Arc<AtomicBool>,
+    proceed: Arc<AtomicBool>,
+}
+
+impl Syncpoint {
+    pub fn new() -> Self {
+        Self {
+            arrived: Arc::new(AtomicBool::new(false)),
+            proceed: Arc::new(AtomicBool::new(true)),
+        }
+    }
+
+    pub fn wait_at(&self) -> SyncWaiter {
+        let arrived = Arc::clone(&self.arrived);
+        let proceed = Arc::clone(&self.proceed);
+
+        proceed.store(false, Ordering::SeqCst);
+
+        SyncWaiter { arrived, proceed }
+    }
+
+    pub fn check(&self) {
+        self.arrived.store(true, Ordering::SeqCst);
+
+        while !self.proceed.load(Ordering::SeqCst) {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+    }
+}
+
+pub struct LockTestpoints {
+    pub signal_handler_before_disabling_termination: Syncpoint,
+    pub signal_handler_after_disabling_termination: Syncpoint,
+    pub signal_handler_lock_before_returning: Syncpoint,
+    pub signal_handler_lock_after_acquiring_termination: Syncpoint,
+    pub kill_switch_lock_before_disabling_termination: Syncpoint,
+    pub kill_switch_lock_after_acquiring_termination: Syncpoint,
+    pub kill_switch_lock_after_forbidden_termination: Syncpoint,
+    pub kill_switch_lock_after_acquiring_domain_lock: Syncpoint,
+    pub kill_switch_lock_before_guest_termination: Syncpoint,
+    pub kill_switch_lock_before_guest_alarm: Syncpoint,
+    pub kill_switch_lock_before_hostcall_termination: Syncpoint,
+    pub kill_switch_lock_before_terminated_termination: Syncpoint,
+    pub kill_switch_lock_before_releasing_domain: Syncpoint,
+    pub kill_switch_lock_after_releasing_domain: Syncpoint,
+}
+
+impl LockTestpoints {
+    pub fn new() -> Self {
+        LockTestpoints {
+            signal_handler_before_disabling_termination: Syncpoint::new(),
+            signal_handler_after_disabling_termination: Syncpoint::new(),
+            signal_handler_lock_before_returning: Syncpoint::new(),
+            signal_handler_lock_after_acquiring_termination: Syncpoint::new(),
+            kill_switch_lock_before_disabling_termination: Syncpoint::new(),
+            kill_switch_lock_after_acquiring_termination: Syncpoint::new(),
+            kill_switch_lock_after_forbidden_termination: Syncpoint::new(),
+            kill_switch_lock_after_acquiring_domain_lock: Syncpoint::new(),
+            kill_switch_lock_before_guest_termination: Syncpoint::new(),
+            kill_switch_lock_before_guest_alarm: Syncpoint::new(),
+            kill_switch_lock_before_hostcall_termination: Syncpoint::new(),
+            kill_switch_lock_before_terminated_termination: Syncpoint::new(),
+            kill_switch_lock_before_releasing_domain: Syncpoint::new(),
+            kill_switch_lock_after_releasing_domain: Syncpoint::new(),
+        }
+    }
+}


### PR DESCRIPTION
This sprinkles in some points where, with a crate flag, we can force `lucet-runtime` to hang in race-sensitive code in ways we want to explicitly test. I think this is a good way for us to robustly test timing both for [platform-dependent ordering](https://github.com/bytecodealliance/lucet/pull/481#issuecomment-607923040) and for timing conditions that may be hard to otherwise artificially introduce (such as "two timeouts occur at the same time").

I've rewritten one test, that we correctly handle timeouts in guest code, here. By the time this is a real PR, I plan on porting most of the tests in `lucet-runtime-tests`' `timeouts` suite here, but for reason I don't yet understand these changes seem to have tripped up `guest_fault`. :unamused: 