### PR TITLE
lucet-runtime-internals: do not reset kill state in signal handler

### DIFF
--- a/lucet-runtime/lucet-runtime-internals/src/instance.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/instance.rs
@@ -1008,6 +1008,12 @@ impl Instance {
         // Set transitioning state temporarily so that we can move values out of the current state
         let st = mem::replace(&mut self.state, State::Transitioning);
 
+        if !st.is_yielding() {
+            // If the instance is *not* yielding, initialize a fresh `KillState` for subsequent
+            // executions, which will invalidate any existing `KillSwitch`'s weak references.
+            self.kill_state = Arc::new(KillState::default());
+        }
+
         match st {
             State::Running => {
                 let retval = self.ctx.get_untyped_retval();

--- a/lucet-runtime/lucet-runtime-internals/src/instance/execution.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/instance/execution.rs
@@ -235,15 +235,13 @@ pub unsafe extern "C" fn exit_guest_region(instance: *mut Instance) {
         let current_domain = instance.kill_state.execution_domain.lock().unwrap();
         match *current_domain {
             Domain::Guest => {
-                // We finished executing the code in our guest region normally! We should reset
-                // the kill state, invalidating any existing killswitches' weak references.
-                mem::drop(current_domain);
+                // We finished executing the code in our guest region normally!
+                //
                 // There should be only one strong reference to `kill_state`, so as a consistency
                 // check ensure that's still true. This is necessary so that when we drop this
                 // `Arc`, weak refs are no longer valid. If this assert fails, something cloned
                 // `KillState`, or a `KillSwitch` has upgraded its ref - both of these are errors!
                 assert_eq!(Arc::strong_count(&instance.kill_state), 1);
-                instance.kill_state = Arc::new(KillState::default());
             }
             ref domain @ Domain::Pending
             | ref domain @ Domain::Cancelled

--- a/lucet-runtime/lucet-runtime-internals/src/instance/signals.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/instance/signals.rs
@@ -1,6 +1,5 @@
 use crate::alloc::validate_sigstack_size;
 use crate::error::Error;
-use crate::instance::execution::KillState;
 use crate::instance::{
     siginfo_ext::SiginfoExt, FaultDetails, Instance, State, TerminationDetails, CURRENT_INSTANCE,
     HOST_CTX,
@@ -329,9 +328,6 @@ extern "C" fn handle_signal(signum: c_int, siginfo_ptr: *mut siginfo_t, ucontext
             // we must disable termination so no KillSwitch for this execution may fire in host
             // code.
             inst.kill_state.disable_termination();
-            // and reset `kill_state` so that subsequent executions use a fresh KillState (not the
-            // stale one for the execution that just faulted)
-            inst.kill_state = Arc::new(KillState::default());
         }
 
         switch_to_host

--- a/lucet-runtime/lucet-runtime-internals/src/instance/state.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/instance/state.rs
@@ -164,6 +164,14 @@ impl State {
             false
         }
     }
+
+    pub fn is_yielding(&self) -> bool {
+        if let State::Yielding { .. } = self {
+            true
+        } else {
+            false
+        }
+    }
 }
 
 // TODO: PR into `libc`


### PR DESCRIPTION
1. Overview

This patch changes where we re-initialize an instance's `KillState`
after completing an execution. This re-initialization, to review, is
required for upholding guarantees about the validity of a `KillSwitch`
with respect to an instance's lifetime.

2. Motivation

Previously, we reset the kill state in one of two places: (1) the lucet
context backstop `exit_guest_region`, and (2) the lucet signal handler,
`handle_signal` defined in
`lucet-runtime-internals/src/instance/signals.rs`.

The latter poses a potential problem, because neither `malloc` or `free`
are required to be async-signal-safe by POSIX.1 (see signal-safety(7)[1]
for more information on this topic).

This means that we should neither allocate or free a new kill state,
because `Arc` *does* in fact use heap allocations.[2]

3. Fix

Rather than resetting our kill state in two places, we handle this in
`swap_and_return` after jumping back to the host process. The kill state
is reset when handling our `State` transition, *unless* the guest is
yielded.

Outstanding kill switches must not be invalidated when a guest yields.
In order to accomodate nicer control flow in `swap_and_return`, the
`State` enum has grown a new `is_yielding` method.

[1]: http://man7.org/linux/man-pages/man7/signal-safety.7.html
[2]: https://doc.rust-lang.org/src/alloc/sync.rs.html#299-308

Thanks also to @iximeow for collaborating when working on this. :sparkles: 