### PR TITLE
Add release mode testing to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,6 +53,41 @@ jobs:
     - name: Ensure testing did not change sources
       run: git diff --exit-code
 
+  test_release:
+    name: Test Release
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: 'recursive'
+
+    # Testing uses the development environment Docker container.
+    # This action builds the container and executes the test suite inside it.
+    - uses: ./.github/actions/test
+      with:
+        target: test-release
+
+    - name: Ensure testing did not change sources
+      run: git diff --exit-code
+
+  test_release_executables:
+    name: Test Release Executables
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: 'recursive'
+
+    # Testing uses the development environment Docker container.
+    # This action builds the container and executes the test suite inside it.
+    - uses: ./.github/actions/test
+      with:
+        target: test-release-executables
+
+    - name: Ensure testing did not change sources
+      run: git diff --exit-code
+
+
   package:
     name: Package
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 export GUEST_MODULE_PREFIX:=$(abspath .)
 
+CRATES_NOT_TESTED = lucet-spectest lucet-benchmarks lucet-runtime-example
+
 .PHONY: build-dev
 build-dev:
 	@echo Creating a DEBUG build
@@ -25,19 +27,22 @@ test: indent-check test-packages
 
 .PHONY: test-packages
 test-packages:
-	cargo test --no-fail-fast \
-            -p lucet-runtime-internals \
-            -p lucet-runtime \
-            -p lucet-module \
-            -p lucetc \
-            -p lucet-wasi-sdk \
-            -p lucet-wasi \
-            -p lucet-wasi-fuzz \
-            -p lucet-validate \
-            -p lucet-wiggle
+	cargo test --no-fail-fast --all $(CRATES_NOT_TESTED:%=--exclude %)
 
 .PHONY: test-full
 test-full: indent-check audit book test-ci test-benchmarks test-fuzz
+
+# The --release option runs the tests on an artifact built in release mode. We
+# have found regressions in release mode due to optimizations in the past.
+.PHONY: test-release
+test-release:
+	cargo test --release --no-fail-fast --all --exclude $(CRATES_NOT_TESTED:%=--exclude %)
+
+.PHONY: test-release-executables
+test-release-executables:
+	cargo build --release
+	helpers/lucet-toolchain-tests/signature.sh
+	helpers/lucet-toolchain-tests/objdump.sh
 
 .PHONY: test-ci
 test-ci: test-packages test-objdump test-bitrot test-signature test-objdump
@@ -106,12 +111,4 @@ package:
 
 .PHONY: watch
 watch:
-	cargo watch --exec "test \
-            -p lucet-runtime-internals \
-            -p lucet-runtime \
-            -p lucet-module \
-            -p lucetc \
-            -p lucet-wasi-sdk \
-            -p lucet-wasi \
-            -p lucet-benchmarks \
-            -p lucet-validate"
+	cargo watch --exec "test --all --exclude $(CRATES_NOT_TESTED)"

--- a/lucet-wasi/tests/test_helpers/mod.rs
+++ b/lucet-wasi/tests/test_helpers/mod.rs
@@ -144,5 +144,6 @@ pub fn run_with_null_stdin<P: AsRef<Path>>(
 #[no_mangle]
 #[doc(hidden)]
 pub extern "C" fn lucet_wasi_tests_internal_ensure_linked() {
+    lucet_runtime::lucet_internal_ensure_linked();
     lucet_wasi::export_wasi_funcs();
 }

--- a/lucet-wasi/tests/tests.rs
+++ b/lucet-wasi/tests/tests.rs
@@ -1,6 +1,9 @@
 mod test_helpers;
 
-use crate::test_helpers::{run, run_with_null_stdin, run_with_stdout, LUCET_WASI_ROOT};
+use crate::test_helpers::{
+    lucet_wasi_tests_internal_ensure_linked, run, run_with_null_stdin, run_with_stdout,
+    LUCET_WASI_ROOT,
+};
 use lucet_wasi::{WasiCtx, WasiCtxBuilder};
 use std::fs::File;
 use std::path::Path;
@@ -8,6 +11,8 @@ use tempfile::TempDir;
 
 #[test]
 fn double_import() {
+    lucet_wasi_tests_internal_ensure_linked();
+
     let mut ctx = WasiCtxBuilder::new();
 
     let (exitcode, stdout) = run_with_stdout("duplicate_import.wat", &mut ctx).unwrap();

--- a/lucet-wiggle/tests/wasi.rs
+++ b/lucet-wiggle/tests/wasi.rs
@@ -385,6 +385,8 @@ fn main() {
     // The `init` function ensures that all of the host call functions are
     // linked into the executable.
     crate::hostcalls::init();
+    // Same for lucet-runtime:
+    lucet_runtime::lucet_internal_ensure_linked();
 
     // Temporary directory for outputs.
     let workdir = TempDir::new().expect("create working directory");


### PR DESCRIPTION
Adds makefile targets and CI jobs to test in `--release` mode, and fixes all tests to work in that mode.

Optimizations run in release builds which often lead to dead-code-elimination or link-time garbage collection opportunities, and change how our runtime dynamic linking ends up working. This testing should prevent further regressions like we had when upgrading to rust 1.42.