### PR TITLE
use `cargo build --workspace`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,13 @@ export GUEST_MODULE_PREFIX:=$(abspath .)
 .PHONY: build-dev
 build-dev:
 	@echo Creating a DEBUG build
-	cargo build --all
+	cargo build --workspace
 	make -C lucet-builtins
 
 .PHONY: build
 build:
 	@echo Creating a RELEASE build
-	cargo build --all --release --bins --lib
+	cargo build --workspace --release --bins --lib
 	make -C lucet-builtins
 
 .PHONY: install


### PR DESCRIPTION
This time, in a proper PR :grimacing: :pensive: 

See: https://doc.rust-lang.org/cargo/commands/cargo-build.html

```
--workspace
Build all members in the workspace.

--all
Deprecated alias for --workspace.
```

I don't expect `--all` to go away _soon_, but we might as well be sure not to rely on a deprecated alias.