### PR TITLE
move `host_page_size` to sysdeps

### DIFF
--- a/lucet-runtime/lucet-runtime-internals/src/alloc/mod.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/alloc/mod.rs
@@ -1,37 +1,11 @@
 use crate::error::Error;
 use crate::module::Module;
 use crate::region::RegionInternal;
+use crate::sysdeps::host_page_size;
 use libc::c_void;
 use lucet_module::GlobalValue;
-use nix::unistd::{sysconf, SysconfVar};
 use rand::{thread_rng, Rng, RngCore};
-use std::sync::{Arc, Mutex, Once, Weak};
-
-pub const HOST_PAGE_SIZE_EXPECTED: usize = 4096;
-static mut HOST_PAGE_SIZE: usize = 0;
-static HOST_PAGE_SIZE_INIT: Once = Once::new();
-
-/// Our host is Linux x86_64, which should always use a 4K page.
-///
-/// We double check the expected value using `sysconf` at runtime.
-pub fn host_page_size() -> usize {
-    unsafe {
-        HOST_PAGE_SIZE_INIT.call_once(|| match sysconf(SysconfVar::PAGE_SIZE) {
-            Ok(Some(sz)) => {
-                if sz as usize == HOST_PAGE_SIZE_EXPECTED {
-                    HOST_PAGE_SIZE = HOST_PAGE_SIZE_EXPECTED;
-                } else {
-                    panic!(
-                        "host page size was {}; expected {}",
-                        sz, HOST_PAGE_SIZE_EXPECTED
-                    );
-                }
-            }
-            _ => panic!("could not get host page size from sysconf"),
-        });
-        HOST_PAGE_SIZE
-    }
-}
+use std::sync::{Arc, Mutex, Weak};
 
 pub fn instance_heap_offset() -> usize {
     1 * host_page_size()

--- a/lucet-runtime/lucet-runtime-internals/src/alloc/tests.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/alloc/tests.rs
@@ -6,7 +6,7 @@ macro_rules! alloc_tests {
         use rand::{thread_rng, Rng, SeedableRng};
         use std::sync::{Arc, Mutex};
         use $TestRegion as TestRegion;
-        use $crate::alloc::{host_page_size, AllocStrategy, Limits, MINSIGSTKSZ};
+        use $crate::alloc::{AllocStrategy, Limits, MINSIGSTKSZ};
         use $crate::context::{Context, ContextHandle};
         use $crate::error::Error;
         use $crate::instance::InstanceInternal;
@@ -14,6 +14,7 @@ macro_rules! alloc_tests {
             FunctionPointer, GlobalValue, HeapSpec, MockExportBuilder, MockModuleBuilder, Module,
         };
         use $crate::region::Region;
+        use $crate::sysdeps::host_page_size;
         use $crate::val::Val;
         use $crate::vmctx::lucet_vmctx;
 

--- a/lucet-runtime/lucet-runtime-internals/src/instance.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/instance.rs
@@ -7,7 +7,7 @@ pub use crate::instance::execution::{KillError, KillState, KillSuccess, KillSwit
 pub use crate::instance::signals::{signal_handler_none, SignalBehavior, SignalHandler};
 pub use crate::instance::state::State;
 
-use crate::alloc::{Alloc, HOST_PAGE_SIZE_EXPECTED};
+use crate::alloc::Alloc;
 use crate::context::Context;
 use crate::embed_ctx::CtxMap;
 use crate::error::Error;
@@ -15,6 +15,7 @@ use crate::error::Error;
 use crate::lock_testpoints::LockTestpoints;
 use crate::module::{self, FunctionHandle, Global, GlobalValue, Module, TrapCode};
 use crate::region::RegionInternal;
+use crate::sysdeps::HOST_PAGE_SIZE_EXPECTED;
 use crate::val::{UntypedRetVal, Val};
 use crate::WASM_PAGE_SIZE;
 use libc::{c_void, pthread_self, siginfo_t, uintptr_t};

--- a/lucet-runtime/lucet-runtime-internals/src/module/sparse_page_data.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/module/sparse_page_data.rs
@@ -3,10 +3,11 @@ macro_rules! sparse_page_data_tests {
     ( $TestRegion:path ) => {
         use std::sync::Arc;
         use $TestRegion as TestRegion;
-        use $crate::alloc::{host_page_size, Limits};
+        use $crate::alloc::Limits;
         use $crate::instance::InstanceInternal;
         use $crate::module::{MockModuleBuilder, Module};
         use $crate::region::Region;
+        use $crate::sysdeps::host_page_size;
 
         const FIRST_MESSAGE: &'static [u8] = b"hello from mock_sparse_module!";
         const SECOND_MESSAGE: &'static [u8] = b"hello again from mock_sparse_module!";

--- a/lucet-runtime/lucet-runtime-internals/src/region/mmap.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/region/mmap.rs
@@ -1,9 +1,10 @@
-use crate::alloc::{host_page_size, instance_heap_offset, Alloc, AllocStrategy, Limits, Slot};
+use crate::alloc::{instance_heap_offset, Alloc, AllocStrategy, Limits, Slot};
 use crate::embed_ctx::CtxMap;
 use crate::error::Error;
 use crate::instance::{new_instance_handle, Instance, InstanceHandle};
 use crate::module::Module;
 use crate::region::{Region, RegionCreate, RegionInternal};
+use crate::sysdeps::host_page_size;
 use libc::c_void;
 #[cfg(not(target_os = "linux"))]
 use libc::memset;

--- a/lucet-runtime/lucet-runtime-internals/src/sysdeps/mod.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/sysdeps/mod.rs
@@ -4,8 +4,14 @@ mod macos;
 #[cfg(target_os = "linux")]
 mod linux;
 
+#[cfg(unix)]
+mod unix;
+
 #[cfg(target_os = "macos")]
 pub use macos::*;
 
 #[cfg(target_os = "linux")]
 pub use linux::*;
+
+#[cfg(unix)]
+pub use unix::*;

--- a/lucet-runtime/lucet-runtime-internals/src/sysdeps/unix.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/sysdeps/unix.rs
@@ -1,0 +1,28 @@
+use nix::unistd::{sysconf, SysconfVar};
+use std::sync::Once;
+
+pub const HOST_PAGE_SIZE_EXPECTED: usize = 4096;
+static mut HOST_PAGE_SIZE: usize = 0;
+static HOST_PAGE_SIZE_INIT: Once = Once::new();
+
+/// Linux x86-64 and Mac x86-64 hosts should always use a 4K page.
+///
+/// We double check the expected value using `sysconf` at runtime.
+pub fn host_page_size() -> usize {
+    unsafe {
+        HOST_PAGE_SIZE_INIT.call_once(|| match sysconf(SysconfVar::PAGE_SIZE) {
+            Ok(Some(sz)) => {
+                if sz as usize == HOST_PAGE_SIZE_EXPECTED {
+                    HOST_PAGE_SIZE = HOST_PAGE_SIZE_EXPECTED;
+                } else {
+                    panic!(
+                        "host page size was {}; expected {}",
+                        sz, HOST_PAGE_SIZE_EXPECTED
+                    );
+                }
+            }
+            _ => panic!("could not get host page size from sysconf"),
+        });
+        HOST_PAGE_SIZE
+    }
+}


### PR DESCRIPTION
I have this quixotic idea that most OS/arch-specific stuff should be able to live in `lucet_runtime_internals::sysdeps`; this patch is a first step along that path.  Ideally, adding Windows support can be boiled down to figuring out how to expose the right interfaces from `sysdeps` that everybody can implement.  Signals make this very tricky, among other things, but perhaps since Firefox doesn't care about signals + Lucet, the signal support for Windows can somehow be punted down the road.

Happy to hear thoughts about what might be a better path to structuring the codebase for Windows support.