### PR TITLE
Allow use of pinned heap registers

### DIFF
--- a/benchmarks/lucet-benchmarks/src/context.rs
+++ b/benchmarks/lucet-benchmarks/src/context.rs
@@ -9,7 +9,8 @@ fn context_init(c: &mut Criterion) {
 
     c.bench_function("context_init", move |b| {
         b.iter(|| {
-            ContextHandle::create_and_init(&mut *stack, f as usize, &[]).unwrap();
+            ContextHandle::create_and_init(&mut *stack, f as usize, &[], std::ptr::null_mut())
+                .unwrap();
         })
     });
 }
@@ -22,7 +23,13 @@ fn context_swap_return(c: &mut Criterion) {
         b.iter_batched(
             || {
                 let mut stack = vec![0u64; 1024].into_boxed_slice();
-                let child = ContextHandle::create_and_init(&mut *stack, f as usize, &[]).unwrap();
+                let child = ContextHandle::create_and_init(
+                    &mut *stack,
+                    f as usize,
+                    &[],
+                    std::ptr::null_mut(),
+                )
+                .unwrap();
                 (stack, child)
             },
             |(stack, mut child)| unsafe {
@@ -44,8 +51,13 @@ fn context_init_swap_return(c: &mut Criterion) {
             || vec![0u64; 1024].into_boxed_slice(),
             |mut stack| {
                 let mut parent = ContextHandle::new();
-                let mut child =
-                    ContextHandle::create_and_init(&mut *stack, f as usize, &[]).unwrap();
+                let mut child = ContextHandle::create_and_init(
+                    &mut *stack,
+                    f as usize,
+                    &[],
+                    std::ptr::null_mut(),
+                )
+                .unwrap();
                 unsafe { Context::swap(&mut parent, &mut child) };
                 stack
             },
@@ -332,8 +344,13 @@ fn context_init_swap_return_many_args(c: &mut Criterion) {
             || vec![0u64; 1024].into_boxed_slice(),
             |mut stack| {
                 let mut parent = ContextHandle::new();
-                let mut child =
-                    ContextHandle::create_and_init(&mut *stack, f as usize, &args).unwrap();
+                let mut child = ContextHandle::create_and_init(
+                    &mut *stack,
+                    f as usize,
+                    &args,
+                    std::ptr::null_mut(),
+                )
+                .unwrap();
                 unsafe { Context::swap(&mut parent, &mut child) };
                 stack
             },

--- a/lucet-module/src/module_data.rs
+++ b/lucet-module/src/module_data.rs
@@ -59,6 +59,8 @@ pub struct ModuleFeatures {
     pub lzcnt: bool,
     pub popcnt: bool,
     pub instruction_count: bool,
+    pub pinned_heap: bool,
+    pub pinned_heap_register: u16,
     _hidden: (),
 }
 
@@ -75,6 +77,8 @@ impl ModuleFeatures {
             lzcnt: false,
             popcnt: false,
             instruction_count: false,
+            pinned_heap: false,
+            pinned_heap_register: 0,
             _hidden: (),
         }
     }

--- a/lucet-runtime/lucet-runtime-internals/src/alloc/tests.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/alloc/tests.rs
@@ -656,6 +656,7 @@ macro_rules! alloc_tests {
                     inst.alloc_mut().stack_u64_mut(),
                     heap_touching_child as usize,
                     &[Val::CPtr(heap_ptr)],
+                    heap_ptr,
                 )
                 .expect("context init succeeds");
                 Context::swap(&mut parent, &mut child);
@@ -705,6 +706,7 @@ macro_rules! alloc_tests {
                     inst.alloc_mut().stack_u64_mut(),
                     stack_pattern_child as usize,
                     &[Val::CPtr(heap_ptr)],
+                    heap_ptr,
                 )
                 .expect("context init succeeds");
                 Context::swap(&mut parent, &mut child);

--- a/lucet-runtime/lucet-runtime-internals/src/context/tests/c_child.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/context/tests/c_child.rs
@@ -55,6 +55,7 @@ macro_rules! init_and_swap {
                 &mut *$stack,
                 $fn as usize,
                 &[$( $args ),*],
+                std::ptr::null_mut(),
             ).unwrap()));
 
             child_regs = child;

--- a/lucet-runtime/lucet-runtime-internals/src/context/tests/mod.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/context/tests/mod.rs
@@ -31,7 +31,12 @@ fn init_rejects_unaligned() {
     let mut stack_unaligned = unsafe { slice::from_raw_parts_mut(ptr, len) };
 
     // now we have the unaligned stack, let's make sure it blows up right
-    let res = ContextHandle::create_and_init(&mut stack_unaligned, dummy as usize, &[]);
+    let res = ContextHandle::create_and_init(
+        &mut stack_unaligned,
+        dummy as usize,
+        &[],
+        std::ptr::null_mut(),
+    );
 
     if let Err(Error::UnalignedStack) = res {
         assert!(true);

--- a/lucet-runtime/lucet-runtime-internals/src/context/tests/rust_child.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/context/tests/rust_child.rs
@@ -51,6 +51,7 @@ macro_rules! init_and_swap {
                 &mut *$stack,
                 $fn as usize,
                 &[$( $args ),*],
+                std::ptr::null_mut(),
             ).unwrap();
             CHILD = Some(child);
 

--- a/lucet-runtime/lucet-runtime-internals/src/instance.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/instance.rs
@@ -973,7 +973,8 @@ impl Instance {
 
         self.entrypoint = Some(func);
 
-        let mut args_with_vmctx = vec![Val::from(self.alloc.slot().heap)];
+        let heap = self.alloc.slot().heap;
+        let mut args_with_vmctx = vec![Val::from(heap)];
         args_with_vmctx.extend_from_slice(args);
 
         let self_ptr = self as *mut _;
@@ -984,6 +985,7 @@ impl Instance {
             self_ptr,
             func.ptr.as_usize(),
             &args_with_vmctx,
+            heap,
         )?;
 
         self.install_activator();

--- a/lucetc/lucetc/main.rs
+++ b/lucetc/lucetc/main.rs
@@ -100,7 +100,8 @@ pub fn run(opts: &Options) -> Result<(), Error> {
         .with_bindings(bindings)
         .with_opt_level(opts.opt_level)
         .with_cpu_features(opts.cpu_features.clone())
-        .with_target(opts.target.clone());
+        .with_target(opts.target.clone())
+        .with_pinned_heap(opts.pinned_heap);
 
     if let Some(validator) = validator.take() {
         c.validator(validator);

--- a/lucetc/lucetc/options.rs
+++ b/lucetc/lucetc/options.rs
@@ -120,6 +120,7 @@ pub struct Options {
     pub pk_path: Option<PathBuf>,
     pub sk_path: Option<PathBuf>,
     pub count_instructions: bool,
+    pub pinned_heap: bool,
     pub error_style: ErrorStyle,
     pub target: Triple,
 }
@@ -211,6 +212,7 @@ impl Options {
         let sk_path = m.value_of("sk_path").map(PathBuf::from);
         let pk_path = m.value_of("pk_path").map(PathBuf::from);
         let count_instructions = m.is_present("count_instructions");
+        let pinned_heap = m.is_present("pinned_heap");
 
         let error_style = match m.value_of("error_style") {
             None => ErrorStyle::default(),
@@ -239,6 +241,7 @@ impl Options {
             sk_path,
             pk_path,
             count_instructions,
+            pinned_heap,
             error_style,
             target,
         })
@@ -451,6 +454,12 @@ SSE3 but not AVX:
                     .long("--count-instructions")
                     .takes_value(false)
                     .help("Instrument the produced binary to count the number of wasm operations the translated program executes")
+            )
+            .arg(
+                Arg::with_name("pinned_heap")
+                    .long("--pinned-heap-reg")
+                    .takes_value(false)
+                    .help("This feature is not stable - it may be removed in the future! Pin a register to use as this module's heap base. Typically improves performance.")
             )
             .arg(
                 Arg::with_name("error_style")

--- a/lucetc/src/lib.rs
+++ b/lucetc/src/lib.rs
@@ -104,6 +104,8 @@ pub trait LucetcOpts {
     fn with_count_instructions(self, enable_count: bool) -> Self;
     fn canonicalize_nans(&mut self, enable_canonicalize_nans: bool);
     fn with_canonicalize_nans(self, enable_canonicalize_nans: bool) -> Self;
+    fn pinned_heap(&mut self, enable_pinned_heap: bool);
+    fn with_pinned_heap(self, enable_pinned_heap: bool) -> Self;
 }
 
 impl<T: AsLucetc> LucetcOpts for T {
@@ -258,6 +260,15 @@ impl<T: AsLucetc> LucetcOpts for T {
         self.canonicalize_nans(enable_nans_canonicalization);
         self
     }
+
+    fn pinned_heap(&mut self, enable_pinned_heap: bool) {
+        self.as_lucetc().builder.pinned_heap(enable_pinned_heap);
+    }
+
+    fn with_pinned_heap(mut self, enable_pinned_heap: bool) -> Self {
+        self.pinned_heap(enable_pinned_heap);
+        self
+    }
 }
 
 impl Lucetc {
@@ -315,7 +326,6 @@ impl Lucetc {
         let (module_contents, bindings) = self.build()?;
 
         let compiler = self.builder.create(&module_contents, &bindings)?;
-
         compiler.cranelift_funcs()?.write(&output)?;
 
         Ok(())

--- a/lucetc/tests/wasm.rs
+++ b/lucetc/tests/wasm.rs
@@ -58,6 +58,7 @@ mod module_data {
             false,
             &None,
             false,
+            false,
         )
         .expect("compiling exported_import");
         let mdata = c.module_data().unwrap();
@@ -288,7 +289,6 @@ mod module_data {
         let h = HeapSettings::default();
         let builder = Compiler::builder().with_heap_settings(h.clone());
         let c = builder.create(&m, &b).expect("compiling heap_spec_import");
-
         assert_eq!(
             c.module_data().unwrap().heap_spec(),
             Some(&HeapSpec {
@@ -313,7 +313,6 @@ mod module_data {
         let c = builder
             .create(&m, &b)
             .expect("compiling heap_spec_definition");
-
         assert_eq!(
             c.module_data().unwrap().heap_spec(),
             Some(&HeapSpec {
@@ -572,6 +571,7 @@ mod validate {
             h,
             false,
             &Some(v),
+            false,
             false,
         )
         .expect("compile");


### PR DESCRIPTION
@pchickey @awortman-fastly @iximeow Slightly cleaned up and rebased version of https://github.com/bytecodealliance/lucet/pull/273 with some comment fixes

I've left the code mostly as is although some of the changes here seem orthogonal. Wanted to ask about this first before removing the code
- Context save for sandbox is also saving the value for register r8
- In stack.rs, there is a stack overflow test where the size of the stack seems to be bumped.

Let me know if I should remove either of these, and I can update the PR
