### PR TITLE
fix lucetc error message about linker flags

### DIFF
--- a/lucetc/src/lib.rs
+++ b/lucetc/src/lib.rs
@@ -419,7 +419,7 @@ fn ldflags_default(target: &Triple) -> String {
 
 Please define the LDFLAGS environment variable with the necessary command-line
 flags for generating shared libraries.",
-            Triple::host()
+            target
         ),
     }
     .into()


### PR DESCRIPTION
We have an explicit target triple that we should use here.