### PR TITLE
Fix hostcalls when building in release mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,3 @@
-# Lucet version 0.3.1
-
 [workspace]
 members = [
   "benchmarks/lucet-benchmarks",
@@ -25,6 +23,3 @@ exclude = ["wasmtime"]
 
 [profile.test]
 rpath = true
-
-[profile.release]
-lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,6 @@ exclude = ["wasmtime"]
 
 [profile.test]
 rpath = true
+
+[profile.release]
+lto = true

--- a/lucet-runtime/lucet-runtime-tests/src/entrypoint.rs
+++ b/lucet-runtime/lucet-runtime-tests/src/entrypoint.rs
@@ -922,5 +922,10 @@ macro_rules! entrypoint_tests {
                 .unwrap_returned();
             assert_eq!(u64::from(retval), 3);
         }
+
+        #[test]
+        fn ensure_linked() {
+            lucet_runtime::lucet_internal_ensure_linked();
+        }
     };
 }

--- a/lucet-runtime/lucet-runtime-tests/src/host.rs
+++ b/lucet-runtime/lucet-runtime-tests/src/host.rs
@@ -12,6 +12,7 @@ macro_rules! host_tests {
         use $TestRegion as TestRegion;
         use $crate::build::test_module_c;
         use $crate::helpers::{FunctionPointer, MockExportBuilder, MockModuleBuilder};
+
         #[test]
         fn load_module() {
             let _module = test_module_c("host", "trivial.c").expect("build and load module");
@@ -634,6 +635,11 @@ macro_rules! host_tests {
             .join()
             .unwrap();
             assert_eq!(u64::from(res), 42u64);
+        }
+
+        #[test]
+        fn ensure_linked() {
+            lucet_runtime::lucet_internal_ensure_linked();
         }
     };
 }

--- a/lucet-runtime/lucet-runtime-tests/src/strcmp.rs
+++ b/lucet-runtime/lucet-runtime-tests/src/strcmp.rs
@@ -89,5 +89,10 @@ macro_rules! strcmp_tests {
                 res => panic!("unexpected result: {:?}", res),
             }
         }
+
+        #[test]
+        fn ensure_linked() {
+            lucet_runtime::lucet_internal_ensure_linked();
+        }
     };
 }

--- a/lucet-runtime/lucet-runtime-tests/src/timeout.rs
+++ b/lucet-runtime/lucet-runtime-tests/src/timeout.rs
@@ -368,5 +368,10 @@ macro_rules! timeout_tests {
             inst.reset().expect("instance resets");
             run_onetwothree(&mut inst);
         }
+
+        #[test]
+        fn ensure_linked() {
+            lucet_runtime::lucet_internal_ensure_linked();
+        }
     };
 }

--- a/lucet-runtime/src/c_api.rs
+++ b/lucet-runtime/src/c_api.rs
@@ -364,11 +364,15 @@ static C_API_INIT: Once = Once::new();
 
 /// Should never actually be called, but should be reachable via a trait method to prevent DCE.
 pub fn ensure_linked() {
-    use std::ptr::read_volatile;
-    C_API_INIT.call_once(|| unsafe {
-        read_volatile(lucet_vmctx_get_heap as *const extern "C" fn());
-        read_volatile(lucet_vmctx_current_memory as *const extern "C" fn());
-        read_volatile(lucet_vmctx_grow_memory as *const extern "C" fn());
+    C_API_INIT.call_once(|| {
+        let funcs: &[*const extern "C" fn()] = &[
+            lucet_vmctx_get_heap as _,
+            lucet_vmctx_current_memory as _,
+            lucet_vmctx_grow_memory as _,
+        ];
+        for func in funcs {
+            assert_ne!(*func, std::ptr::null(), "hostcall address is not null");
+        }
     });
 }
 

--- a/lucet-runtime/tests/guest_fault.rs
+++ b/lucet-runtime/tests/guest_fault.rs
@@ -1,3 +1,5 @@
-use lucet_runtime_tests::guest_fault_tests;
+use lucet_runtime_tests::{guest_fault_common_defs, guest_fault_tests};
+
+guest_fault_common_defs!();
 
 guest_fault_tests!(lucet_runtime::MmapRegion);

--- a/lucet-runtime/tests/instruction_counting.rs
+++ b/lucet-runtime/tests/instruction_counting.rs
@@ -109,3 +109,8 @@ pub fn check_instruction_count() {
         );
     });
 }
+
+#[test]
+fn ensure_linked() {
+    lucet_runtime::lucet_internal_ensure_linked();
+}

--- a/lucet-runtime/tests/version_checks.rs
+++ b/lucet-runtime/tests/version_checks.rs
@@ -19,3 +19,8 @@ pub fn reject_old_modules() {
         panic!("unexpected error loading module: {}", err);
     }
 }
+
+#[test]
+fn ensure_linked() {
+    lucet_runtime::lucet_internal_ensure_linked();
+}

--- a/lucet-wasi/tests/guests/duplicate_import.wat
+++ b/lucet-wasi/tests/guests/duplicate_import.wat
@@ -17,8 +17,8 @@
   ;; import fd_write again for grins.
   (import "wasi_snapshot_preview1" "fd_write" (func (type 0)))
   (memory 1)
-  (data (i32.const 0) "duplicate import works!\0a")
-  (data (i32.const 64) "\00\00\00\00\18\00\00\00")
+  (data (i32.const 4) "duplicate import works!\0a")
+  (data (i32.const 64) "\04\00\00\00\18\00\00\00")
 
   (func $_setup (type 1)
     (drop (call $write (i32.const 1) (i32.const 64) (i32.const 1) (i32.const 0))))

--- a/lucet-wiggle/generate/src/lib.rs
+++ b/lucet-wiggle/generate/src/lib.rs
@@ -93,7 +93,9 @@ pub fn generate(
                 let funcs: &[*const extern "C" fn()] = &[
                     #(#init),*
                 ];
-                ::std::mem::forget(::std::rc::Rc::new(funcs));
+                for func in funcs {
+                    assert_ne!(*func, std::ptr::null(), "hostcall address is not null");
+                }
             }
         }
     }


### PR DESCRIPTION
As part of the upgrade to rust 1.42, executables which export hostcalls through the usual methods (e.g. `lucet_wasi::export_wasi_funcs`) apparently broke, but only when compiling in release mode.

Adam determined that changing the Rc leak of the hostcall function pointers to `assert_ne!(fptr, null)` fixed the issue. Previously, I noticed that enabling LTO fixed the issue as well, but the assert_ne fix seems a lot more likely to keep working across changes to rustc and llvm.

```sh
cargo build --release -p lucetc -p lucet-wasi
./target/release/lucetc lucet-wasi/tests/guests/duplicate_import.wat --bindings lucet-wasi/bindings.json
./target/release/lucet-wasi a.out
```

Prior to this patch, `target/release/lucet-wasi` will fail to dlopen the module because the wasi hostcall symbols are missing, and `nm` of the executable confirms this. After this patch, the symbols are present in the release executable again, and `nm` confirms it.

Our CI doesn't check that release mode executables work correctly. That should be corrected in a follow-up PR.