### PR TITLE
[PR into tyler/uffd-integration] Fixes uncovered during review of #492

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -770,16 +770,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "linux-version"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bindgen 0.51.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "nix 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "log"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -887,7 +877,7 @@ dependencies = [
  "raw-cpuid 6.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "userfaultfd 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "userfaultfd 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1111,18 +1101,6 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "adler32 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "nix"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
- "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2032,25 +2010,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "userfaultfd"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
- "nix 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nix 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "userfaultfd-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "userfaultfd-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "userfaultfd-sys"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bindgen 0.51.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "linux-version 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2449,14 +2426,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum leb128 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3576a87f2ba00f6f106fdfcd16db1d698d648a26ad8e0573cad8537c3c362d2a"
 "checksum libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)" = "dea0c0405123bba743ee3f91f49b1c7cfb684eef0da0a50110f758ccf24cdff0"
 "checksum libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
-"checksum linux-version 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c85966c8171cf471b2ac0fa33b9e45b9fbc48e75e462a8cb2a315ebdb0e244d1"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 "checksum memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 "checksum memoffset 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b4fc2c02a7e374099d4ee95a193111f72d2110197fe200272371758f6c3643d8"
 "checksum minisign 0.5.15 (registry+https://github.com/rust-lang/crates.io-index)" = "e4ba4f3bfa2d67def1b18805caeb719f5c30438f87f1c03fb618497707715e1a"
 "checksum miniz_oxide 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "aa679ff6578b1cddee93d7e82e263b94a575e0bfced07284eb0c037c1d2416a5"
-"checksum nix 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4dbdc256eaac2e3bd236d93ad999d3479ef775c863dbda3068c4006a92eec51b"
 "checksum nix 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3b2e0b4f3320ed72aaedb9a5ac838690a8047c7b275da22711fddff4f8a14229"
 "checksum nix 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)" = "50e4785f2c3b7589a0d0c1dd60285e1188adac4006e8abd6dd578e1567027363"
 "checksum nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
@@ -2561,8 +2536,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
-"checksum userfaultfd 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "45f718200831909259d1f05beafb64dfc6b7d1781662eb38279619607f725860"
-"checksum userfaultfd-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4c6e183d6d9a20a44491bf60e2743b309231255e818a107b1e9c94c4094fe28d"
+"checksum userfaultfd 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e394bc3ecd454f68f04803a7b527b36956413120fa06420dc1329cda49340763"
+"checksum userfaultfd-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3e34081f6dafe78988982f6139db289dd147ce1ac1d1dce208ae94e37650ac03"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM ubuntu:xenial
+FROM ubuntu:bionic
+
+# This env variable makes sure installing the tzdata package doesn't hang in prompt
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \
@@ -19,9 +22,11 @@ RUN apt-get update \
 	creduce \
 	gcc-multilib \
 	clang-6.0 \
+	llvm-6.0 \
 	&& rm -rf /var/lib/apt/lists/*
 
 RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-6.0 100
+RUN update-alternatives --install /usr/bin/llvm-config llvm-config /usr/bin/llvm-config-6.0 100
 
 # Setting a consistent LD_LIBRARY_PATH across the entire environment prevents unnecessary Cargo
 # rebuilds.
@@ -46,7 +51,7 @@ ENV BINARYEN_DIR=/opt/binaryen
 ENV BINARYEN_VERSION=86
 RUN curl -sS -L "https://github.com/WebAssembly/binaryen/archive/version_${BINARYEN_VERSION}.tar.gz" | tar xzf - && \
     mkdir -p binaryen-build && ( cd binaryen-build && cmake "../binaryen-version_${BINARYEN_VERSION}" && \
-    make wasm-opt wasm-reduce ) && \
+    make -j wasm-opt wasm-reduce ) && \
     install -d -v "${BINARYEN_DIR}/bin" && \
     for tool in wasm-opt wasm-reduce; do install -v "binaryen-build/bin/${tool}" "${BINARYEN_DIR}/bin/"; done && \
     rm -fr binaryen-build binaryen-version_${BINARYEN_VERSION}

--- a/lucet-runtime/Cargo.toml
+++ b/lucet-runtime/Cargo.toml
@@ -49,4 +49,8 @@ assets = [
 ]
 
 [features]
+default-features = []
 uffd = ["lucet-runtime-internals/uffd"]
+
+[package.metadata.docs.rs]
+features = ["uffd"]

--- a/lucet-runtime/Cargo.toml
+++ b/lucet-runtime/Cargo.toml
@@ -49,7 +49,7 @@ assets = [
 ]
 
 [features]
-default-features = []
+default = ["uffd"]
 uffd = ["lucet-runtime-internals/uffd"]
 
 [package.metadata.docs.rs]

--- a/lucet-runtime/lucet-runtime-internals/Cargo.toml
+++ b/lucet-runtime/lucet-runtime-internals/Cargo.toml
@@ -29,7 +29,7 @@ thiserror = "1.0.4"
 tracing = "0.1.12"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-userfaultfd = { version = "0.1.0", optional = true }
+userfaultfd = { version = "0.2.0", optional = true }
 
 # This is only a dependency to ensure that other crates don't pick a newer version as a transitive
 # dependency. `0.1.3 < getrandom <= 0.1.6` cause `lazy_static` to pull in spinlock implementations

--- a/lucet-runtime/lucet-runtime-internals/Cargo.toml
+++ b/lucet-runtime/lucet-runtime-internals/Cargo.toml
@@ -43,4 +43,8 @@ byteorder = "1.2"
 cc = "1.0"
 
 [features]
+default-features = []
 uffd = ["userfaultfd"]
+
+[package.metadata.docs.rs]
+features = ["uffd"]

--- a/lucet-runtime/lucet-runtime-internals/Cargo.toml
+++ b/lucet-runtime/lucet-runtime-internals/Cargo.toml
@@ -27,6 +27,8 @@ num-traits = "0.2"
 raw-cpuid = "6.0.0"
 thiserror = "1.0.4"
 tracing = "0.1.12"
+
+[target.'cfg(target_os = "linux")'.dependencies]
 userfaultfd = { version = "0.1.0", optional = true }
 
 # This is only a dependency to ensure that other crates don't pick a newer version as a transitive
@@ -43,7 +45,7 @@ byteorder = "1.2"
 cc = "1.0"
 
 [features]
-default-features = []
+default = ["uffd"]
 uffd = ["userfaultfd"]
 
 [package.metadata.docs.rs]

--- a/lucet-runtime/lucet-runtime-internals/src/alloc/tests.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/alloc/tests.rs
@@ -1017,7 +1017,7 @@ mod mmap {
     alloc_tests!(crate::region::mmap::MmapRegion);
 }
 
-#[cfg(all(test, feature = "uffd"))]
+#[cfg(all(test, target_os = "linux", feature = "uffd"))]
 mod uffd {
     alloc_tests!(crate::region::uffd::UffdRegion);
 }

--- a/lucet-runtime/lucet-runtime-internals/src/region.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/region.rs
@@ -1,6 +1,6 @@
 pub mod mmap;
 
-#[cfg(feature = "uffd")]
+#[cfg(all(target_os = "linux", feature = "uffd"))]
 pub mod uffd;
 
 use crate::alloc::{Alloc, Limits, Slot};

--- a/lucet-runtime/src/c_api.rs
+++ b/lucet-runtime/src/c_api.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "uffd")]
+#[cfg(all(target_os = "linux", feature = "uffd"))]
 use crate::UffdRegion;
 use crate::{DlModule, Instance, Limits, MmapRegion, Module, Region};
 use libc::{c_char, c_int, c_void};
@@ -103,7 +103,7 @@ pub unsafe extern "C" fn lucet_uffd_region_create(
     region_out: *mut *mut lucet_region,
 ) -> lucet_error {
     cfg_if::cfg_if! {
-        if #[cfg(feature = "uffd")] {
+        if #[cfg(all(target_os = "linux", feature = "uffd"))] {
             assert_nonnull!(region_out);
             let limits = limits
                 .as_ref()

--- a/lucet-runtime/src/lib.rs
+++ b/lucet-runtime/src/lib.rs
@@ -23,7 +23,10 @@
 //! [`InstanceHandle`](struct.InstanceHandle.html) smart pointer.
 //!
 //! - [`Region`](trait.Region.html): the memory from which instances are created. This crate
-//! includes [`MmapRegion`](struct.MmapRegion.html), an implementation backed by `mmap`.
+//! includes [`MmapRegion`](struct.MmapRegion.html), an implementation backed by `mmap`, and
+//! optionally [`UffdRegion`](struct.UffdRegion.html), which is backed by the
+//! [`userfaultfd`](http://man7.org/linux/man-pages/man2/userfaultfd.2.html) feature available on
+//! newer Linux kernels ([see below](index.html#userfaultfd-backed-region)).
 //!
 //! - [`Limits`](struct.Limits.html): upper bounds for the resources a Lucet instance may
 //! consume. These may be larger or smaller than the limits described in the WebAssembly module
@@ -374,6 +377,16 @@
 //! this number could change between Lucet releases or even Rust compiler versions.
 //!
 //! [default-sigstack-size]: constant.DEFAULT_SIGNAL_STACK_SIZE.html
+//!
+//! ## `userfaultfd`-Backed Region
+//!
+//! [`UffdRegion`](struct.UffdRegion.html) is a [`Region`](trait.Region.html) backed by the
+//! [`userfaultfd`](http://man7.org/linux/man-pages/man2/userfaultfd.2.html) feature available in
+//! newer Linux kernels. It allows Lucet instances to lazily copy in the initial heap contents of an
+//! `Instance`, reducing startup time. Instance stack pages can also be lazily initialized, reducing
+//! the memory footprint of instances that only use a small portion of their available stack space.
+//!
+//! To use `UffdRegion`, enable the `uffd` Cargo feature, which is off by default.
 
 #![deny(bare_trait_objects)]
 

--- a/lucet-runtime/src/lib.rs
+++ b/lucet-runtime/src/lib.rs
@@ -386,7 +386,14 @@
 //! `Instance`, reducing startup time. Instance stack pages can also be lazily initialized, reducing
 //! the memory footprint of instances that only use a small portion of their available stack space.
 //!
-//! To use `UffdRegion`, enable the `uffd` Cargo feature, which is off by default.
+//! `UffdRegion` is enabled by default on Linux platforms, but can be disabled by disabling default
+//! features for this crate and `lucet-runtime-internals`:
+//!
+//! ```toml
+//! [dependencies]
+//! lucet-runtime = { version = "0.6.1", default-features = false }
+//! lucet-runtime-internals = { version = "0.6.1", default-features = false }
+//! ```
 
 #![deny(bare_trait_objects)]
 
@@ -410,7 +417,7 @@ pub use lucet_runtime_internals::instance::{
 pub use lucet_runtime_internals::lucet_hostcalls;
 pub use lucet_runtime_internals::module::{DlModule, Module};
 pub use lucet_runtime_internals::region::mmap::MmapRegion;
-#[cfg(feature = "uffd")]
+#[cfg(all(target_os = "linux", feature = "uffd"))]
 pub use lucet_runtime_internals::region::uffd::UffdRegion;
 pub use lucet_runtime_internals::region::{InstanceBuilder, Region, RegionCreate};
 pub use lucet_runtime_internals::val::{UntypedRetVal, Val};

--- a/lucet-runtime/tests/entrypoint.rs
+++ b/lucet-runtime/tests/entrypoint.rs
@@ -1,7 +1,7 @@
 use lucet_runtime_tests::entrypoint_tests;
 
 cfg_if::cfg_if! {
-    if #[cfg(feature = "uffd")] {
+    if #[cfg(all(target_os = "linux", feature = "uffd"))] {
         entrypoint_tests!(
             mmap => lucet_runtime::MmapRegion,
             uffd => lucet_runtime::UffdRegion

--- a/lucet-runtime/tests/globals.rs
+++ b/lucet-runtime/tests/globals.rs
@@ -1,7 +1,7 @@
 use lucet_runtime_tests::globals_tests;
 
 cfg_if::cfg_if! {
-    if #[cfg(feature = "uffd")] {
+    if #[cfg(all(target_os = "linux", feature = "uffd"))] {
         globals_tests!(
             mmap => lucet_runtime::MmapRegion,
             uffd => lucet_runtime::UffdRegion

--- a/lucet-runtime/tests/guest_fault.rs
+++ b/lucet-runtime/tests/guest_fault.rs
@@ -1,7 +1,7 @@
 use lucet_runtime_tests::guest_fault_tests;
 
 cfg_if::cfg_if! {
-    if #[cfg(feature = "uffd")] {
+    if #[cfg(all(target_os = "linux", feature = "uffd"))] {
         guest_fault_tests!(
             mmap => lucet_runtime::MmapRegion,
             uffd => lucet_runtime::UffdRegion

--- a/lucet-runtime/tests/host.rs
+++ b/lucet-runtime/tests/host.rs
@@ -1,7 +1,7 @@
 use lucet_runtime_tests::host_tests;
 
 cfg_if::cfg_if! {
-    if #[cfg(feature = "uffd")] {
+    if #[cfg(all(target_os = "linux", feature = "uffd"))] {
         host_tests!(
             mmap => lucet_runtime::MmapRegion,
             uffd => lucet_runtime::UffdRegion

--- a/lucet-runtime/tests/memory.rs
+++ b/lucet-runtime/tests/memory.rs
@@ -1,7 +1,7 @@
 use lucet_runtime_tests::memory_tests;
 
 cfg_if::cfg_if! {
-    if #[cfg(feature = "uffd")] {
+    if #[cfg(all(target_os = "linux", feature = "uffd"))] {
         memory_tests!(
             mmap => lucet_runtime::MmapRegion,
             uffd => lucet_runtime::UffdRegion

--- a/lucet-runtime/tests/stack.rs
+++ b/lucet-runtime/tests/stack.rs
@@ -1,7 +1,7 @@
 use lucet_runtime_tests::stack_tests;
 
 cfg_if::cfg_if! {
-    if #[cfg(feature = "uffd")] {
+    if #[cfg(all(target_os = "linux", feature = "uffd"))] {
         stack_tests!(
             mmap => lucet_runtime::MmapRegion,
             uffd => lucet_runtime::UffdRegion

--- a/lucet-runtime/tests/start.rs
+++ b/lucet-runtime/tests/start.rs
@@ -1,7 +1,7 @@
 use lucet_runtime_tests::start_tests;
 
 cfg_if::cfg_if! {
-    if #[cfg(feature = "uffd")] {
+    if #[cfg(all(target_os = "linux", feature = "uffd"))] {
         start_tests!(
             mmap => lucet_runtime::MmapRegion,
             uffd => lucet_runtime::UffdRegion

--- a/lucet-runtime/tests/strcmp.rs
+++ b/lucet-runtime/tests/strcmp.rs
@@ -1,7 +1,7 @@
 use lucet_runtime_tests::strcmp_tests;
 
 cfg_if::cfg_if! {
-    if #[cfg(feature = "uffd")] {
+    if #[cfg(all(target_os = "linux", feature = "uffd"))] {
         strcmp_tests!(
             mmap => lucet_runtime::MmapRegion,
             uffd => lucet_runtime::UffdRegion

--- a/lucet-runtime/tests/timeout.rs
+++ b/lucet-runtime/tests/timeout.rs
@@ -1,7 +1,7 @@
 use lucet_runtime_tests::timeout_tests;
 
 cfg_if::cfg_if! {
-    if #[cfg(feature = "uffd")] {
+    if #[cfg(all(target_os = "linux", feature = "uffd"))] {
         timeout_tests!(
             mmap => lucet_runtime::MmapRegion,
             uffd => lucet_runtime::UffdRegion


### PR DESCRIPTION
This first commit enables alloc tests for `UffdRegion`, adds a new test, and fixes some things:

- Instantiates the suite in `lucet_runtime_internals::alloc::tests` for `UffdRegion`

- Fixes early return issues in `UffdRegion` similar to #455

- Adds a test to show that the per-instance heap limit applies to runtime expansions, not just initial instantiation

- Refactors `validate_runtime_spec` to take the per-instance heap limit as an additional argument. This centralizes the logic for rejecting initially-oversized heap limits, and makes it clearer what's happening in each region's instantiation logic.

- Removes the `UffdRegion`'s assertion that signal stack size is a multiple of page size. Since the user can now control this as a parameter, we reject it gracefully when validating `Limits` rather than panicking.