### PR TITLE
factor makefile & ci jobs to run more parallel jobs

### DIFF
--- a/.github/workflows/mac-ci.yml
+++ b/.github/workflows/mac-ci.yml
@@ -24,7 +24,7 @@ jobs:
         sudo mv wasi-sdk-10.0/* /opt/wasi-sdk/
 
     - name: Test Lucet
-      run: make test-except-fuzz
+      run: make test-ci
 
     - name: Ensure testing did not change sources
       run: git diff --exit-code

--- a/.github/workflows/mac-ci.yml
+++ b/.github/workflows/mac-ci.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 jobs:
   test:
-    name: Test
+    name: Test (MacOS)
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@master

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,41 @@ jobs:
     # This action builds the container and executes the test suite inside it.
     - uses: ./.github/actions/test
       with:
-        target: test-full
+        target: test-ci
+
+    - name: Ensure testing did not change sources
+      run: git diff --exit-code
+
+  smoke_test_benchmarks:
+    name: Smoke-test benchmarks
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: 'recursive'
+
+    # Testing uses the development environment Docker container.
+    # This action builds the container and executes the test suite inside it.
+    - uses: ./.github/actions/test
+      with:
+        target: test-benchmarks
+
+    - name: Ensure testing did not change sources
+      run: git diff --exit-code
+
+  smoke_test_fuzz:
+    name: Smoke-test fuzz
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: 'recursive'
+
+    # Testing uses the development environment Docker container.
+    # This action builds the container and executes the test suite inside it.
+    - uses: ./.github/actions/test
+      with:
+        target: test-fuzz
 
     - name: Ensure testing did not change sources
       run: git diff --exit-code
@@ -39,7 +73,7 @@ jobs:
 
   rustfmt:
     name: Rustfmt
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
       with:
@@ -49,3 +83,31 @@ jobs:
         rustup update
         rustup component add rustfmt
     - run: make indent-check
+
+  audit:
+    name: Cargo audit
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: 'recursive'
+    - name: Install Rust (rustup)
+      run: |
+        rustup update
+        rustup component add rustfmt
+    - run: cargo install cargo-audit
+    - run: cargo audit
+
+  docs:
+    name: Build docs
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: 'recursive'
+    - name: Install Rust (rustup)
+      run: |
+        rustup update
+        rustup component add rustfmt
+    - run: cargo install mdbook
+    - run: mdbook build docs

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN rustup component add rustfmt
 RUN rustup target add wasm32-wasi
 
 # Optional additional Rust programs
-RUN cargo install --debug cargo-audit cargo-watch rsign2 cargo-deb mdbook
+RUN cargo install --debug rsign2 cargo-deb
 
 RUN curl -sSLO https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-10/wasi-sdk_10.0_amd64.deb \
 	&& dpkg -i wasi-sdk_10.0_amd64.deb && rm -f wasi-sdk_10.0_amd64.deb

--- a/Makefile
+++ b/Makefile
@@ -37,17 +37,29 @@ test-packages:
             -p lucet-wiggle
 
 .PHONY: test-full
-test-full: indent-check audit book test-except-fuzz test-fuzz
+test-full: indent-check audit book test-ci test-benchmarks test-fuzz
 
-.PHONY: test-except-fuzz
-test-except-fuzz: test-packages
+.PHONY: test-ci
+test-ci: test-packages test-objdump test-bitrot test-signature test-objdump
+
+.PHONY: test-bitrot
+test-bitrot:
 	# check but do *not* build or run these packages to mitigate bitrot
 	cargo check -p lucet-spectest -p lucet-runtime-example
-	# run the benchmarks in debug mode
-	cargo test --benches -p lucet-benchmarks -- --test
+
+.PHONY: test-signature
+test-signature:
 	helpers/lucet-toolchain-tests/signature.sh
+
+.PHONY: test-objdump
+test-objdump:
 	cargo build -p lucet-objdump
 	helpers/lucet-toolchain-tests/objdump.sh
+
+.PHONY: test-benchmarks
+test-benchmarks:
+	# Smoke test of benchmarks:
+	cargo test --benches -p lucet-benchmarks -- --test
 
 # run a single seed through the fuzzer to stave off bitrot
 .PHONY: test-fuzz


### PR DESCRIPTION
we have run out of disk space on github actions. We're building an awful
lot of suff serially, so lets split them into many jobs so that each job
has some headroom.

* test-ci should just do a `profile = test` build. I'm not 100%
confident I got that right but lets run it and see.

* smoke testing benchmarks does a `profile = bench` build, so
  we can move that to its own makefile target and job.

* smoke testing fuzz does a `profile = debug` build, so
  we can move that to its own makefile target and job.

* cargo audit doesnt need to be in docker container. it can be its own
job in parallel. Just need stable rust and cargo-audit installed.

* docs build doesnt need to be in docker container. it can be its own
job in parallel. Just need stable rust and mdbook