### PR TITLE
Allow flexible memory management using Uffd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -853,6 +853,8 @@ dependencies = [
 [[package]]
 name = "linux-version"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c85966c8171cf471b2ac0fa33b9e45b9fbc48e75e462a8cb2a315ebdb0e244d1"
 dependencies = [
  "bindgen",
  "nix 0.13.1",
@@ -2198,7 +2200,9 @@ checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 
 [[package]]
 name = "userfaultfd"
-version = "0.2.0-dev"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45f718200831909259d1f05beafb64dfc6b7d1781662eb38279619607f725860"
 dependencies = [
  "bitflags 1.2.1",
  "libc",
@@ -2209,7 +2213,9 @@ dependencies = [
 
 [[package]]
 name = "userfaultfd-sys"
-version = "0.2.0-dev"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6e183d6d9a20a44491bf60e2743b309231255e818a107b1e9c94c4094fe28d"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,17 +116,13 @@ dependencies = [
  "cexpr",
  "cfg-if",
  "clang-sys",
- "clap",
- "env_logger",
  "lazy_static",
- "log",
  "peeking_take_while",
  "proc-macro2 1.0.10",
  "quote 1.0.3",
  "regex",
  "rustc-hash",
  "shlex",
- "which",
 ]
 
 [[package]]
@@ -851,17 +847,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "linux-version"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85966c8171cf471b2ac0fa33b9e45b9fbc48e75e462a8cb2a315ebdb0e244d1"
-dependencies = [
- "bindgen",
- "nix 0.13.1",
- "semver",
-]
-
-[[package]]
 name = "log"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -882,7 +867,7 @@ dependencies = [
  "lucet-wasi",
  "lucet-wasi-sdk",
  "lucetc",
- "nix 0.17.0",
+ "nix",
  "num_cpus",
  "rayon",
  "tempfile",
@@ -944,7 +929,7 @@ dependencies = [
  "lucet-runtime-tests",
  "lucet-wasi-sdk",
  "lucetc",
- "nix 0.17.0",
+ "nix",
  "num-derive",
  "num-traits",
  "rayon",
@@ -974,7 +959,7 @@ dependencies = [
  "lucet-module",
  "lucet-runtime-macros",
  "memoffset",
- "nix 0.17.0",
+ "nix",
  "num-derive",
  "num-traits",
  "rand 0.7.3",
@@ -1055,7 +1040,7 @@ dependencies = [
  "lucet-wasi-sdk",
  "lucet-wiggle",
  "lucetc",
- "nix 0.17.0",
+ "nix",
  "rand 0.6.5",
  "tempfile",
  "wasi-common",
@@ -1073,7 +1058,7 @@ dependencies = [
  "lucet-wasi",
  "lucet-wasi-sdk",
  "lucetc",
- "nix 0.17.0",
+ "nix",
  "num_cpus",
  "progress",
  "rand 0.6.5",
@@ -1223,19 +1208,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa679ff6578b1cddee93d7e82e263b94a575e0bfced07284eb0c037c1d2416a5"
 dependencies = [
  "adler32",
-]
-
-[[package]]
-name = "nix"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dbdc256eaac2e3bd236d93ad999d3479ef775c863dbda3068c4006a92eec51b"
-dependencies = [
- "bitflags 1.2.1",
- "cc",
- "cfg-if",
- "libc",
- "void",
 ]
 
 [[package]]
@@ -2200,27 +2172,26 @@ checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 
 [[package]]
 name = "userfaultfd"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45f718200831909259d1f05beafb64dfc6b7d1781662eb38279619607f725860"
+checksum = "e394bc3ecd454f68f04803a7b527b36956413120fa06420dc1329cda49340763"
 dependencies = [
  "bitflags 1.2.1",
  "libc",
- "nix 0.13.1",
+ "nix",
  "thiserror",
  "userfaultfd-sys",
 ]
 
 [[package]]
 name = "userfaultfd-sys"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6e183d6d9a20a44491bf60e2743b309231255e818a107b1e9c94c4094fe28d"
+checksum = "3e34081f6dafe78988982f6139db289dd147ce1ac1d1dce208ae94e37650ac03"
 dependencies = [
  "bindgen",
  "cc",
  "cfg-if",
- "linux-version",
 ]
 
 [[package]]
@@ -2393,15 +2364,6 @@ checksum = "2d6f51648d8c56c366144378a33290049eafdd784071077f6fe37dae64c1c4cb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "which"
-version = "3.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
-dependencies = [
- "libc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -934,6 +934,7 @@ dependencies = [
  "anyhow",
  "byteorder",
  "cc",
+ "cfg-if",
  "lazy_static",
  "libc",
  "lucet-module",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,6 +107,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.51.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebd71393f1ec0509b553aa012b9b58e81dadbdff7130bd3b8cba576e69b32f75"
+dependencies = [
+ "bitflags 1.2.1",
+ "cexpr",
+ "cfg-if",
+ "clang-sys",
+ "clap",
+ "env_logger",
+ "lazy_static",
+ "log",
+ "peeking_take_while",
+ "proc-macro2 1.0.10",
+ "quote 1.0.3",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "which",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -200,10 +223,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d87b23d6a92cd03af510a5ade527033f6aa6fa92161e2d5863a907d4c5e31d"
 
 [[package]]
+name = "cexpr"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fce5b5fb86b0c57c20c834c1b412fd09c77c8a59b9473f86272709e78874cd1d"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "clang-sys"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81de550971c976f176130da4b2978d3b524eaa0fd9ac31f3ceb5ae1231fb4853"
+dependencies = [
+ "glob 0.3.0",
+ "libc",
+ "libloading",
+]
 
 [[package]]
 name = "clap"
@@ -662,6 +705,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 
 [[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+
+[[package]]
 name = "goblin"
 version = "0.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -802,6 +851,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-version"
+version = "0.1.0"
+dependencies = [
+ "bindgen",
+ "nix 0.13.1",
+ "semver",
+]
+
+[[package]]
 name = "log"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -822,7 +880,7 @@ dependencies = [
  "lucet-wasi",
  "lucet-wasi-sdk",
  "lucetc",
- "nix",
+ "nix 0.17.0",
  "num_cpus",
  "rayon",
  "tempfile",
@@ -883,7 +941,7 @@ dependencies = [
  "lucet-runtime-tests",
  "lucet-wasi-sdk",
  "lucetc",
- "nix",
+ "nix 0.17.0",
  "num-derive",
  "num-traits",
  "rayon",
@@ -913,13 +971,14 @@ dependencies = [
  "lucet-module",
  "lucet-runtime-macros",
  "memoffset",
- "nix",
+ "nix 0.17.0",
  "num-derive",
  "num-traits",
  "rand 0.7.3",
  "raw-cpuid 6.1.0",
  "thiserror",
  "tracing",
+ "userfaultfd",
 ]
 
 [[package]]
@@ -993,7 +1052,7 @@ dependencies = [
  "lucet-wasi-sdk",
  "lucet-wiggle",
  "lucetc",
- "nix",
+ "nix 0.17.0",
  "rand 0.6.5",
  "tempfile",
  "wasi-common",
@@ -1011,7 +1070,7 @@ dependencies = [
  "lucet-wasi",
  "lucet-wasi-sdk",
  "lucetc",
- "nix",
+ "nix 0.17.0",
  "num_cpus",
  "progress",
  "rand 0.6.5",
@@ -1165,6 +1224,19 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dbdc256eaac2e3bd236d93ad999d3479ef775c863dbda3068c4006a92eec51b"
+dependencies = [
+ "bitflags 1.2.1",
+ "cc",
+ "cfg-if",
+ "libc",
+ "void",
+]
+
+[[package]]
+name = "nix"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50e4785f2c3b7589a0d0c1dd60285e1188adac4006e8abd6dd578e1567027363"
@@ -1174,6 +1246,16 @@ dependencies = [
  "cfg-if",
  "libc",
  "void",
+]
+
+[[package]]
+name = "nom"
+version = "4.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
+dependencies = [
+ "memchr",
+ "version_check 0.1.5",
 ]
 
 [[package]]
@@ -1274,6 +1356,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1330,7 +1418,7 @@ dependencies = [
  "proc-macro2 1.0.10",
  "quote 1.0.3",
  "syn 1.0.18",
- "version_check",
+ "version_check 0.9.1",
 ]
 
 [[package]]
@@ -1343,7 +1431,7 @@ dependencies = [
  "quote 1.0.3",
  "syn 1.0.18",
  "syn-mid",
- "version_check",
+ "version_check 0.9.1",
 ]
 
 [[package]]
@@ -1838,6 +1926,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
+
+[[package]]
 name = "sightglass"
 version = "0.1.0"
 dependencies = [
@@ -2102,10 +2196,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 
 [[package]]
+name = "userfaultfd"
+version = "0.2.0-dev"
+dependencies = [
+ "bitflags 1.2.1",
+ "libc",
+ "nix 0.13.1",
+ "thiserror",
+ "userfaultfd-sys",
+]
+
+[[package]]
+name = "userfaultfd-sys"
+version = "0.2.0-dev"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cfg-if",
+ "linux-version",
+]
+
+[[package]]
 name = "vec_map"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
+
+[[package]]
+name = "version_check"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 
 [[package]]
 name = "version_check"
@@ -2139,7 +2260,7 @@ checksum = "23d7043ebb3e5d96fad7a8d3ca22ee9880748ff8c3e18092cfb2a49d3b8f9084"
 dependencies = [
  "cc",
  "cmake",
- "glob",
+ "glob 0.2.11",
 ]
 
 [[package]]
@@ -2265,6 +2386,15 @@ checksum = "2d6f51648d8c56c366144378a33290049eafdd784071077f6fe37dae64c1c4cb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "which"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@ FROM ubuntu:bionic
 
 # This env variable makes sure installing the tzdata package doesn't hang in prompt
 ENV DEBIAN_FRONTEND=noninteractive
+
+# This env variable makes sure installing the tzdata package doesn't hang in prompt
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \
 	build-essential \
@@ -21,9 +24,11 @@ RUN apt-get update \
 	creduce \
 	gcc-multilib \
 	clang-6.0 \
+	llvm-6.0 \
 	&& rm -rf /var/lib/apt/lists/*
 
 RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-6.0 100
+RUN update-alternatives --install /usr/bin/llvm-config llvm-config /usr/bin/llvm-config-6.0 100
 
 # Setting a consistent LD_LIBRARY_PATH across the entire environment prevents unnecessary Cargo
 # rebuilds.
@@ -48,7 +53,7 @@ ENV BINARYEN_DIR=/opt/binaryen
 ENV BINARYEN_VERSION=86
 RUN curl -sS -L "https://github.com/WebAssembly/binaryen/archive/version_${BINARYEN_VERSION}.tar.gz" | tar xzf - && \
     mkdir -p binaryen-build && ( cd binaryen-build && cmake "../binaryen-version_${BINARYEN_VERSION}" && \
-    make wasm-opt wasm-reduce ) && \
+    make -j wasm-opt wasm-reduce ) && \
     install -d -v "${BINARYEN_DIR}/bin" && \
     for tool in wasm-opt wasm-reduce; do install -v "binaryen-build/bin/${tool}" "${BINARYEN_DIR}/bin/"; done && \
     rm -fr binaryen-build binaryen-version_${BINARYEN_VERSION}

--- a/lucet-runtime/Cargo.toml
+++ b/lucet-runtime/Cargo.toml
@@ -49,7 +49,9 @@ assets = [
 ]
 
 [features]
-default = []
-
-concurrent_testpoints = []
+default-features = []
 uffd = ["lucet-runtime-internals/uffd"]
+concurrent_testpoints = []
+
+[package.metadata.docs.rs]
+features = ["uffd"]

--- a/lucet-runtime/Cargo.toml
+++ b/lucet-runtime/Cargo.toml
@@ -49,7 +49,7 @@ assets = [
 ]
 
 [features]
-default-features = []
+default = ["uffd"]
 uffd = ["lucet-runtime-internals/uffd"]
 concurrent_testpoints = []
 

--- a/lucet-runtime/Cargo.toml
+++ b/lucet-runtime/Cargo.toml
@@ -10,6 +10,7 @@ authors = ["Lucet team <lucet@fastly.com>"]
 edition = "2018"
 
 [dependencies]
+cfg-if = "0.1"
 libc = "0.2.65"
 lucet-runtime-internals = { path = "lucet-runtime-internals", version = "=0.7.0-dev" }
 lucet-module = { path = "../lucet-module", version = "=0.7.0-dev" }
@@ -51,3 +52,4 @@ assets = [
 default = []
 
 concurrent_testpoints = []
+uffd = ["lucet-runtime-internals/uffd"]

--- a/lucet-runtime/include/lucet.h
+++ b/lucet-runtime/include/lucet.h
@@ -66,6 +66,10 @@ enum lucet_error lucet_mmap_region_create(uint64_t                         insta
                                           const struct lucet_alloc_limits *limits,
                                           struct lucet_region **           region_out);
 
+enum lucet_error lucet_uffd_region_create(uint64_t                         instance_capacity,
+                                          const struct lucet_alloc_limits *limits,
+                                          struct lucet_region **           region_out);
+
 enum lucet_error lucet_region_new_instance(const struct lucet_region *   region,
                                            const struct lucet_dl_module *module,
                                            struct lucet_instance **      inst_out);

--- a/lucet-runtime/lucet-runtime-internals/Cargo.toml
+++ b/lucet-runtime/lucet-runtime-internals/Cargo.toml
@@ -37,7 +37,10 @@ byteorder = "1.2"
 cc = "1.0"
 
 [features]
-default = []
+default-features = []
 
-concurrent_testpoints = []
 uffd = ["userfaultfd"]
+concurrent_testpoints = []
+
+[package.metadata.docs.rs]
+features = ["uffd"]

--- a/lucet-runtime/lucet-runtime-internals/Cargo.toml
+++ b/lucet-runtime/lucet-runtime-internals/Cargo.toml
@@ -28,7 +28,7 @@ rand = "0.7"
 raw-cpuid = "6.0.0"
 thiserror = "1.0.4"
 tracing = "0.1.12"
-userfaultfd = { path = "../../../userfaultfd-rs" }
+userfaultfd = { path = "../../../userfaultfd-rs", optional = true }
 
 [dev-dependencies]
 byteorder = "1.2"
@@ -40,3 +40,4 @@ cc = "1.0"
 default = []
 
 concurrent_testpoints = []
+uffd = ["userfaultfd"]

--- a/lucet-runtime/lucet-runtime-internals/Cargo.toml
+++ b/lucet-runtime/lucet-runtime-internals/Cargo.toml
@@ -28,7 +28,7 @@ rand = "0.7"
 raw-cpuid = "6.0.0"
 thiserror = "1.0.4"
 tracing = "0.1.12"
-userfaultfd = { path = "../../../userfaultfd-rs", optional = true }
+userfaultfd = { version = "0.1.0", optional = true }
 
 [dev-dependencies]
 byteorder = "1.2"

--- a/lucet-runtime/lucet-runtime-internals/Cargo.toml
+++ b/lucet-runtime/lucet-runtime-internals/Cargo.toml
@@ -28,6 +28,7 @@ rand = "0.7"
 raw-cpuid = "6.0.0"
 thiserror = "1.0.4"
 tracing = "0.1.12"
+userfaultfd = { path = "../../../userfaultfd-rs" }
 
 [dev-dependencies]
 byteorder = "1.2"

--- a/lucet-runtime/lucet-runtime-internals/Cargo.toml
+++ b/lucet-runtime/lucet-runtime-internals/Cargo.toml
@@ -30,7 +30,7 @@ thiserror = "1.0.4"
 tracing = "0.1.12"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-userfaultfd = { version = "0.1.0", optional = true }
+userfaultfd = { version = "0.2.0", optional = true }
 
 [dev-dependencies]
 byteorder = "1.2"

--- a/lucet-runtime/lucet-runtime-internals/Cargo.toml
+++ b/lucet-runtime/lucet-runtime-internals/Cargo.toml
@@ -28,6 +28,8 @@ rand = "0.7"
 raw-cpuid = "6.0.0"
 thiserror = "1.0.4"
 tracing = "0.1.12"
+
+[target.'cfg(target_os = "linux")'.dependencies]
 userfaultfd = { version = "0.1.0", optional = true }
 
 [dev-dependencies]
@@ -37,8 +39,7 @@ byteorder = "1.2"
 cc = "1.0"
 
 [features]
-default-features = []
-
+default = ["uffd"]
 uffd = ["userfaultfd"]
 concurrent_testpoints = []
 

--- a/lucet-runtime/lucet-runtime-internals/src/alloc/tests.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/alloc/tests.rs
@@ -1186,7 +1186,7 @@ mod mmap {
     alloc_tests!(crate::region::mmap::MmapRegion);
 }
 
-#[cfg(all(test, feature = "uffd"))]
+#[cfg(all(test, target_os = "linux", feature = "uffd"))]
 mod uffd {
     alloc_tests!(crate::region::uffd::UffdRegion);
 }

--- a/lucet-runtime/lucet-runtime-internals/src/alloc/tests.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/alloc/tests.rs
@@ -242,9 +242,9 @@ macro_rules! alloc_tests {
             max_size: Some(EXPANDPASTLIMIT_MAX_SIZE),
         };
 
-        /// This test shows that a heap refuses to grow past the alloc limits, even if the runtime
-        /// spec says it can grow bigger. This test uses a region with multiple slots in order to
-        /// exercise more edge cases with adjacent managed memory.
+        /// This test shows that a heap refuses to grow past the region's limits, even if the
+        /// runtime spec says it can grow bigger. This test uses a region with multiple slots in
+        /// order to exercise more edge cases with adjacent managed memory.
         #[test]
         fn expand_past_heap_limit() {
             let region = TestRegion::create(10, &LIMITS).expect("region created");
@@ -275,6 +275,55 @@ macro_rules! alloc_tests {
 
             let still_heap_len = inst.alloc().heap_len();
             assert_eq!(still_heap_len, LIMITS_HEAP_MEM_SIZE);
+
+            let heap = unsafe { inst.alloc_mut().heap_mut() };
+            assert_eq!(heap[new_heap_len - 1], 0);
+            heap[new_heap_len - 1] = 0xFF;
+            assert_eq!(heap[new_heap_len - 1], 0xFF);
+        }
+
+        /// This test shows that a heap refuses to grow past the instance-specific heap limit, even
+        /// if both the region's limits and the runtime spec says it can grow bigger. This test uses
+        /// a region with multiple slots in order to exercise more edge cases with adjacent managed
+        /// memory.
+        #[test]
+        fn expand_past_instance_heap_limit() {
+            const INSTANCE_LIMIT: usize = LIMITS.heap_memory_size / 2;
+            const SPEC: HeapSpec = HeapSpec {
+                initial_size: INSTANCE_LIMIT as u64 - 64 * 1024,
+                ..EXPAND_PAST_LIMIT_SPEC
+            };
+            assert_eq!(INSTANCE_LIMIT % host_page_size(), 0);
+
+            let region = TestRegion::create(10, &LIMITS).expect("region created");
+            let module = MockModuleBuilder::new().with_heap_spec(SPEC).build();
+            let mut inst = region
+                .new_instance_builder(module.clone())
+                .with_heap_size_limit(INSTANCE_LIMIT)
+                .build()
+                .expect("instantiation succeeds");
+
+            let heap_len = inst.alloc().heap_len();
+            assert_eq!(heap_len, SPEC.initial_size as usize);
+
+            // fill up the rest of the per-instance limit area
+            let new_heap_area = inst
+                .alloc_mut()
+                .expand_heap(64 * 1024, module.as_ref())
+                .expect("expand_heap succeeds");
+            assert_eq!(heap_len, new_heap_area as usize);
+
+            let new_heap_len = inst.alloc().heap_len();
+            assert_eq!(new_heap_len, INSTANCE_LIMIT);
+
+            let past_limit_heap_area = inst.alloc_mut().expand_heap(64 * 1024, module.as_ref());
+            assert!(
+                past_limit_heap_area.is_err(),
+                "heap expansion past limit fails"
+            );
+
+            let still_heap_len = inst.alloc().heap_len();
+            assert_eq!(still_heap_len, INSTANCE_LIMIT);
 
             let heap = unsafe { inst.alloc_mut().heap_mut() };
             assert_eq!(heap[new_heap_len - 1], 0);
@@ -1133,4 +1182,11 @@ macro_rules! alloc_tests {
 }
 
 #[cfg(test)]
-alloc_tests!(crate::region::mmap::MmapRegion);
+mod mmap {
+    alloc_tests!(crate::region::mmap::MmapRegion);
+}
+
+#[cfg(all(test, feature = "uffd"))]
+mod uffd {
+    alloc_tests!(crate::region::uffd::UffdRegion);
+}

--- a/lucet-runtime/lucet-runtime-internals/src/module.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/module.rs
@@ -118,7 +118,6 @@ pub trait ModuleInternal: Send + Sync {
             ));
         }
         let heap_memory_size = std::cmp::min(limits.heap_memory_size, instance_heap_limit);
-
         // Modules without heap specs will not access the heap
         if let Some(heap) = self.heap_spec() {
             // Assure that the total reserved + guard regions fit in the address space.

--- a/lucet-runtime/lucet-runtime-internals/src/region.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/region.rs
@@ -1,4 +1,5 @@
 pub mod mmap;
+pub mod uffd;
 
 use crate::alloc::{Alloc, AllocStrategy, Limits, Slot};
 use crate::embed_ctx::CtxMap;

--- a/lucet-runtime/lucet-runtime-internals/src/region.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/region.rs
@@ -1,4 +1,6 @@
 pub mod mmap;
+
+#[cfg(feature = "uffd")]
 pub mod uffd;
 
 use crate::alloc::{Alloc, AllocStrategy, Limits, Slot};

--- a/lucet-runtime/lucet-runtime-internals/src/region.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/region.rs
@@ -1,6 +1,6 @@
 pub mod mmap;
 
-#[cfg(feature = "uffd")]
+#[cfg(all(target_os = "linux", feature = "uffd"))]
 pub mod uffd;
 
 use crate::alloc::{Alloc, AllocStrategy, Limits, Slot};

--- a/lucet-runtime/lucet-runtime-internals/src/region/mmap.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/region/mmap.rs
@@ -82,6 +82,7 @@ impl RegionInternal for MmapRegion {
         mut alloc_strategy: AllocStrategy,
     ) -> Result<InstanceHandle, Error> {
         let limits = self.get_limits();
+
         module.validate_runtime_spec(&limits, heap_memory_size_limit)?;
 
         // Use the supplied alloc_strategy to get the next available slot

--- a/lucet-runtime/lucet-runtime-internals/src/region/uffd.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/region/uffd.rs
@@ -6,6 +6,7 @@ use crate::error::Error;
 use crate::instance::{new_instance_handle, Instance, InstanceHandle, InstanceInternal};
 use crate::module::Module;
 use crate::region::{Region, RegionCreate, RegionInternal};
+use crate::WASM_PAGE_SIZE;
 use crate::{lucet_bail, lucet_ensure, lucet_format_err};
 use libc::c_void;
 use nix::poll;
@@ -138,7 +139,8 @@ fn uffd_handler(
                     lucet_bail!("instance magic incorrect");
                 }
 
-                let loc = inst.alloc().addr_location(fault_addr as *const c_void);
+                let alloc = inst.alloc();
+                let loc = alloc.addr_location(fault_addr as *const c_void);
                 match loc {
                     AddrLocation::InaccessibleHeap | AddrLocation::StackGuard => {
                         // eprintln!("fault in heap guard!");
@@ -160,16 +162,12 @@ fn uffd_handler(
                     AddrLocation::Stack => {
                         uffd_strategy.stack_fault(&uffd, fault_page as *mut c_void)?
                     }
-                    AddrLocation::Heap => {
-                        let pages_into_heap =
-                            (fault_page - inst.alloc().slot().heap as usize) / host_page_size();
-                        uffd_strategy.heap_fault(
-                            &uffd,
-                            inst.module(),
-                            fault_page as *mut c_void,
-                            pages_into_heap,
-                        )?
-                    }
+                    AddrLocation::Heap => uffd_strategy.heap_fault(
+                        &uffd,
+                        inst.module(),
+                        alloc,
+                        fault_page as *mut c_void,
+                    )?,
                 }
             }
             Ok(Some(ev)) => panic!("unexpected uffd event: {:?}", ev),
@@ -327,7 +325,7 @@ impl RegionCreate for UffdRegion {
     const TYPE_NAME: &'static str = "UffdRegion";
 
     fn create(instance_capacity: usize, limits: &Limits) -> Result<Arc<Self>, Error> {
-        UffdRegion::create(instance_capacity, limits, DefaultUffdStrategy {})
+        UffdRegion::create(instance_capacity, limits, WasmPageSizedUffdStrategy {})
     }
 }
 
@@ -515,14 +513,14 @@ pub trait UffdStrategy: Send + Sync + 'static {
         &self,
         uffd: &Uffd,
         module: &dyn Module,
+        alloc: &Alloc,
         fault_page: *mut c_void,
-        pages_into_heap: usize,
     ) -> Result<(), Error>;
 }
 
-pub struct DefaultUffdStrategy;
+pub struct HostPageSizedUffdStrategy;
 
-impl UffdStrategy for DefaultUffdStrategy {
+impl UffdStrategy for HostPageSizedUffdStrategy {
     fn stack_fault(&self, uffd: &Uffd, fault_page: *mut c_void) -> Result<(), Error> {
         unsafe {
             uffd.zeropage(fault_page as *mut c_void, host_page_size(), true)
@@ -535,9 +533,11 @@ impl UffdStrategy for DefaultUffdStrategy {
         &self,
         uffd: &Uffd,
         module: &dyn Module,
+        alloc: &Alloc,
         fault_page: *mut c_void,
-        pages_into_heap: usize,
     ) -> Result<(), Error> {
+        let pages_into_heap = (fault_page as usize - alloc.slot().heap as usize) / host_page_size();
+
         // page fault occurred in the heap; copy or zero
         if let Some(page) = module.get_sparse_page_data(pages_into_heap) {
             // we are in the sparse data area, with a non-empty page; copy it in
@@ -552,12 +552,76 @@ impl UffdStrategy for DefaultUffdStrategy {
             }
         } else {
             // else if outside the sparse data area, or with an empty page
-            // eprintln!("zeroing a page at {:p}", fault_page as *mut c_void);
             unsafe {
                 uffd.zeropage(fault_page, host_page_size(), true)
                     .map_err(|e| Error::InternalError(e.into()))?;
             }
         }
+        Ok(())
+    }
+}
+
+pub struct WasmPageSizedUffdStrategy;
+
+impl UffdStrategy for WasmPageSizedUffdStrategy {
+    fn stack_fault(&self, uffd: &Uffd, fault_page: *mut c_void) -> Result<(), Error> {
+        unsafe {
+            uffd.zeropage(fault_page as *mut c_void, host_page_size(), true)
+                .map_err(|e| Error::InternalError(e.into()))?;
+        }
+        Ok(())
+    }
+
+    fn heap_fault(
+        &self,
+        uffd: &Uffd,
+        module: &dyn Module,
+        alloc: &Alloc,
+        fault_page: *mut c_void,
+    ) -> Result<(), Error> {
+        let slot = alloc.slot.as_ref().unwrap();
+        // Find the address of the fault relative to the heap base
+        let rel_fault_addr = fault_page as usize - slot.heap as usize;
+        // Find the base of the wasm page, relative to the heap start
+        let rel_wasm_page_base_addr = rel_fault_addr - (rel_fault_addr % WASM_PAGE_SIZE as usize);
+        // Find the absolute address of the base of the wasm page
+        let wasm_page_base_addr = slot.heap as usize + rel_wasm_page_base_addr;
+        // Find the number of host pages into the heap the wasm page base begins at
+        let base_pages_into_heap = rel_wasm_page_base_addr / host_page_size();
+
+        assert!(WASM_PAGE_SIZE as usize > host_page_size());
+        assert_eq!(WASM_PAGE_SIZE as usize % host_page_size(), 0);
+
+        let host_pages_per_wasm_page = WASM_PAGE_SIZE as usize / host_page_size();
+
+        for page_num in 0..host_pages_per_wasm_page {
+            let pages_into_heap = base_pages_into_heap + page_num;
+            let host_page_addr = wasm_page_base_addr + (page_num * host_page_size());
+
+            // page fault occurred in the heap; copy or zero
+            if let Some(page) = module.get_sparse_page_data(pages_into_heap) {
+                // we are in the sparse data area, with a non-empty page; copy it in
+                unsafe {
+                    uffd.copy(
+                        page.as_ptr() as *const c_void,
+                        host_page_addr as *mut c_void,
+                        host_page_size(),
+                        false,
+                    )
+                    .map_err(|e| Error::InternalError(e.into()))?;
+                }
+            } else {
+                // else if outside the sparse data area, or with an empty page
+                unsafe {
+                    uffd.zeropage(host_page_addr as *mut c_void, host_page_size(), false)
+                        .map_err(|e| Error::InternalError(e.into()))?;
+                }
+            }
+        }
+
+        uffd.wake(fault_page as *mut c_void, host_page_size())
+            .map_err(|e| Error::InternalError(e.into()))?;
+
         Ok(())
     }
 }

--- a/lucet-runtime/lucet-runtime-internals/src/region/uffd.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/region/uffd.rs
@@ -1,0 +1,468 @@
+//! Region backend for `lucet-runtime` backed by
+//! [`userfaultfd(2)`](http://man7.org/linux/man-pages/man2/userfaultfd.2.html) via the
+//! `userfaultfd-rs` crate.
+
+use crate::alloc::{host_page_size, instance_heap_offset, AddrLocation, Alloc, Limits, Slot};
+use crate::embed_ctx::CtxMap;
+use crate::error::Error;
+use crate::instance::{new_instance_handle, Instance, InstanceHandle, InstanceInternal};
+use crate::module::Module;
+use crate::region::{Region, RegionCreate, RegionInternal};
+use crate::{lucet_bail, lucet_ensure, lucet_format_err};
+use libc::{c_void, SIGSTKSZ};
+use nix::poll;
+use nix::sys::mman::{madvise, mmap, munmap, MapFlags, MmapAdvise, ProtFlags};
+use std::os::unix::io::{AsRawFd, RawFd};
+use std::ptr;
+use std::sync::{Arc, Mutex, Weak};
+use std::thread::{self, JoinHandle};
+use userfaultfd::{IoctlFlags, Uffd, UffdBuilder};
+
+pub struct UffdRegion {
+    uffd: Arc<Uffd>,
+    start: *mut c_void,
+    limits: Limits,
+    freelist: Mutex<Vec<Slot>>,
+    instance_capacity: usize,
+    handler: Option<JoinHandle<Result<(), Error>>>,
+    handler_pipe: RawFd,
+}
+
+// the start pointer prevents these from auto-deriving
+unsafe impl Send for UffdRegion {}
+unsafe impl Sync for UffdRegion {}
+
+fn uffd_handler(
+    uffd: Arc<Uffd>,
+    start: *mut c_void,
+    instance_capacity: usize,
+    handler_pipe: RawFd,
+    limits: Limits,
+) -> Result<(), Error> {
+    use userfaultfd::Event;
+
+    let mut pollfds = [
+        poll::PollFd::new(uffd.as_raw_fd(), poll::PollFlags::POLLIN),
+        poll::PollFd::new(handler_pipe, poll::PollFlags::POLLIN),
+    ];
+
+    loop {
+        let poll_res = poll::poll(&mut pollfds, 500)?;
+        let uffd_pfd = pollfds[0];
+        let pipe_pfd = pollfds[1];
+
+        if poll_res == 0 {
+            // we set a timeout on the poll in case the main thread panics, so the handler doesn't
+            // run forever; just run the loop again
+            continue;
+        }
+
+        // reading anything from the handler pipe kills this thread
+        if let Some(ev) = pipe_pfd.revents() {
+            lucet_ensure!(!ev.contains(poll::PollFlags::POLLERR), "pipe event error");
+            if ev.contains(poll::PollFlags::POLLIN) {
+                break;
+            }
+        }
+
+        if let Some(ev) = uffd_pfd.revents() {
+            lucet_ensure!(
+                !ev.contains(poll::PollFlags::POLLERR) && ev.contains(poll::PollFlags::POLLIN),
+                "unexpected uffd event flags: {:?}",
+                ev
+            );
+        }
+
+        // eprintln!("handling a fault on fd {}", uffd.as_raw_fd());
+
+        match uffd.read_event() {
+            Err(e) => lucet_bail!("error reading event from uffd: {}", e),
+            Ok(None) => lucet_bail!("uffd had POLLIN set, but could not be read"),
+            Ok(Some(Event::Pagefault {
+                addr: fault_addr, ..
+            })) => {
+                // eprintln!("fd {} fault address: {:p}", uffd.as_raw_fd(), fault_addr);
+                let fault_addr = fault_addr as usize;
+                let fault_page = fault_addr - (fault_addr % host_page_size());
+                let instance_size = limits.total_memory_size();
+
+                let in_region = fault_addr >= start as usize
+                    && fault_addr < start as usize + instance_size * instance_capacity;
+                lucet_ensure!(in_region, "fault is within the uffd region");
+
+                let fault_offs = fault_addr - start as usize;
+                let fault_base = fault_offs - (fault_offs % instance_size);
+                let inst_base = start as usize + fault_base;
+
+                // NB: we are blatantly lying to the compiler here! the lifetime is *not* actually
+                // static, but for the purposes of reaching in to read the sparse page data and the
+                // heap layout, we can treat it as such. The important property to maintain is that
+                // the *real* region lifetime (`'r`) lives at least as long as this handler thread,
+                // which can be shown by examining the `drop` method of `UffdRegion`.
+
+                let inst: &mut Instance = unsafe {
+                    (inst_base as *mut Instance)
+                        .as_mut()
+                        .ok_or(lucet_format_err!("instance pointer is non-null"))?
+                };
+                if !inst.valid_magic() {
+                    eprintln!(
+                        "instance magic incorrect, fault address {:p}",
+                        fault_addr as *mut c_void
+                    );
+                    lucet_bail!("instance magic incorrect");
+                }
+
+                match inst.alloc().addr_location(fault_addr as *const c_void) {
+                    AddrLocation::InaccessibleHeap => {
+                        // eprintln!("fault in heap guard!");
+                        // page fault occurred out of bounds; trigger a fault by waking the faulting
+                        // thread without copying or zeroing
+                        uffd.wake(fault_page as *mut c_void, host_page_size())
+                            .map_err(|e| Error::InternalError(e.into()))?;
+                    }
+                    AddrLocation::Heap => {
+                        // page fault occurred in the heap; copy or zero
+                        let pages_into_heap =
+                            (fault_page - inst.alloc().slot().heap as usize) / host_page_size();
+                        if let Some(page) = inst.module().get_sparse_page_data(pages_into_heap) {
+                            // we are in the sparse data area, with a non-empty page; copy it in
+                            unsafe {
+                                uffd.copy(
+                                    page.as_ptr() as *const c_void,
+                                    fault_page as *mut c_void,
+                                    host_page_size(),
+                                    true,
+                                )
+                                .map_err(|e| Error::InternalError(e.into()))?;
+                            }
+                        } else {
+                            // else if outside the sparse data area, or with an empty page
+                            // eprintln!("zeroing a page at {:p}", fault_page as *mut c_void);
+                            unsafe {
+                                uffd.zeropage(fault_page as *mut c_void, host_page_size(), true)
+                                    .map_err(|e| Error::InternalError(e.into()))?;
+                            }
+                        }
+                    }
+                    location => panic!("unexpected uffd fault location: {:?}", location),
+                }
+            }
+            Ok(Some(ev)) => panic!("unexpected uffd event: {:?}", ev),
+        }
+    }
+
+    Ok(())
+}
+
+impl Region for UffdRegion {
+    fn free_slots(&self) -> usize {
+        self.freelist.lock().unwrap().len()
+    }
+
+    fn used_slots(&self) -> usize {
+        self.capacity() - self.free_slots()
+    }
+
+    fn capacity(&self) -> usize {
+        self.instance_capacity
+    }
+}
+
+impl RegionInternal for UffdRegion {
+    fn new_instance_with(
+        &self,
+        module: Arc<dyn Module>,
+        embed_ctx: CtxMap,
+    ) -> Result<InstanceHandle, Error> {
+        let slot = self
+            .freelist
+            .lock()
+            .unwrap()
+            .pop()
+            .ok_or(Error::RegionFull(self.instance_capacity))?;
+
+        if slot.heap as usize % host_page_size() != 0 {
+            lucet_bail!("heap is not page-aligned; this is a bug");
+        }
+
+        let limits = &slot.limits;
+        module.validate_runtime_spec(limits)?;
+
+        for (ptr, len) in [
+            // zero the stack
+            (slot.stack, limits.stack_size),
+            // zero the globals
+            (slot.globals, limits.globals_size),
+            // zero the sigstack
+            (slot.sigstack, SIGSTKSZ),
+        ]
+        .into_iter()
+        {
+            // globals_size = 0 is valid, but the ioctl fails if you pass it 0
+            if *len > 0 {
+                // eprintln!("zeroing {:p}[{:x}]", *ptr, len);
+                unsafe {
+                    self.uffd
+                        .zeropage(*ptr, *len, true)
+                        .map_err(|e| Error::InternalError(e.into()))?;
+                }
+            }
+        }
+
+        let inst_ptr = slot.start as *mut Instance;
+
+        // upgrade the slot's weak region pointer so the region can't get dropped while the instance
+        // exists
+        let region = slot
+            .region
+            .upgrade()
+            // if this precondition isn't met, something is deeply wrong as some other region's slot
+            // ended up in our freelist
+            .expect("backing region of slot (`self`) exists");
+
+        let alloc = Alloc {
+            heap_accessible_size: module
+                .heap_spec()
+                .map(|h| h.initial_size as usize)
+                .unwrap_or(0),
+            heap_inaccessible_size: slot.limits.heap_address_space_size,
+            slot: Some(slot),
+            region,
+        };
+
+        let inst = new_instance_handle(inst_ptr, module, alloc, embed_ctx)?;
+
+        Ok(inst)
+    }
+
+    fn drop_alloc(&self, alloc: &mut Alloc) {
+        let slot = alloc
+            .slot
+            .take()
+            .expect("alloc didn't have a slot during drop; dropped twice?");
+
+        if slot.heap as usize % host_page_size() != 0 {
+            panic!("heap is not page-aligned");
+        }
+
+        // set dontneed for everything past the `Instance` page
+        let ptr = (slot.start as usize + instance_heap_offset()) as *mut c_void;
+        let len = slot.limits.total_memory_size() - instance_heap_offset();
+        // eprintln!("setting none {:p}[{:x}]", ptr, len);
+        unsafe {
+            madvise(ptr, len, MmapAdvise::MADV_DONTNEED).expect("madvise succeeds during drop");
+        }
+
+        self.freelist.lock().unwrap().push(slot);
+    }
+
+    fn expand_heap(&self, _slot: &Slot, _start: u32, _len: u32) -> Result<(), Error> {
+        // the actual work of heap expansion for UFFD is done in the worker thread; we just need the
+        // `Alloc` to validate the new limits and update the metadata
+        Ok(())
+    }
+
+    fn reset_heap(&self, alloc: &mut Alloc, module: &dyn Module) -> Result<(), Error> {
+        // zero the heap, if any of it is currently accessible
+        if alloc.heap_accessible_size > 0 {
+            unsafe {
+                madvise(
+                    alloc.slot().heap,
+                    alloc.heap_accessible_size,
+                    MmapAdvise::MADV_DONTNEED,
+                )?;
+            }
+        }
+
+        // reset the heap to the initial size
+        let initial_size = module
+            .heap_spec()
+            .map(|h| h.initial_size as usize)
+            .unwrap_or(0);
+        alloc.heap_accessible_size = initial_size;
+        alloc.heap_inaccessible_size = alloc.slot().limits.heap_address_space_size - initial_size;
+        Ok(())
+    }
+
+    fn as_dyn_internal(&self) -> &dyn RegionInternal {
+        self
+    }
+}
+
+impl RegionCreate for UffdRegion {
+    const TYPE_NAME: &'static str = "UffdRegion";
+
+    fn create(instance_capacity: usize, limits: &Limits) -> Result<Arc<Self>, Error> {
+        UffdRegion::create(instance_capacity, limits)
+    }
+}
+
+impl Drop for UffdRegion {
+    fn drop(&mut self) {
+        // eprintln!("UffdRegion::drop()");
+        // write to the pipe to notify the handler to exit
+        if let Err(e) = nix::unistd::write(self.handler_pipe, b"macht nichts") {
+            // this probably means the handler errored out; note it but don't panic
+            eprintln!("couldn't write to handler shutdown pipe: {}", e);
+        };
+
+        // eprintln!("joining");
+        // wait for the handler to exit
+        let res = self
+            .handler
+            .take()
+            .expect("region has a join handle")
+            .join()
+            .expect("join on uffd handler");
+
+        // close the send end of the pipe; the handler closes the other end
+        nix::unistd::close(self.handler_pipe).expect("close handler exit pipe");
+
+        let total_region_size = self.instance_capacity * self.limits.total_memory_size();
+        unsafe {
+            munmap(self.start, total_region_size).expect("unmapping region");
+        }
+
+        if let Err(e) = res {
+            panic!("uffd handler thread failed: {}", e);
+        }
+    }
+}
+
+impl UffdRegion {
+    pub fn create(instance_capacity: usize, limits: &Limits) -> Result<Arc<Self>, Error> {
+        assert!(
+            SIGSTKSZ % host_page_size() == 0,
+            "signal stack size is a multiple of host page size"
+        );
+        if instance_capacity == 0 {
+            return Err(Error::InvalidArgument(
+                "region must be able to hold at least one instance",
+            ));
+        }
+        limits.validate()?;
+
+        let uffd = Arc::new(
+            UffdBuilder::new()
+                .close_on_exec(true)
+                .non_blocking(true)
+                .create()
+                .map_err(|e| Error::InternalError(e.into()))?,
+        );
+
+        // map the chunk of virtual memory for all of the slots
+        let total_region_size =
+            if let Some(sz) = instance_capacity.checked_mul(limits.total_memory_size()) {
+                sz
+            } else {
+                lucet_bail!("region size overflowed");
+            };
+        let start = unsafe {
+            mmap(
+                ptr::null_mut(),
+                total_region_size,
+                ProtFlags::PROT_READ | ProtFlags::PROT_WRITE,
+                MapFlags::MAP_ANONYMOUS | MapFlags::MAP_PRIVATE | MapFlags::MAP_NORESERVE,
+                0,
+                0,
+            )?
+        };
+
+        // register the memory region with uffd and verify the required ioctls are supported
+        let ioctls = uffd
+            .register(start, total_region_size)
+            .map_err(|e| Error::InternalError(e.into()))?;
+        if !ioctls.contains(IoctlFlags::WAKE | IoctlFlags::COPY | IoctlFlags::ZEROPAGE) {
+            lucet_bail!("required uffd ioctls not supported; found: {:?}", ioctls);
+        }
+
+        let (handler_pipe_recv, handler_pipe) = nix::unistd::pipe()?;
+
+        let handler_uffd = uffd.clone();
+        // morally equivalent to `unsafe impl Send`
+        let handler_start = start as usize;
+        let handler_limits = limits.clone();
+        let handler = thread::Builder::new()
+            .name("uffd region handler".into())
+            .spawn(move || {
+                let res = uffd_handler(
+                    handler_uffd.clone(),
+                    handler_start as *mut c_void,
+                    instance_capacity,
+                    handler_pipe_recv,
+                    handler_limits,
+                );
+                // clean up the shutdown pipe before terminating
+                if let Err(e) = nix::unistd::close(handler_pipe_recv) {
+                    // note but don't return an error just for the pipe
+                    eprintln!("error closing handler_pipe_recv: {}", e);
+                }
+                if res.is_err() {
+                    // We can't currently recover from something going wrong in the handler thread,
+                    // so we unregister the region and wake all faulting threads so that they crash
+                    // rather than hanging. This is in lieu of bringing down the other threads with
+                    // `panic!`
+                    handler_uffd
+                        .unregister(handler_start as *mut c_void, total_region_size)
+                        .unwrap_or_else(|e| {
+                            eprintln!("error while unregistering in error case: {}", e)
+                        });
+                    handler_uffd
+                        .wake(handler_start as *mut c_void, total_region_size)
+                        .unwrap_or_else(|e| eprintln!("error while waking in error case: {}", e));
+                }
+                res
+            })
+            .map_err(|e| lucet_format_err!("error spawning uffd region handler: {}", e))?;
+
+        let region = Arc::new(UffdRegion {
+            uffd,
+            start,
+            limits: limits.clone(),
+            freelist: Mutex::new(Vec::with_capacity(instance_capacity)),
+            instance_capacity,
+            handler: Some(handler),
+            handler_pipe,
+        });
+
+        {
+            let mut freelist = region.freelist.lock().unwrap();
+            for i in 0..instance_capacity {
+                freelist.push(UffdRegion::create_slot(&region, i)?);
+            }
+        }
+
+        Ok(region)
+    }
+
+    fn create_slot(region: &Arc<UffdRegion>, index: usize) -> Result<Slot, Error> {
+        // get the memory from the offset into the overall region
+        let start =
+            (region.start as usize + (index * region.limits.total_memory_size())) as *mut c_void;
+        // lay out the other sections in memory
+        let heap = start as usize + instance_heap_offset();
+        let stack = heap + region.limits.heap_address_space_size;
+        let globals = stack + region.limits.stack_size + host_page_size();
+        let sigstack = globals + host_page_size();
+
+        // turn on the `Instance` page
+        // eprintln!("zeroing {:p}[{:x}]", start, host_page_size());
+        unsafe {
+            region
+                .uffd
+                .zeropage(start, host_page_size(), true)
+                .map_err(|e| Error::InternalError(e.into()))?;
+        }
+
+        Ok(Slot {
+            start,
+            heap: heap as *mut c_void,
+            stack: stack as *mut c_void,
+            globals: globals as *mut c_void,
+            sigstack: sigstack as *mut c_void,
+            limits: region.limits.clone(),
+            region: Arc::downgrade(region) as Weak<dyn RegionInternal>,
+        })
+    }
+}

--- a/lucet-runtime/lucet-runtime-internals/src/region/uffd.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/region/uffd.rs
@@ -520,7 +520,7 @@ pub trait UffdStrategy: Send + Sync + 'static {
     ) -> Result<(), Error>;
 }
 
-pub struct DefaultUffdStrategy {}
+pub struct DefaultUffdStrategy;
 
 impl UffdStrategy for DefaultUffdStrategy {
     fn stack_fault(&self, uffd: &Uffd, fault_page: *mut c_void) -> Result<(), Error> {

--- a/lucet-runtime/lucet-runtime-tests/guests/memory/uffd_memory.wat
+++ b/lucet-runtime/lucet-runtime-tests/guests/memory/uffd_memory.wat
@@ -1,0 +1,8 @@
+(module
+  (import "env" "memory" (memory 2))
+  (func $main (export "main")
+    (i32.store (i32.const 65536) (i32.const 1))
+    (drop (grow_memory (i32.const 2)))
+    (i32.store (i32.const 196608) (i32.const 2))
+  )
+)

--- a/lucet-runtime/lucet-runtime-tests/src/entrypoint.rs
+++ b/lucet-runtime/lucet-runtime-tests/src/entrypoint.rs
@@ -194,7 +194,7 @@ macro_rules! entrypoint_tests {
         use libc::c_void;
         use lucet_runtime::vmctx::{lucet_vmctx, Vmctx};
         use lucet_runtime::{
-            lucet_hostcall, DlModule, Error, Limits, Module, Region, Val, WASM_PAGE_SIZE,
+            lucet_hostcall, DlModule, Error, Limits, Module, Region, Val, WASM_PAGE_SIZE
         };
 
         #[lucet_hostcall]
@@ -231,7 +231,7 @@ macro_rules! entrypoint_tests {
                 use libc::c_void;
                 use lucet_runtime::vmctx::{lucet_vmctx, Vmctx};
                 use lucet_runtime::{
-                    lucet_hostcall, DlModule, Error, Limits, Module, Region, Val, WASM_PAGE_SIZE,
+                    lucet_hostcall, DlModule, Error, Limits, Module, Region, Val, WASM_PAGE_SIZE, RegionCreate
                 };
                 use std::sync::Arc;
                 use $TestRegion as TestRegion;
@@ -249,7 +249,7 @@ macro_rules! entrypoint_tests {
                 }
 
                 fn calc_add_2(module: Arc<dyn Module>) {
-                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let region = <TestRegion as RegionCreate>::create(1, &Limits::default()).expect("region can be created");
                     let mut inst = region
                         .new_instance(module)
                         .expect("instance can be created");
@@ -273,7 +273,7 @@ macro_rules! entrypoint_tests {
                 }
 
                 fn calc_add_10(module: Arc<dyn Module>) {
-                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let region = <TestRegion as RegionCreate>::create(1, &Limits::default()).expect("region can be created");
                     let mut inst = region
                         .new_instance(module)
                         .expect("instance can be created");
@@ -317,7 +317,7 @@ macro_rules! entrypoint_tests {
                 }
 
                 fn calc_mul_2(module: Arc<dyn Module>) {
-                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let region = <TestRegion as RegionCreate>::create(1, &Limits::default()).expect("region can be created");
                     let mut inst = region
                         .new_instance(module)
                         .expect("instance can be created");
@@ -336,7 +336,7 @@ macro_rules! entrypoint_tests {
                 }
 
                 fn calc_add_then_mul(module: Arc<dyn Module>) {
-                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let region = <TestRegion as RegionCreate>::create(1, &Limits::default()).expect("region can be created");
                     let mut inst = region
                         .new_instance(module)
                         .expect("instance can be created");
@@ -367,7 +367,7 @@ macro_rules! entrypoint_tests {
                 }
 
                 fn calc_invalid_entrypoint(module: Arc<dyn Module>) {
-                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let region = <TestRegion as RegionCreate>::create(1, &Limits::default()).expect("region can be created");
                     let mut inst = region
                         .new_instance(module)
                         .expect("instance can be created");
@@ -388,7 +388,7 @@ macro_rules! entrypoint_tests {
                 }
 
                 fn calc_add_f32_2(module: Arc<dyn Module>) {
-                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let region = <TestRegion as RegionCreate>::create(1, &Limits::default()).expect("region can be created");
                     let mut inst = region
                         .new_instance(module)
                         .expect("instance can be created");
@@ -410,7 +410,7 @@ macro_rules! entrypoint_tests {
                     calc_add_f64_2(wat_calculator_module());
                 }
                 fn calc_add_f64_2(module: Arc<dyn Module>) {
-                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let region = <TestRegion as RegionCreate>::create(1, &Limits::default()).expect("region can be created");
                     let mut inst = region
                         .new_instance(module)
                         .expect("instance can be created");
@@ -432,7 +432,7 @@ macro_rules! entrypoint_tests {
                     calc_add_f32_10(wat_calculator_module());
                 }
                 fn calc_add_f32_10(module: Arc<dyn Module>) {
-                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let region = <TestRegion as RegionCreate>::create(1, &Limits::default()).expect("region can be created");
                     let mut inst = region
                         .new_instance(module)
                         .expect("instance can be created");
@@ -471,7 +471,7 @@ macro_rules! entrypoint_tests {
                     calc_add_f64_10(wat_calculator_module());
                 }
                 fn calc_add_f64_10(module: Arc<dyn Module>) {
-                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let region = <TestRegion as RegionCreate>::create(1, &Limits::default()).expect("region can be created");
                     let mut inst = region
                         .new_instance(module)
                         .expect("instance can be created");
@@ -507,7 +507,7 @@ macro_rules! entrypoint_tests {
                 }
                 // TODO: it would be pretty annoying to write the mixed_20 calc test in wasm, so we havent.
                 fn calc_add_mixed_20(module: Arc<dyn Module>) {
-                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let region = <TestRegion as RegionCreate>::create(1, &Limits::default()).expect("region can be created");
                     let mut inst = region
                         .new_instance(module)
                         .expect("instance can be created");
@@ -577,7 +577,7 @@ macro_rules! entrypoint_tests {
                 }
 
                 fn typecheck_entrypoint_wrong_args(module: Arc<dyn Module>) {
-                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let region = <TestRegion as RegionCreate>::create(1, &Limits::default()).expect("region can be created");
                     let mut inst = region
                         .new_instance(module)
                         .expect("instance can be created");
@@ -601,7 +601,7 @@ macro_rules! entrypoint_tests {
                 }
 
                 fn typecheck_entrypoint_too_few_args(module: Arc<dyn Module>) {
-                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let region = <TestRegion as RegionCreate>::create(1, &Limits::default()).expect("region can be created");
                     let mut inst = region
                         .new_instance(module)
                         .expect("instance can be created");
@@ -626,7 +626,7 @@ macro_rules! entrypoint_tests {
                 }
 
                 fn typecheck_entrypoint_too_many_args(module: Arc<dyn Module>) {
-                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let region = <TestRegion as RegionCreate>::create(1, &Limits::default()).expect("region can be created");
                     let mut inst = region
                         .new_instance(module)
                         .expect("instance can be created");
@@ -651,7 +651,7 @@ macro_rules! entrypoint_tests {
                 }
 
                 fn imported_entrypoint(module: Arc<dyn Module>) {
-                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let region = <TestRegion as RegionCreate>::create(1, &Limits::default()).expect("region can be created");
                     let mut inst = region
                         .new_instance(module)
                         .expect("instance can be created");
@@ -676,7 +676,7 @@ macro_rules! entrypoint_tests {
 
                     let module =
                         test_module_c("entrypoint", "use_allocator.c").expect("module builds and loads");
-                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let region = <TestRegion as RegionCreate>::create(1, &Limits::default()).expect("region can be created");
 
                     let mut inst = region
                         .new_instance(module)
@@ -728,7 +728,7 @@ macro_rules! entrypoint_tests {
 
                     let module =
                         test_module_c("entrypoint", "use_allocator.c").expect("module builds and loads");
-                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let region = <TestRegion as RegionCreate>::create(1, &Limits::default()).expect("region can be created");
 
                     let mut inst = region
                         .new_instance(module)
@@ -804,7 +804,7 @@ macro_rules! entrypoint_tests {
 
                     let module =
                         test_module_c("entrypoint", "use_allocator.c").expect("module builds and loads");
-                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let region = <TestRegion as RegionCreate>::create(1, &Limits::default()).expect("region can be created");
 
                     let mut inst = region
                         .new_instance(module)
@@ -881,7 +881,7 @@ macro_rules! entrypoint_tests {
                 fn entrypoint_ctype() {
                     use byteorder::{LittleEndian, ReadBytesExt};
                     let module = test_module_c("entrypoint", "ctype.c").expect("module builds and loads");
-                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let region = <TestRegion as RegionCreate>::create(1, &Limits::default()).expect("region can be created");
 
                     let mut inst = region
                         .new_instance(module)
@@ -920,7 +920,7 @@ macro_rules! entrypoint_tests {
                 fn entrypoint_callback() {
                     let module =
                         test_module_c("entrypoint", "callback.c").expect("module builds and loads");
-                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let region = <TestRegion as RegionCreate>::create(1, &Limits::default()).expect("region can be created");
 
                     let mut inst = region
                         .new_instance(module)

--- a/lucet-runtime/lucet-runtime-tests/src/entrypoint.rs
+++ b/lucet-runtime/lucet-runtime-tests/src/entrypoint.rs
@@ -190,697 +190,16 @@ pub fn mock_calculator_module() -> Arc<dyn Module> {
 
 #[macro_export]
 macro_rules! entrypoint_tests {
-    ( $TestRegion:path ) => {
+    ( $( $TestRegion:path => $region_id:ident ),* ) => {
         use libc::c_void;
         use lucet_runtime::vmctx::{lucet_vmctx, Vmctx};
         use lucet_runtime::{
             lucet_hostcall, DlModule, Error, Limits, Module, Region, Val, WASM_PAGE_SIZE,
         };
-        use std::sync::Arc;
-        use $TestRegion as TestRegion;
-        use $crate::entrypoint::{mock_calculator_module, wat_calculator_module};
 
         #[lucet_hostcall]
         #[no_mangle]
         pub fn black_box(_vmctx: &mut Vmctx, _val: *mut c_void) {}
-
-        #[test]
-        fn mock_calc_add_2() {
-            calc_add_2(mock_calculator_module())
-        }
-
-        #[test]
-        fn wat_calc_add_2() {
-            calc_add_2(wat_calculator_module());
-        }
-
-        fn calc_add_2(module: Arc<dyn Module>) {
-            let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
-            let mut inst = region
-                .new_instance(module)
-                .expect("instance can be created");
-
-            let retval = inst
-                .run("add_2", &[123u64.into(), 456u64.into()])
-                .expect("instance runs")
-                .unwrap_returned();
-
-            assert_eq!(u64::from(retval), 123u64 + 456);
-        }
-
-        #[test]
-        fn mock_calc_add_10() {
-            calc_add_10(mock_calculator_module())
-        }
-
-        #[test]
-        fn wat_calc_add_10() {
-            calc_add_10(wat_calculator_module())
-        }
-
-        fn calc_add_10(module: Arc<dyn Module>) {
-            let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
-            let mut inst = region
-                .new_instance(module)
-                .expect("instance can be created");
-
-            // Add all 10 arguments. Why 10? Because its more than will fit in registers to be passed to
-            // `guest_add_10` by liblucet, so it will make sure that the calling convention of putting stuff
-            // on the stack is working.
-            //
-            // A better test might be to use an operation that doesn't commute, so we can verify that the
-            // order is correct.
-            let retval = inst
-                .run(
-                    "add_10",
-                    &[
-                        1u64.into(),
-                        2u64.into(),
-                        3u64.into(),
-                        4u64.into(),
-                        5u64.into(),
-                        6u64.into(),
-                        7u64.into(),
-                        8u64.into(),
-                        9u64.into(),
-                        10u64.into(),
-                    ],
-                )
-                .expect("instance runs")
-                .unwrap_returned();
-
-            assert_eq!(u64::from(retval), 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10);
-        }
-
-        #[test]
-        fn mock_calc_mul_2() {
-            calc_mul_2(mock_calculator_module())
-        }
-
-        #[test]
-        fn wat_calc_mul_2() {
-            calc_mul_2(wat_calculator_module())
-        }
-
-        fn calc_mul_2(module: Arc<dyn Module>) {
-            let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
-            let mut inst = region
-                .new_instance(module)
-                .expect("instance can be created");
-
-            let retval = inst
-                .run("mul_2", &[123u64.into(), 456u64.into()])
-                .expect("instance runs")
-                .unwrap_returned();
-
-            assert_eq!(u64::from(retval), 123 * 456);
-        }
-
-        #[test]
-        fn mock_calc_add_then_mul() {
-            calc_add_then_mul(mock_calculator_module())
-        }
-
-        fn calc_add_then_mul(module: Arc<dyn Module>) {
-            let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
-            let mut inst = region
-                .new_instance(module)
-                .expect("instance can be created");
-
-            let retval = inst
-                .run("add_2", &[111u64.into(), 222u64.into()])
-                .expect("instance runs")
-                .unwrap_returned();
-
-            assert_eq!(u64::from(retval), 111 + 222);
-
-            let retval = inst
-                .run("mul_2", &[333u64.into(), 444u64.into()])
-                .expect("instance runs")
-                .unwrap_returned();
-
-            assert_eq!(u64::from(retval), 333 * 444);
-        }
-
-        #[test]
-        fn mock_calc_invalid_entrypoint() {
-            calc_invalid_entrypoint(mock_calculator_module())
-        }
-
-        #[test]
-        fn wat_calc_invalid_entrypoint() {
-            calc_invalid_entrypoint(wat_calculator_module())
-        }
-
-        fn calc_invalid_entrypoint(module: Arc<dyn Module>) {
-            let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
-            let mut inst = region
-                .new_instance(module)
-                .expect("instance can be created");
-
-            match inst.run("invalid", &[123u64.into(), 456u64.into()]) {
-                Err(Error::SymbolNotFound(sym)) => assert_eq!(sym, "invalid"),
-                res => panic!("unexpected result: {:?}", res),
-            }
-        }
-
-        #[test]
-        fn mock_calc_add_f32_2() {
-            calc_add_f32_2(mock_calculator_module());
-        }
-        #[test]
-        fn wat_calc_add_f32_2() {
-            calc_add_f32_2(wat_calculator_module());
-        }
-
-        fn calc_add_f32_2(module: Arc<dyn Module>) {
-            let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
-            let mut inst = region
-                .new_instance(module)
-                .expect("instance can be created");
-
-            let retval = inst
-                .run("add_f32_2", &[(-6.9f32).into(), 4.2f32.into()])
-                .expect("instance runs")
-                .unwrap_returned();
-
-            assert_eq!(f32::from(retval), -6.9 + 4.2);
-        }
-
-        #[test]
-        fn mock_calc_add_f64_2() {
-            calc_add_f64_2(mock_calculator_module());
-        }
-        #[test]
-        fn wat_calc_add_f64_2() {
-            calc_add_f64_2(wat_calculator_module());
-        }
-        fn calc_add_f64_2(module: Arc<dyn Module>) {
-            let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
-            let mut inst = region
-                .new_instance(module)
-                .expect("instance can be created");
-
-            let retval = inst
-                .run("add_f64_2", &[(-6.9f64).into(), 4.2f64.into()])
-                .expect("instance runs")
-                .unwrap_returned();
-
-            assert_eq!(f64::from(retval), -6.9 + 4.2);
-        }
-
-        #[test]
-        fn mock_calc_add_f32_10() {
-            calc_add_f32_10(mock_calculator_module());
-        }
-        #[test]
-        fn wat_calc_add_f32_10() {
-            calc_add_f32_10(wat_calculator_module());
-        }
-        fn calc_add_f32_10(module: Arc<dyn Module>) {
-            let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
-            let mut inst = region
-                .new_instance(module)
-                .expect("instance can be created");
-
-            let retval = inst
-                .run(
-                    "add_f32_10",
-                    &[
-                        0.1f32.into(),
-                        0.2f32.into(),
-                        0.3f32.into(),
-                        0.4f32.into(),
-                        0.5f32.into(),
-                        0.6f32.into(),
-                        0.7f32.into(),
-                        0.8f32.into(),
-                        0.9f32.into(),
-                        1.0f32.into(),
-                    ],
-                )
-                .expect("instance runs")
-                .unwrap_returned();
-
-            assert_eq!(
-                f32::from(retval),
-                0.1 + 0.2 + 0.3 + 0.4 + 0.5 + 0.6 + 0.7 + 0.8 + 0.9 + 1.0
-            );
-        }
-
-        #[test]
-        fn mock_calc_add_f64_10() {
-            calc_add_f64_10(mock_calculator_module());
-        }
-        #[test]
-        fn wat_calc_add_f64_10() {
-            calc_add_f64_10(wat_calculator_module());
-        }
-        fn calc_add_f64_10(module: Arc<dyn Module>) {
-            let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
-            let mut inst = region
-                .new_instance(module)
-                .expect("instance can be created");
-
-            let retval = inst
-                .run(
-                    "add_f64_10",
-                    &[
-                        0.1f64.into(),
-                        0.2f64.into(),
-                        0.3f64.into(),
-                        0.4f64.into(),
-                        0.5f64.into(),
-                        0.6f64.into(),
-                        0.7f64.into(),
-                        0.8f64.into(),
-                        0.9f64.into(),
-                        1.0f64.into(),
-                    ],
-                )
-                .expect("instance runs")
-                .unwrap_returned();
-
-            assert_eq!(
-                f64::from(retval),
-                0.1 + 0.2 + 0.3 + 0.4 + 0.5 + 0.6 + 0.7 + 0.8 + 0.9 + 1.0
-            );
-        }
-
-        #[test]
-        fn mock_calc_add_mixed_20() {
-            calc_add_mixed_20(mock_calculator_module());
-        }
-        // TODO: it would be pretty annoying to write the mixed_20 calc test in wasm, so we havent.
-        fn calc_add_mixed_20(module: Arc<dyn Module>) {
-            let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
-            let mut inst = region
-                .new_instance(module)
-                .expect("instance can be created");
-
-            let retval = inst
-                .run(
-                    "add_mixed_20",
-                    &[
-                        (-1.1f64).into(),
-                        1u8.into(),
-                        2.1f32.into(),
-                        3.1f64.into(),
-                        4u16.into(),
-                        5.1f32.into(),
-                        6.1f64.into(),
-                        7u32.into(),
-                        8.1f32.into(),
-                        9.1f64.into(),
-                        true.into(),
-                        11.1f32.into(),
-                        12.1f64.into(),
-                        13u32.into(),
-                        14.1f32.into(),
-                        15.1f64.into(),
-                        16u64.into(),
-                        17.1f32.into(),
-                        18.1f64.into(),
-                        19u64.into(),
-                    ],
-                )
-                .expect("instance runs")
-                .unwrap_returned();
-
-            assert_eq!(
-                f64::from(retval),
-                -1.1f64
-                    + 1u8 as f64
-                    + 2.1f32 as f64
-                    + 3.1f64
-                    + 4u16 as f64
-                    + 5.1f32 as f64
-                    + 6.1f64
-                    + 7u32 as f64
-                    + 8.1f32 as f64
-                    + 9.1f64
-                    + 1 as f64
-                    + 11.1f32 as f64
-                    + 12.1f64
-                    + 13u32 as f64
-                    + 14.1f32 as f64
-                    + 15.1f64
-                    + 16u64 as f64
-                    + 17.1f32 as f64
-                    + 18.1f64
-                    + 19u64 as f64
-            );
-        }
-
-        #[test]
-        fn mock_typecheck_entrypoint_wrong_args() {
-            typecheck_entrypoint_wrong_args(mock_calculator_module())
-        }
-
-        #[test]
-        fn wat_typecheck_entrypoint_wrong_args() {
-            typecheck_entrypoint_wrong_args(wat_calculator_module())
-        }
-
-        fn typecheck_entrypoint_wrong_args(module: Arc<dyn Module>) {
-            let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
-            let mut inst = region
-                .new_instance(module)
-                .expect("instance can be created");
-
-            match inst.run("add_2", &[123.0f64.into(), 456.0f64.into()]) {
-                Err(Error::InvalidArgument(err)) => {
-                    assert_eq!(err, "entrypoint function signature mismatch")
-                }
-                res => panic!("unexpected result: {:?}", res),
-            }
-        }
-
-        #[test]
-        fn mock_typecheck_entrypoint_too_few_args() {
-            typecheck_entrypoint_too_few_args(mock_calculator_module())
-        }
-
-        #[test]
-        fn wat_typecheck_entrypoint_too_few_args() {
-            typecheck_entrypoint_too_few_args(wat_calculator_module())
-        }
-
-        fn typecheck_entrypoint_too_few_args(module: Arc<dyn Module>) {
-            let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
-            let mut inst = region
-                .new_instance(module)
-                .expect("instance can be created");
-
-            match inst.run("add_2", &[123u64.into()]) {
-                Err(Error::InvalidArgument(err)) => assert_eq!(
-                    err,
-                    "entrypoint function signature mismatch (number of arguments is incorrect)"
-                ),
-                res => panic!("unexpected result: {:?}", res),
-            }
-        }
-
-        #[test]
-        fn mock_typecheck_entrypoint_too_many_args() {
-            typecheck_entrypoint_too_many_args(mock_calculator_module())
-        }
-
-        #[test]
-        fn wat_typecheck_entrypoint_too_many_args() {
-            typecheck_entrypoint_too_many_args(wat_calculator_module())
-        }
-
-        fn typecheck_entrypoint_too_many_args(module: Arc<dyn Module>) {
-            let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
-            let mut inst = region
-                .new_instance(module)
-                .expect("instance can be created");
-
-            match inst.run("add_2", &[123u64.into(), 456u64.into(), 789u64.into()]) {
-                Err(Error::InvalidArgument(err)) => assert_eq!(
-                    err,
-                    "entrypoint function signature mismatch (number of arguments is incorrect)"
-                ),
-                res => panic!("unexpected result: {:?}", res),
-            }
-        }
-
-        #[test]
-        fn mock_imported_entrypoint() {
-            imported_entrypoint(mock_calculator_module())
-        }
-
-        #[test]
-        fn wat_imported_entrypoint() {
-            imported_entrypoint(wat_calculator_module())
-        }
-
-        fn imported_entrypoint(module: Arc<dyn Module>) {
-            let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
-            let mut inst = region
-                .new_instance(module)
-                .expect("instance can be created");
-
-            let retval = inst
-                .run(
-                    "add_4_reexport",
-                    &[123u64.into(), 456u64.into(), 789u64.into(), 432u64.into()],
-                )
-                .unwrap()
-                .unwrap_returned();
-            assert_eq!(u64::from(retval), 1800);
-        }
-
-        use $crate::build::test_module_c;
-        const TEST_REGION_INIT_VAL: libc::c_int = 123;
-        const TEST_REGION_SIZE: libc::size_t = 4;
-
-        #[test]
-        fn allocator_create_region() {
-            use byteorder::{LittleEndian, ReadBytesExt};
-
-            let module =
-                test_module_c("entrypoint", "use_allocator.c").expect("module builds and loads");
-            let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
-
-            let mut inst = region
-                .new_instance(module)
-                .expect("instance can be created");
-
-            // First, we need to get an unused location in linear memory for the pointer that will be passed
-            // as an argument to create_and_memset.
-            let new_page = inst.grow_memory(1).expect("grow_memory succeeds");
-            assert!(new_page > 0);
-            // wasm memory index for the start of the new page
-            let loc_outval = new_page * WASM_PAGE_SIZE;
-
-            // This function will call `malloc` for the given size, then `memset` the entire region to the
-            // init_as argument. The pointer to the allocated region gets stored in loc_outval.
-            inst.run(
-                "create_and_memset",
-                &[
-                    // int init_as
-                    TEST_REGION_INIT_VAL.into(),
-                    // size_t size
-                    TEST_REGION_SIZE.into(),
-                    // char** ptr_outval
-                    Val::GuestPtr(loc_outval),
-                ],
-            )
-            .expect("instance runs");
-
-            // The location of the created region should be in a new page that the allocator grabbed from
-            // the runtime. That page will be above the one we got above.
-            let heap = inst.heap();
-            let loc_region_1 = (&heap[loc_outval as usize..])
-                .read_u32::<LittleEndian>()
-                .expect("can read outval");
-            assert!(loc_region_1 > loc_outval);
-
-            // Each character in the newly created region will match the expected value.
-            for i in 0..TEST_REGION_SIZE {
-                assert_eq!(
-                    TEST_REGION_INIT_VAL as u8,
-                    heap[loc_region_1 as usize + i],
-                    "character in new region matches"
-                );
-            }
-        }
-
-        #[test]
-        fn allocator_create_region_and_increment() {
-            use byteorder::{LittleEndian, ReadBytesExt};
-
-            let module =
-                test_module_c("entrypoint", "use_allocator.c").expect("module builds and loads");
-            let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
-
-            let mut inst = region
-                .new_instance(module)
-                .expect("instance can be created");
-
-            // First, we need to get an unused location in linear memory for the pointer that will be passed
-            // as an argument to create_and_memset.
-            let new_page = inst.grow_memory(1).expect("grow_memory succeeds");
-            assert!(new_page > 0);
-            // wasm memory index for the start of the new page
-            let loc_outval = new_page * WASM_PAGE_SIZE as u32;
-
-            // Create a region and initialize it, just like above
-            inst.run(
-                "create_and_memset",
-                &[
-                    // int init_as
-                    TEST_REGION_INIT_VAL.into(),
-                    // size_t size
-                    TEST_REGION_SIZE.into(),
-                    // char** ptr_outval
-                    Val::GuestPtr(loc_outval),
-                ],
-            )
-            .expect("instance runs");
-
-            // The location of the created region should be in a new page that the allocator grabbed from
-            // the runtime. That page will be above the one we got above.
-            let heap = inst.heap();
-            let loc_region_1 = (&heap[loc_outval as usize..])
-                .read_u32::<LittleEndian>()
-                .expect("can read outval");
-            assert!(loc_region_1 > loc_outval);
-
-            // Each character in the newly created region will match the expected value.
-            for i in 0..TEST_REGION_SIZE {
-                assert_eq!(
-                    TEST_REGION_INIT_VAL as u8,
-                    heap[loc_region_1 as usize + i],
-                    "character in new region matches"
-                );
-            }
-
-            // Then increment the first location in the region
-            inst.run("increment_ptr", &[Val::GuestPtr(loc_region_1)])
-                .expect("instance runs");
-
-            let heap = inst.heap();
-            // Just the first location in the region should be incremented
-            for i in 0..TEST_REGION_SIZE {
-                if i == 0 {
-                    assert_eq!(
-                        TEST_REGION_INIT_VAL as u8 + 1,
-                        heap[loc_region_1 as usize + i],
-                        "character in new region matches"
-                    );
-                } else {
-                    assert_eq!(
-                        TEST_REGION_INIT_VAL as u8,
-                        heap[loc_region_1 as usize + i],
-                        "character in new region matches"
-                    );
-                }
-            }
-        }
-
-        const TEST_REGION2_INIT_VAL: libc::c_int = 99;
-        const TEST_REGION2_SIZE: libc::size_t = 420;
-
-        #[test]
-        fn allocator_create_two_regions() {
-            use byteorder::{LittleEndian, ReadBytesExt};
-
-            let module =
-                test_module_c("entrypoint", "use_allocator.c").expect("module builds and loads");
-            let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
-
-            let mut inst = region
-                .new_instance(module)
-                .expect("instance can be created");
-
-            // same as above
-            let new_page = inst.grow_memory(1).expect("grow_memory succeeds");
-            assert!(new_page > 0);
-            // wasm memory index for the start of the new page
-            let loc_outval = new_page * WASM_PAGE_SIZE;
-
-            // same as above
-            inst.run(
-                "create_and_memset",
-                &[
-                    // int init_as
-                    TEST_REGION_INIT_VAL.into(),
-                    // size_t size
-                    TEST_REGION_SIZE.into(),
-                    // char** ptr_outval
-                    Val::GuestPtr(loc_outval),
-                ],
-            )
-            .expect("instance runs");
-
-            let heap = inst.heap();
-            let loc_region_1 = (&heap[loc_outval as usize..])
-                .read_u32::<LittleEndian>()
-                .expect("can read outval");
-            assert!(loc_region_1 > loc_outval);
-
-            // Create a second region
-            inst.run(
-                "create_and_memset",
-                &[
-                    // int init_as
-                    TEST_REGION2_INIT_VAL.into(),
-                    // size_t size
-                    TEST_REGION2_SIZE.into(),
-                    // char** ptr_outval
-                    Val::GuestPtr(loc_outval),
-                ],
-            )
-            .expect("instance runs");
-
-            // The allocator should pick a spot *after* the first region for the second one. (It doesn't
-            // have to, but it will.) This shows that the allocator's metadata (free list) is preserved
-            // between the runs.
-            let heap = inst.heap();
-            let loc_region_2 = (&heap[loc_outval as usize..])
-                .read_u32::<LittleEndian>()
-                .expect("can read outval");
-            assert!(loc_region_2 > loc_region_1);
-
-            // After this, both regions should be initialized as expected
-            for i in 0..TEST_REGION_SIZE {
-                assert_eq!(
-                    TEST_REGION_INIT_VAL as u8,
-                    heap[loc_region_1 as usize + i],
-                    "character in region 1 matches"
-                );
-            }
-
-            for i in 0..TEST_REGION2_SIZE {
-                assert_eq!(
-                    TEST_REGION2_INIT_VAL as u8,
-                    heap[loc_region_2 as usize + i],
-                    "character in region 2 matches"
-                );
-            }
-        }
-
-        #[test]
-        fn entrypoint_ctype() {
-            use byteorder::{LittleEndian, ReadBytesExt};
-            let module = test_module_c("entrypoint", "ctype.c").expect("module builds and loads");
-            let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
-
-            let mut inst = region
-                .new_instance(module)
-                .expect("instance can be created");
-
-            // First, we need to get an unused location in linear memory for the pointer that will be passed
-            // as an argument to create_and_memset.
-            let new_page = inst.grow_memory(1).expect("grow_memory succeeds");
-            assert!(new_page > 0);
-            // wasm memory index for the start of the new page
-            let loc_ctxstar = new_page * WASM_PAGE_SIZE;
-
-            // Run the setup routine
-            inst.run(
-                "ctype_setup",
-                &[
-                    std::ptr::null::<c_void>().into(),
-                    Val::GuestPtr(loc_ctxstar),
-                ],
-            )
-            .expect("instance runs");
-
-            // Grab the value of the pointer that the setup routine wrote
-            let heap = inst.heap();
-            let ctxstar = (&heap[loc_ctxstar as usize..])
-                .read_u32::<LittleEndian>()
-                .expect("can read ctxstar");
-            assert!(ctxstar > 0);
-
-            // Run the body routine
-            inst.run("ctype_body", &[Val::GuestPtr(ctxstar)])
-                .expect("instance runs");
-        }
 
         #[lucet_hostcall]
         #[no_mangle]
@@ -906,26 +225,720 @@ macro_rules! entrypoint_tests {
             x + y + z + w
         }
 
-        #[test]
-        fn entrypoint_callback() {
-            let module =
-                test_module_c("entrypoint", "callback.c").expect("module builds and loads");
-            let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
 
-            let mut inst = region
-                .new_instance(module)
-                .expect("instance can be created");
+        $(
+            mod $region_id {
+                use libc::c_void;
+                use lucet_runtime::vmctx::{lucet_vmctx, Vmctx};
+                use lucet_runtime::{
+                    lucet_hostcall, DlModule, Error, Limits, Module, Region, Val, WASM_PAGE_SIZE,
+                };
+                use std::sync::Arc;
+                use $TestRegion as TestRegion;
 
-            let retval = inst
-                .run("callback_entrypoint", &[0u64.into()])
-                .expect("instance runs")
-                .unwrap_returned();
-            assert_eq!(u64::from(retval), 3);
-        }
+                use $crate::entrypoint::{mock_calculator_module, wat_calculator_module};
 
-        #[test]
-        fn ensure_linked() {
-            lucet_runtime::lucet_internal_ensure_linked();
-        }
+                #[test]
+                fn mock_calc_add_2() {
+                    calc_add_2(mock_calculator_module())
+                }
+
+                #[test]
+                fn wat_calc_add_2() {
+                    calc_add_2(wat_calculator_module());
+                }
+
+                fn calc_add_2(module: Arc<dyn Module>) {
+                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let mut inst = region
+                        .new_instance(module)
+                        .expect("instance can be created");
+
+                    let retval = inst
+                        .run("add_2", &[123u64.into(), 456u64.into()])
+                        .expect("instance runs")
+                        .unwrap_returned();
+
+                    assert_eq!(u64::from(retval), 123u64 + 456);
+                }
+
+                #[test]
+                fn mock_calc_add_10() {
+                    calc_add_10(mock_calculator_module())
+                }
+
+                #[test]
+                fn wat_calc_add_10() {
+                    calc_add_10(wat_calculator_module())
+                }
+
+                fn calc_add_10(module: Arc<dyn Module>) {
+                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let mut inst = region
+                        .new_instance(module)
+                        .expect("instance can be created");
+
+                    // Add all 10 arguments. Why 10? Because its more than will fit in registers to be passed to
+                    // `guest_add_10` by liblucet, so it will make sure that the calling convention of putting stuff
+                    // on the stack is working.
+                    //
+                    // A better test might be to use an operation that doesn't commute, so we can verify that the
+                    // order is correct.
+                    let retval = inst
+                        .run(
+                            "add_10",
+                            &[
+                                1u64.into(),
+                                2u64.into(),
+                                3u64.into(),
+                                4u64.into(),
+                                5u64.into(),
+                                6u64.into(),
+                                7u64.into(),
+                                8u64.into(),
+                                9u64.into(),
+                                10u64.into(),
+                            ],
+                        )
+                        .expect("instance runs")
+                        .unwrap_returned();
+
+                    assert_eq!(u64::from(retval), 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10);
+                }
+
+                #[test]
+                fn mock_calc_mul_2() {
+                    calc_mul_2(mock_calculator_module())
+                }
+
+                #[test]
+                fn wat_calc_mul_2() {
+                    calc_mul_2(wat_calculator_module())
+                }
+
+                fn calc_mul_2(module: Arc<dyn Module>) {
+                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let mut inst = region
+                        .new_instance(module)
+                        .expect("instance can be created");
+
+                    let retval = inst
+                        .run("mul_2", &[123u64.into(), 456u64.into()])
+                        .expect("instance runs")
+                        .unwrap_returned();
+
+                    assert_eq!(u64::from(retval), 123 * 456);
+                }
+
+                #[test]
+                fn mock_calc_add_then_mul() {
+                    calc_add_then_mul(mock_calculator_module())
+                }
+
+                fn calc_add_then_mul(module: Arc<dyn Module>) {
+                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let mut inst = region
+                        .new_instance(module)
+                        .expect("instance can be created");
+
+                    let retval = inst
+                        .run("add_2", &[111u64.into(), 222u64.into()])
+                        .expect("instance runs")
+                        .unwrap_returned();
+
+                    assert_eq!(u64::from(retval), 111 + 222);
+
+                    let retval = inst
+                        .run("mul_2", &[333u64.into(), 444u64.into()])
+                        .expect("instance runs")
+                        .unwrap_returned();
+
+                    assert_eq!(u64::from(retval), 333 * 444);
+                }
+
+                #[test]
+                fn mock_calc_invalid_entrypoint() {
+                    calc_invalid_entrypoint(mock_calculator_module())
+                }
+
+                #[test]
+                fn wat_calc_invalid_entrypoint() {
+                    calc_invalid_entrypoint(wat_calculator_module())
+                }
+
+                fn calc_invalid_entrypoint(module: Arc<dyn Module>) {
+                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let mut inst = region
+                        .new_instance(module)
+                        .expect("instance can be created");
+
+                    match inst.run("invalid", &[123u64.into(), 456u64.into()]) {
+                        Err(Error::SymbolNotFound(sym)) => assert_eq!(sym, "invalid"),
+                        res => panic!("unexpected result: {:?}", res),
+                    }
+                }
+
+                #[test]
+                fn mock_calc_add_f32_2() {
+                    calc_add_f32_2(mock_calculator_module());
+                }
+                #[test]
+                fn wat_calc_add_f32_2() {
+                    calc_add_f32_2(wat_calculator_module());
+                }
+
+                fn calc_add_f32_2(module: Arc<dyn Module>) {
+                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let mut inst = region
+                        .new_instance(module)
+                        .expect("instance can be created");
+
+                    let retval = inst
+                        .run("add_f32_2", &[(-6.9f32).into(), 4.2f32.into()])
+                        .expect("instance runs")
+                        .unwrap_returned();
+
+                    assert_eq!(f32::from(retval), -6.9 + 4.2);
+                }
+
+                #[test]
+                fn mock_calc_add_f64_2() {
+                    calc_add_f64_2(mock_calculator_module());
+                }
+                #[test]
+                fn wat_calc_add_f64_2() {
+                    calc_add_f64_2(wat_calculator_module());
+                }
+                fn calc_add_f64_2(module: Arc<dyn Module>) {
+                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let mut inst = region
+                        .new_instance(module)
+                        .expect("instance can be created");
+
+                    let retval = inst
+                        .run("add_f64_2", &[(-6.9f64).into(), 4.2f64.into()])
+                        .expect("instance runs")
+                        .unwrap_returned();
+
+                    assert_eq!(f64::from(retval), -6.9 + 4.2);
+                }
+
+                #[test]
+                fn mock_calc_add_f32_10() {
+                    calc_add_f32_10(mock_calculator_module());
+                }
+                #[test]
+                fn wat_calc_add_f32_10() {
+                    calc_add_f32_10(wat_calculator_module());
+                }
+                fn calc_add_f32_10(module: Arc<dyn Module>) {
+                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let mut inst = region
+                        .new_instance(module)
+                        .expect("instance can be created");
+
+                    let retval = inst
+                        .run(
+                            "add_f32_10",
+                            &[
+                                0.1f32.into(),
+                                0.2f32.into(),
+                                0.3f32.into(),
+                                0.4f32.into(),
+                                0.5f32.into(),
+                                0.6f32.into(),
+                                0.7f32.into(),
+                                0.8f32.into(),
+                                0.9f32.into(),
+                                1.0f32.into(),
+                            ],
+                        )
+                        .expect("instance runs")
+                        .unwrap_returned();
+
+                    assert_eq!(
+                        f32::from(retval),
+                        0.1 + 0.2 + 0.3 + 0.4 + 0.5 + 0.6 + 0.7 + 0.8 + 0.9 + 1.0
+                    );
+                }
+
+                #[test]
+                fn mock_calc_add_f64_10() {
+                    calc_add_f64_10(mock_calculator_module());
+                }
+                #[test]
+                fn wat_calc_add_f64_10() {
+                    calc_add_f64_10(wat_calculator_module());
+                }
+                fn calc_add_f64_10(module: Arc<dyn Module>) {
+                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let mut inst = region
+                        .new_instance(module)
+                        .expect("instance can be created");
+
+                    let retval = inst
+                        .run(
+                            "add_f64_10",
+                            &[
+                                0.1f64.into(),
+                                0.2f64.into(),
+                                0.3f64.into(),
+                                0.4f64.into(),
+                                0.5f64.into(),
+                                0.6f64.into(),
+                                0.7f64.into(),
+                                0.8f64.into(),
+                                0.9f64.into(),
+                                1.0f64.into(),
+                            ],
+                        )
+                        .expect("instance runs")
+                        .unwrap_returned();
+
+                    assert_eq!(
+                        f64::from(retval),
+                        0.1 + 0.2 + 0.3 + 0.4 + 0.5 + 0.6 + 0.7 + 0.8 + 0.9 + 1.0
+                    );
+                }
+
+                #[test]
+                fn mock_calc_add_mixed_20() {
+                    calc_add_mixed_20(mock_calculator_module());
+                }
+                // TODO: it would be pretty annoying to write the mixed_20 calc test in wasm, so we havent.
+                fn calc_add_mixed_20(module: Arc<dyn Module>) {
+                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let mut inst = region
+                        .new_instance(module)
+                        .expect("instance can be created");
+
+                    let retval = inst
+                        .run(
+                            "add_mixed_20",
+                            &[
+                                (-1.1f64).into(),
+                                1u8.into(),
+                                2.1f32.into(),
+                                3.1f64.into(),
+                                4u16.into(),
+                                5.1f32.into(),
+                                6.1f64.into(),
+                                7u32.into(),
+                                8.1f32.into(),
+                                9.1f64.into(),
+                                true.into(),
+                                11.1f32.into(),
+                                12.1f64.into(),
+                                13u32.into(),
+                                14.1f32.into(),
+                                15.1f64.into(),
+                                16u64.into(),
+                                17.1f32.into(),
+                                18.1f64.into(),
+                                19u64.into(),
+                            ],
+                        )
+                        .expect("instance runs")
+                        .unwrap_returned();
+
+                    assert_eq!(
+                        f64::from(retval),
+                        -1.1f64
+                            + 1u8 as f64
+                            + 2.1f32 as f64
+                            + 3.1f64
+                            + 4u16 as f64
+                            + 5.1f32 as f64
+                            + 6.1f64
+                            + 7u32 as f64
+                            + 8.1f32 as f64
+                            + 9.1f64
+                            + 1 as f64
+                            + 11.1f32 as f64
+                            + 12.1f64
+                            + 13u32 as f64
+                            + 14.1f32 as f64
+                            + 15.1f64
+                            + 16u64 as f64
+                            + 17.1f32 as f64
+                            + 18.1f64
+                            + 19u64 as f64
+                    );
+                }
+
+                #[test]
+                fn mock_typecheck_entrypoint_wrong_args() {
+                    typecheck_entrypoint_wrong_args(mock_calculator_module())
+                }
+
+                #[test]
+                fn wat_typecheck_entrypoint_wrong_args() {
+                    typecheck_entrypoint_wrong_args(wat_calculator_module())
+                }
+
+                fn typecheck_entrypoint_wrong_args(module: Arc<dyn Module>) {
+                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let mut inst = region
+                        .new_instance(module)
+                        .expect("instance can be created");
+
+                    match inst.run("add_2", &[123.0f64.into(), 456.0f64.into()]) {
+                        Err(Error::InvalidArgument(err)) => {
+                            assert_eq!(err, "entrypoint function signature mismatch")
+                        }
+                        res => panic!("unexpected result: {:?}", res),
+                    }
+                }
+
+                #[test]
+                fn mock_typecheck_entrypoint_too_few_args() {
+                    typecheck_entrypoint_too_few_args(mock_calculator_module())
+                }
+
+                #[test]
+                fn wat_typecheck_entrypoint_too_few_args() {
+                    typecheck_entrypoint_too_few_args(wat_calculator_module())
+                }
+
+                fn typecheck_entrypoint_too_few_args(module: Arc<dyn Module>) {
+                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let mut inst = region
+                        .new_instance(module)
+                        .expect("instance can be created");
+
+                    match inst.run("add_2", &[123u64.into()]) {
+                        Err(Error::InvalidArgument(err)) => assert_eq!(
+                            err,
+                            "entrypoint function signature mismatch (number of arguments is incorrect)"
+                        ),
+                        res => panic!("unexpected result: {:?}", res),
+                    }
+                }
+
+                #[test]
+                fn mock_typecheck_entrypoint_too_many_args() {
+                    typecheck_entrypoint_too_many_args(mock_calculator_module())
+                }
+
+                #[test]
+                fn wat_typecheck_entrypoint_too_many_args() {
+                    typecheck_entrypoint_too_many_args(wat_calculator_module())
+                }
+
+                fn typecheck_entrypoint_too_many_args(module: Arc<dyn Module>) {
+                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let mut inst = region
+                        .new_instance(module)
+                        .expect("instance can be created");
+
+                    match inst.run("add_2", &[123u64.into(), 456u64.into(), 789u64.into()]) {
+                        Err(Error::InvalidArgument(err)) => assert_eq!(
+                            err,
+                            "entrypoint function signature mismatch (number of arguments is incorrect)"
+                        ),
+                        res => panic!("unexpected result: {:?}", res),
+                    }
+                }
+
+                #[test]
+                fn mock_imported_entrypoint() {
+                    imported_entrypoint(mock_calculator_module())
+                }
+
+                #[test]
+                fn wat_imported_entrypoint() {
+                    imported_entrypoint(wat_calculator_module())
+                }
+
+                fn imported_entrypoint(module: Arc<dyn Module>) {
+                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let mut inst = region
+                        .new_instance(module)
+                        .expect("instance can be created");
+
+                    let retval = inst
+                        .run(
+                            "add_4_reexport",
+                            &[123u64.into(), 456u64.into(), 789u64.into(), 432u64.into()],
+                        )
+                        .unwrap()
+                        .unwrap_returned();
+                    assert_eq!(u64::from(retval), 1800);
+                }
+
+                use $crate::build::test_module_c;
+                const TEST_REGION_INIT_VAL: libc::c_int = 123;
+                const TEST_REGION_SIZE: libc::size_t = 4;
+
+                #[test]
+                fn allocator_create_region() {
+                    use byteorder::{LittleEndian, ReadBytesExt};
+
+                    let module =
+                        test_module_c("entrypoint", "use_allocator.c").expect("module builds and loads");
+                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+
+                    let mut inst = region
+                        .new_instance(module)
+                        .expect("instance can be created");
+
+                    // First, we need to get an unused location in linear memory for the pointer that will be passed
+                    // as an argument to create_and_memset.
+                    let new_page = inst.grow_memory(1).expect("grow_memory succeeds");
+                    assert!(new_page > 0);
+                    // wasm memory index for the start of the new page
+                    let loc_outval = new_page * WASM_PAGE_SIZE;
+
+                    // This function will call `malloc` for the given size, then `memset` the entire region to the
+                    // init_as argument. The pointer to the allocated region gets stored in loc_outval.
+                    inst.run(
+                        "create_and_memset",
+                        &[
+                            // int init_as
+                            TEST_REGION_INIT_VAL.into(),
+                            // size_t size
+                            TEST_REGION_SIZE.into(),
+                            // char** ptr_outval
+                            Val::GuestPtr(loc_outval),
+                        ],
+                    )
+                        .expect("instance runs");
+
+                    // The location of the created region should be in a new page that the allocator grabbed from
+                    // the runtime. That page will be above the one we got above.
+                    let heap = inst.heap();
+                    let loc_region_1 = (&heap[loc_outval as usize..])
+                        .read_u32::<LittleEndian>()
+                        .expect("can read outval");
+                    assert!(loc_region_1 > loc_outval);
+
+                    // Each character in the newly created region will match the expected value.
+                    for i in 0..TEST_REGION_SIZE {
+                        assert_eq!(
+                            TEST_REGION_INIT_VAL as u8,
+                            heap[loc_region_1 as usize + i],
+                            "character in new region matches"
+                        );
+                    }
+                }
+
+                #[test]
+                fn allocator_create_region_and_increment() {
+                    use byteorder::{LittleEndian, ReadBytesExt};
+
+                    let module =
+                        test_module_c("entrypoint", "use_allocator.c").expect("module builds and loads");
+                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+
+                    let mut inst = region
+                        .new_instance(module)
+                        .expect("instance can be created");
+
+                    // First, we need to get an unused location in linear memory for the pointer that will be passed
+                    // as an argument to create_and_memset.
+                    let new_page = inst.grow_memory(1).expect("grow_memory succeeds");
+                    assert!(new_page > 0);
+                    // wasm memory index for the start of the new page
+                    let loc_outval = new_page * WASM_PAGE_SIZE as u32;
+
+                    // Create a region and initialize it, just like above
+                    inst.run(
+                        "create_and_memset",
+                        &[
+                            // int init_as
+                            TEST_REGION_INIT_VAL.into(),
+                            // size_t size
+                            TEST_REGION_SIZE.into(),
+                            // char** ptr_outval
+                            Val::GuestPtr(loc_outval),
+                        ],
+                    )
+                        .expect("instance runs");
+
+                    // The location of the created region should be in a new page that the allocator grabbed from
+                    // the runtime. That page will be above the one we got above.
+                    let heap = inst.heap();
+                    let loc_region_1 = (&heap[loc_outval as usize..])
+                        .read_u32::<LittleEndian>()
+                        .expect("can read outval");
+                    assert!(loc_region_1 > loc_outval);
+
+                    // Each character in the newly created region will match the expected value.
+                    for i in 0..TEST_REGION_SIZE {
+                        assert_eq!(
+                            TEST_REGION_INIT_VAL as u8,
+                            heap[loc_region_1 as usize + i],
+                            "character in new region matches"
+                        );
+                    }
+
+                    // Then increment the first location in the region
+                    inst.run("increment_ptr", &[Val::GuestPtr(loc_region_1)])
+                        .expect("instance runs");
+
+                    let heap = inst.heap();
+                    // Just the first location in the region should be incremented
+                    for i in 0..TEST_REGION_SIZE {
+                        if i == 0 {
+                            assert_eq!(
+                                TEST_REGION_INIT_VAL as u8 + 1,
+                                heap[loc_region_1 as usize + i],
+                                "character in new region matches"
+                            );
+                        } else {
+                            assert_eq!(
+                                TEST_REGION_INIT_VAL as u8,
+                                heap[loc_region_1 as usize + i],
+                                "character in new region matches"
+                            );
+                        }
+                    }
+                }
+
+                const TEST_REGION2_INIT_VAL: libc::c_int = 99;
+                const TEST_REGION2_SIZE: libc::size_t = 420;
+
+                #[test]
+                fn allocator_create_two_regions() {
+                    use byteorder::{LittleEndian, ReadBytesExt};
+
+                    let module =
+                        test_module_c("entrypoint", "use_allocator.c").expect("module builds and loads");
+                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+
+                    let mut inst = region
+                        .new_instance(module)
+                        .expect("instance can be created");
+
+                    // same as above
+                    let new_page = inst.grow_memory(1).expect("grow_memory succeeds");
+                    assert!(new_page > 0);
+                    // wasm memory index for the start of the new page
+                    let loc_outval = new_page * WASM_PAGE_SIZE;
+
+                    // same as above
+                    inst.run(
+                        "create_and_memset",
+                        &[
+                            // int init_as
+                            TEST_REGION_INIT_VAL.into(),
+                            // size_t size
+                            TEST_REGION_SIZE.into(),
+                            // char** ptr_outval
+                            Val::GuestPtr(loc_outval),
+                        ],
+                    )
+                        .expect("instance runs");
+
+                    let heap = inst.heap();
+                    let loc_region_1 = (&heap[loc_outval as usize..])
+                        .read_u32::<LittleEndian>()
+                        .expect("can read outval");
+                    assert!(loc_region_1 > loc_outval);
+
+                    // Create a second region
+                    inst.run(
+                        "create_and_memset",
+                        &[
+                            // int init_as
+                            TEST_REGION2_INIT_VAL.into(),
+                            // size_t size
+                            TEST_REGION2_SIZE.into(),
+                            // char** ptr_outval
+                            Val::GuestPtr(loc_outval),
+                        ],
+                    )
+                        .expect("instance runs");
+
+                    // The allocator should pick a spot *after* the first region for the second one. (It doesn't
+                    // have to, but it will.) This shows that the allocator's metadata (free list) is preserved
+                    // between the runs.
+                    let heap = inst.heap();
+                    let loc_region_2 = (&heap[loc_outval as usize..])
+                        .read_u32::<LittleEndian>()
+                        .expect("can read outval");
+                    assert!(loc_region_2 > loc_region_1);
+
+                    // After this, both regions should be initialized as expected
+                    for i in 0..TEST_REGION_SIZE {
+                        assert_eq!(
+                            TEST_REGION_INIT_VAL as u8,
+                            heap[loc_region_1 as usize + i],
+                            "character in region 1 matches"
+                        );
+                    }
+
+                    for i in 0..TEST_REGION2_SIZE {
+                        assert_eq!(
+                            TEST_REGION2_INIT_VAL as u8,
+                            heap[loc_region_2 as usize + i],
+                            "character in region 2 matches"
+                        );
+                    }
+                }
+
+                #[test]
+                fn entrypoint_ctype() {
+                    use byteorder::{LittleEndian, ReadBytesExt};
+                    let module = test_module_c("entrypoint", "ctype.c").expect("module builds and loads");
+                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+
+                    let mut inst = region
+                        .new_instance(module)
+                        .expect("instance can be created");
+
+                    // First, we need to get an unused location in linear memory for the pointer that will be passed
+                    // as an argument to create_and_memset.
+                    let new_page = inst.grow_memory(1).expect("grow_memory succeeds");
+                    assert!(new_page > 0);
+                    // wasm memory index for the start of the new page
+                    let loc_ctxstar = new_page * WASM_PAGE_SIZE;
+
+                    // Run the setup routine
+                    inst.run(
+                        "ctype_setup",
+                        &[
+                            std::ptr::null::<c_void>().into(),
+                            Val::GuestPtr(loc_ctxstar),
+                        ],
+                    )
+                        .expect("instance runs");
+
+                    // Grab the value of the pointer that the setup routine wrote
+                    let heap = inst.heap();
+                    let ctxstar = (&heap[loc_ctxstar as usize..])
+                        .read_u32::<LittleEndian>()
+                        .expect("can read ctxstar");
+                    assert!(ctxstar > 0);
+
+                    // Run the body routine
+                    inst.run("ctype_body", &[Val::GuestPtr(ctxstar)])
+                        .expect("instance runs");
+                }
+
+                #[test]
+                fn entrypoint_callback() {
+                    let module =
+                        test_module_c("entrypoint", "callback.c").expect("module builds and loads");
+                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+
+                    let mut inst = region
+                        .new_instance(module)
+                        .expect("instance can be created");
+
+                    let retval = inst
+                        .run("callback_entrypoint", &[0u64.into()])
+                        .expect("instance runs")
+                        .unwrap_returned();
+                    assert_eq!(u64::from(retval), 3);
+                }
+
+                #[test]
+                fn ensure_linked() {
+                    lucet_runtime::lucet_internal_ensure_linked();
+                }
+
+            }
+        )*
     };
 }

--- a/lucet-runtime/lucet-runtime-tests/src/entrypoint.rs
+++ b/lucet-runtime/lucet-runtime-tests/src/entrypoint.rs
@@ -190,7 +190,7 @@ pub fn mock_calculator_module() -> Arc<dyn Module> {
 
 #[macro_export]
 macro_rules! entrypoint_tests {
-    ( $( $TestRegion:path => $region_id:ident ),* ) => {
+    ( $( $region_id:ident => $TestRegion:path ),* ) => {
         use libc::c_void;
         use lucet_runtime::vmctx::{lucet_vmctx, Vmctx};
         use lucet_runtime::{

--- a/lucet-runtime/lucet-runtime-tests/src/globals.rs
+++ b/lucet-runtime/lucet-runtime-tests/src/globals.rs
@@ -1,179 +1,184 @@
 #[macro_export]
 macro_rules! globals_tests {
-    ( $TestRegion:path ) => {
-        use $crate::build::test_module_wasm;
-        use $crate::helpers::{MockExportBuilder, MockModuleBuilder};
-        use lucet_module::{lucet_signature, FunctionPointer, GlobalValue};
-        use lucet_runtime::vmctx::{lucet_vmctx, Vmctx};
-        use lucet_runtime::{Error, Limits, Module, Region};
-        use std::sync::Arc;
-        use $TestRegion as TestRegion;
+    ( $( $region_id:ident => $TestRegion:path ),* ) => {
 
-        #[test]
-        fn defined_globals() {
-            let module =
-                test_module_wasm("globals", "definition.wat").expect("module compiled and loaded");
-            let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
-            let mut inst = region
-                .new_instance(module)
-                .expect("instance can be created");
+        $(
+            mod $region_id {
+                use $crate::build::test_module_wasm;
+                use $crate::helpers::{MockExportBuilder, MockModuleBuilder};
+                use lucet_module::{lucet_signature, FunctionPointer, GlobalValue};
+                use lucet_runtime::vmctx::{lucet_vmctx, Vmctx};
+                use lucet_runtime::{Error, Limits, Module, Region};
+                use std::sync::Arc;
+                use $TestRegion as TestRegion;
 
-            inst.run("main", &[]).expect("instance runs");
+                #[test]
+                fn defined_globals() {
+                    let module =
+                        test_module_wasm("globals", "definition.wat").expect("module compiled and loaded");
+                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let mut inst = region
+                        .new_instance(module)
+                        .expect("instance can be created");
 
-            // Now the globals should be:
-            // $x = 3
-            // $y = 2
-            // $z = 6
-            // and heap should be:
-            // [0] = 4
-            // [4] = 5
-            // [8] = 6
+                    inst.run("main", &[]).expect("instance runs");
 
-            let heap_u32 = unsafe { inst.heap_u32() };
-            assert_eq!(heap_u32[0..=2], [4, 5, 6]);
+                    // Now the globals should be:
+                    // $x = 3
+                    // $y = 2
+                    // $z = 6
+                    // and heap should be:
+                    // [0] = 4
+                    // [4] = 5
+                    // [8] = 6
 
-            inst.run("main", &[]).expect("instance runs");
+                    let heap_u32 = unsafe { inst.heap_u32() };
+                    assert_eq!(heap_u32[0..=2], [4, 5, 6]);
 
-            // now heap should be:
-            // [0] = 3
-            // [4] = 2
-            // [8] = 6
+                    inst.run("main", &[]).expect("instance runs");
 
-            let heap_u32 = unsafe { inst.heap_u32() };
-            assert_eq!(heap_u32[0..=2], [3, 2, 6]);
-        }
+                    // now heap should be:
+                    // [0] = 3
+                    // [4] = 2
+                    // [8] = 6
 
-        fn mock_import_module() -> Arc<dyn Module> {
-            MockModuleBuilder::new()
-                .with_import(0, "something", "else")
-                .build()
-        }
+                    let heap_u32 = unsafe { inst.heap_u32() };
+                    assert_eq!(heap_u32[0..=2], [3, 2, 6]);
+                }
 
-        #[test]
-        fn reject_import() {
-            let module = mock_import_module();
-            let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
-            match region.new_instance(module) {
-                Ok(_) => panic!("instance creation should not succeed"),
-                Err(Error::Unsupported(_)) => (),
-                Err(e) => panic!("unexpected error: {}", e),
+                fn mock_import_module() -> Arc<dyn Module> {
+                    MockModuleBuilder::new()
+                        .with_import(0, "something", "else")
+                        .build()
+                }
+
+                #[test]
+                fn reject_import() {
+                    let module = mock_import_module();
+                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    match region.new_instance(module) {
+                        Ok(_) => panic!("instance creation should not succeed"),
+                        Err(Error::Unsupported(_)) => (),
+                        Err(e) => panic!("unexpected error: {}", e),
+                    }
+                }
+
+                fn mock_globals_module() -> Arc<dyn Module> {
+                    extern "C" {
+                        fn lucet_vmctx_get_globals(vmctx: *mut lucet_vmctx) -> *mut GlobalValue;
+                    }
+
+                    unsafe extern "C" fn get_global0(vmctx: *mut lucet_vmctx) -> i64 {
+                        let globals = std::slice::from_raw_parts(lucet_vmctx_get_globals(vmctx), 2);
+                        globals[0].i_64
+                    }
+
+                    unsafe extern "C" fn set_global0(vmctx: *mut lucet_vmctx, val: i64) {
+                        let globals = std::slice::from_raw_parts_mut(lucet_vmctx_get_globals(vmctx), 2);
+                        globals[0].i_64 = val;
+                    }
+
+                    unsafe extern "C" fn get_global1(vmctx: *mut lucet_vmctx) -> i64 {
+                        let globals = std::slice::from_raw_parts(lucet_vmctx_get_globals(vmctx), 2);
+                        globals[1].i_64
+                    }
+
+                    MockModuleBuilder::new()
+                        .with_global(0, -1)
+                        .with_global(1, 420)
+                        .with_export_func(
+                            MockExportBuilder::new(
+                                "get_global0",
+                                FunctionPointer::from_usize(get_global0 as usize),
+                            )
+                                .with_sig(lucet_signature!(() -> I64)),
+                        )
+                        .with_export_func(
+                            MockExportBuilder::new(
+                                "set_global0",
+                                FunctionPointer::from_usize(set_global0 as usize),
+                            )
+                                .with_sig(lucet_signature!((I64) -> ())),
+                        )
+                        .with_export_func(
+                            MockExportBuilder::new(
+                                "get_global1",
+                                FunctionPointer::from_usize(get_global1 as usize),
+                            )
+                                .with_sig(lucet_signature!(() -> I64)),
+                        )
+                        .build()
+                }
+
+                /* replace with use of instance public api to make sure defined globals are initialized
+                 * correctly
+                 */
+
+                #[test]
+                fn globals_initialized() {
+                    let module = mock_globals_module();
+                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let inst = region
+                        .new_instance(module)
+                        .expect("instance can be created");
+                    assert_eq!(unsafe { inst.globals()[0].i_64 }, -1);
+                    assert_eq!(unsafe { inst.globals()[1].i_64 }, 420);
+                }
+
+                #[test]
+                fn get_global0() {
+                    let module = mock_globals_module();
+                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let mut inst = region
+                        .new_instance(module)
+                        .expect("instance can be created");
+
+                    let retval = inst
+                        .run("get_global0", &[])
+                        .expect("instance runs")
+                        .unwrap_returned();
+                    assert_eq!(i64::from(retval), -1);
+                }
+
+                #[test]
+                fn get_both_globals() {
+                    let module = mock_globals_module();
+                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let mut inst = region
+                        .new_instance(module)
+                        .expect("instance can be created");
+
+                    let retval = inst
+                        .run("get_global0", &[])
+                        .expect("instance runs")
+                        .unwrap_returned();
+                    assert_eq!(i64::from(retval), -1);
+
+                    let retval = inst
+                        .run("get_global1", &[])
+                        .expect("instance runs")
+                        .unwrap_returned();
+                    assert_eq!(i64::from(retval), 420);
+                }
+
+                #[test]
+                fn mutate_global0() {
+                    let module = mock_globals_module();
+                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let mut inst = region
+                        .new_instance(module)
+                        .expect("instance can be created");
+
+                    inst.run("set_global0", &[666i64.into()])
+                        .expect("instance runs");
+
+                    let retval = inst
+                        .run("get_global0", &[])
+                        .expect("instance runs")
+                        .unwrap_returned();
+                    assert_eq!(i64::from(retval), 666);
+                }
             }
-        }
-
-        fn mock_globals_module() -> Arc<dyn Module> {
-            extern "C" {
-                fn lucet_vmctx_get_globals(vmctx: *mut lucet_vmctx) -> *mut GlobalValue;
-            }
-
-            unsafe extern "C" fn get_global0(vmctx: *mut lucet_vmctx) -> i64 {
-                let globals = std::slice::from_raw_parts(lucet_vmctx_get_globals(vmctx), 2);
-                globals[0].i_64
-            }
-
-            unsafe extern "C" fn set_global0(vmctx: *mut lucet_vmctx, val: i64) {
-                let globals = std::slice::from_raw_parts_mut(lucet_vmctx_get_globals(vmctx), 2);
-                globals[0].i_64 = val;
-            }
-
-            unsafe extern "C" fn get_global1(vmctx: *mut lucet_vmctx) -> i64 {
-                let globals = std::slice::from_raw_parts(lucet_vmctx_get_globals(vmctx), 2);
-                globals[1].i_64
-            }
-
-            MockModuleBuilder::new()
-                .with_global(0, -1)
-                .with_global(1, 420)
-                .with_export_func(
-                    MockExportBuilder::new(
-                        "get_global0",
-                        FunctionPointer::from_usize(get_global0 as usize),
-                    )
-                    .with_sig(lucet_signature!(() -> I64)),
-                )
-                .with_export_func(
-                    MockExportBuilder::new(
-                        "set_global0",
-                        FunctionPointer::from_usize(set_global0 as usize),
-                    )
-                    .with_sig(lucet_signature!((I64) -> ())),
-                )
-                .with_export_func(
-                    MockExportBuilder::new(
-                        "get_global1",
-                        FunctionPointer::from_usize(get_global1 as usize),
-                    )
-                    .with_sig(lucet_signature!(() -> I64)),
-                )
-                .build()
-        }
-
-        /* replace with use of instance public api to make sure defined globals are initialized
-         * correctly
-         */
-
-        #[test]
-        fn globals_initialized() {
-            let module = mock_globals_module();
-            let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
-            let inst = region
-                .new_instance(module)
-                .expect("instance can be created");
-            assert_eq!(unsafe { inst.globals()[0].i_64 }, -1);
-            assert_eq!(unsafe { inst.globals()[1].i_64 }, 420);
-        }
-
-        #[test]
-        fn get_global0() {
-            let module = mock_globals_module();
-            let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
-            let mut inst = region
-                .new_instance(module)
-                .expect("instance can be created");
-
-            let retval = inst
-                .run("get_global0", &[])
-                .expect("instance runs")
-                .unwrap_returned();
-            assert_eq!(i64::from(retval), -1);
-        }
-
-        #[test]
-        fn get_both_globals() {
-            let module = mock_globals_module();
-            let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
-            let mut inst = region
-                .new_instance(module)
-                .expect("instance can be created");
-
-            let retval = inst
-                .run("get_global0", &[])
-                .expect("instance runs")
-                .unwrap_returned();
-            assert_eq!(i64::from(retval), -1);
-
-            let retval = inst
-                .run("get_global1", &[])
-                .expect("instance runs")
-                .unwrap_returned();
-            assert_eq!(i64::from(retval), 420);
-        }
-
-        #[test]
-        fn mutate_global0() {
-            let module = mock_globals_module();
-            let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
-            let mut inst = region
-                .new_instance(module)
-                .expect("instance can be created");
-
-            inst.run("set_global0", &[666i64.into()])
-                .expect("instance runs");
-
-            let retval = inst
-                .run("get_global0", &[])
-                .expect("instance runs")
-                .unwrap_returned();
-            assert_eq!(i64::from(retval), 666);
-        }
+        )*
     };
 }

--- a/lucet-runtime/lucet-runtime-tests/src/globals.rs
+++ b/lucet-runtime/lucet-runtime-tests/src/globals.rs
@@ -8,7 +8,7 @@ macro_rules! globals_tests {
                 use $crate::helpers::{MockExportBuilder, MockModuleBuilder};
                 use lucet_module::{lucet_signature, FunctionPointer, GlobalValue};
                 use lucet_runtime::vmctx::{lucet_vmctx, Vmctx};
-                use lucet_runtime::{Error, Limits, Module, Region};
+                use lucet_runtime::{Error, Limits, Module, Region, RegionCreate};
                 use std::sync::Arc;
                 use $TestRegion as TestRegion;
 
@@ -16,7 +16,7 @@ macro_rules! globals_tests {
                 fn defined_globals() {
                     let module =
                         test_module_wasm("globals", "definition.wat").expect("module compiled and loaded");
-                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let region = <TestRegion as RegionCreate>::create(1, &Limits::default()).expect("region can be created");
                     let mut inst = region
                         .new_instance(module)
                         .expect("instance can be created");
@@ -55,7 +55,7 @@ macro_rules! globals_tests {
                 #[test]
                 fn reject_import() {
                     let module = mock_import_module();
-                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let region = <TestRegion as RegionCreate>::create(1, &Limits::default()).expect("region can be created");
                     match region.new_instance(module) {
                         Ok(_) => panic!("instance creation should not succeed"),
                         Err(Error::Unsupported(_)) => (),
@@ -117,7 +117,7 @@ macro_rules! globals_tests {
                 #[test]
                 fn globals_initialized() {
                     let module = mock_globals_module();
-                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let region = <TestRegion as RegionCreate>::create(1, &Limits::default()).expect("region can be created");
                     let inst = region
                         .new_instance(module)
                         .expect("instance can be created");
@@ -128,7 +128,7 @@ macro_rules! globals_tests {
                 #[test]
                 fn get_global0() {
                     let module = mock_globals_module();
-                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let region = <TestRegion as RegionCreate>::create(1, &Limits::default()).expect("region can be created");
                     let mut inst = region
                         .new_instance(module)
                         .expect("instance can be created");
@@ -143,7 +143,7 @@ macro_rules! globals_tests {
                 #[test]
                 fn get_both_globals() {
                     let module = mock_globals_module();
-                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let region = <TestRegion as RegionCreate>::create(1, &Limits::default()).expect("region can be created");
                     let mut inst = region
                         .new_instance(module)
                         .expect("instance can be created");
@@ -164,7 +164,7 @@ macro_rules! globals_tests {
                 #[test]
                 fn mutate_global0() {
                     let module = mock_globals_module();
-                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let region = <TestRegion as RegionCreate>::create(1, &Limits::default()).expect("region can be created");
                     let mut inst = region
                         .new_instance(module)
                         .expect("instance can be created");

--- a/lucet-runtime/lucet-runtime-tests/src/guest_fault.rs
+++ b/lucet-runtime/lucet-runtime-tests/src/guest_fault.rs
@@ -184,8 +184,6 @@ macro_rules! guest_fault_tests {
         use nix::unistd::{fork, ForkResult};
         use std::ptr;
         use std::sync::{Arc, Mutex};
-        use $TestRegion as TestRegion;
-        use $crate::guest_fault::{mock_traps_module, with_unchanged_signal_handlers};
         use $crate::helpers::{
             test_ex, test_nonex, with_unchanged_signal_handlers, FunctionPointer,
             MockExportBuilder, MockModuleBuilder,
@@ -205,19 +203,6 @@ macro_rules! guest_fault_tests {
         #[cfg(not(target_os = "linux"))]
         const INVALID_PERMISSION_SIGNAL: Signal = Signal::SIGBUS;
 
-        static HOSTCALL_TEST_ERROR: &'static str = "hostcall_test threw an error!";
-
-        #[no_mangle]
-        unsafe extern "C" fn guest_recoverable_get_ptr() -> *const libc::c_char {
-            RECOVERABLE_PTR
-        }
-
-        #[lucet_hostcall]
-        #[no_mangle]
-        pub fn hostcall_test(_vmctx: &mut Vmctx) {
-            lucet_hostcall_terminate!(HOSTCALL_TEST_ERROR);
-        }
-
         $(
             mod $region_id {
                 use lazy_static::lazy_static;
@@ -235,10 +220,10 @@ macro_rules! guest_fault_tests {
                 use std::ptr;
                 use std::sync::{Arc, Mutex};
                 use $TestRegion as TestRegion;
-                use $crate::guest_fault::{mock_traps_module, with_unchanged_signal_handlers};
                 use $crate::helpers::{
-                    test_ex, test_nonex, FunctionPointer, MockExportBuilder, MockModuleBuilder,
+                    test_ex, test_nonex, with_unchanged_signal_handlers, FunctionPointer, MockExportBuilder, MockModuleBuilder,
                 };
+                use super::mock_traps_module;
 
 
                 unsafe fn recoverable_ptr_setup() {

--- a/lucet-runtime/lucet-runtime-tests/src/guest_fault.rs
+++ b/lucet-runtime/lucet-runtime-tests/src/guest_fault.rs
@@ -210,7 +210,7 @@ macro_rules! guest_fault_tests {
                 use lucet_runtime::vmctx::{lucet_vmctx, Vmctx};
                 use lucet_runtime::{
                     lucet_hostcall, lucet_hostcall_terminate, lucet_internal_ensure_linked, DlModule,
-                    Error, FaultDetails, Instance, Limits, Region, SignalBehavior, TerminationDetails,
+                    Error, FaultDetails, Instance, Limits, Region, RegionCreate, SignalBehavior, TerminationDetails,
                     TrapCode,
                 };
                 use nix::sys::mman::{mmap, MapFlags, ProtFlags};
@@ -269,7 +269,7 @@ macro_rules! guest_fault_tests {
                     test_nonex(|| {
                         let module = mock_traps_module();
                         let region =
-                            TestRegion::create(1, &Limits::default()).expect("region can be created");
+                            <TestRegion as RegionCreate>::create(1, &Limits::default()).expect("region can be created");
                         let mut inst = region
                             .new_instance(module)
                             .expect("instance can be created");
@@ -295,7 +295,7 @@ macro_rules! guest_fault_tests {
                         with_unchanged_signal_handlers(|| {
                             let module = mock_traps_module();
                             let region =
-                                TestRegion::create(1, &Limits::default()).expect("region can be created");
+                                <TestRegion as RegionCreate>::create(1, &Limits::default()).expect("region can be created");
                             let mut inst = region
                                 .new_instance(module)
                                 .expect("instance can be created");
@@ -328,7 +328,7 @@ macro_rules! guest_fault_tests {
                         with_unchanged_signal_handlers(|| {
                             let module = mock_traps_module();
                             let region =
-                                TestRegion::create(1, &Limits::default()).expect("region can be created");
+                                <TestRegion as RegionCreate>::create(1, &Limits::default()).expect("region can be created");
                             let mut inst = region
                                 .new_instance(module)
                                 .expect("instance can be created");
@@ -401,7 +401,7 @@ macro_rules! guest_fault_tests {
                             ..Limits::default()
                         };
                         let region =
-                            TestRegion::create(1, &limits_no_sigstack).expect("region can be created");
+                            <TestRegion as RegionCreate>::create(1, &limits_no_sigstack).expect("region can be created");
                         let mut inst = region
                             .new_instance(module)
                             .expect("instance can be created");
@@ -435,7 +435,7 @@ macro_rules! guest_fault_tests {
                     test_nonex(|| {
                         let module = mock_traps_module();
                         let region =
-                            TestRegion::create(1, &Limits::default()).expect("region can be created");
+                            <TestRegion as RegionCreate>::create(1, &Limits::default()).expect("region can be created");
                         let mut inst = region
                             .new_instance(module)
                             .expect("instance can be created");
@@ -461,7 +461,7 @@ macro_rules! guest_fault_tests {
                     test_nonex(|| {
                         let module = mock_traps_module();
                         let region =
-                            TestRegion::create(1, &Limits::default()).expect("region can be created");
+                            <TestRegion as RegionCreate>::create(1, &Limits::default()).expect("region can be created");
                         let mut inst = region
                             .new_instance(module)
                             .expect("instance can be created");
@@ -482,7 +482,7 @@ macro_rules! guest_fault_tests {
                     test_nonex(|| {
                         let module = mock_traps_module();
                         let region =
-                            TestRegion::create(1, &Limits::default()).expect("region can be created");
+                            <TestRegion as RegionCreate>::create(1, &Limits::default()).expect("region can be created");
                         let mut inst = region
                             .new_instance(module)
                             .expect("instance can be created");
@@ -531,7 +531,7 @@ macro_rules! guest_fault_tests {
                         let lock = super::RECOVERABLE_PTR_LOCK.lock().unwrap();
                         let module = mock_traps_module();
                         let region =
-                            TestRegion::create(1, &Limits::default()).expect("region can be created");
+                            <TestRegion as RegionCreate>::create(1, &Limits::default()).expect("region can be created");
                         let mut inst = region
                             .new_instance(module)
                             .expect("instance can be created");
@@ -574,7 +574,7 @@ macro_rules! guest_fault_tests {
                         match fork().expect("can fork") {
                             ForkResult::Child => {
                                 let module = mock_traps_module();
-                                let region = TestRegion::create(1, &Limits::default())
+                                let region = <TestRegion as RegionCreate>::create(1, &Limits::default())
                                     .expect("region can be created");
                                 let mut inst = region
                                     .new_instance(module)
@@ -634,7 +634,7 @@ macro_rules! guest_fault_tests {
                             let recoverable_ptr_lock = super::RECOVERABLE_PTR_LOCK.lock().unwrap();
                             let module = mock_traps_module();
                             let region =
-                                TestRegion::create(1, &Limits::default()).expect("region can be created");
+                                <TestRegion as RegionCreate>::create(1, &Limits::default()).expect("region can be created");
                             let mut inst = region
                                 .new_instance(module)
                                 .expect("instance can be created");
@@ -726,7 +726,7 @@ macro_rules! guest_fault_tests {
                                         FunctionPointer::from_usize(sleepy_guest as usize),
                                     ))
                                     .build();
-                                let region = TestRegion::create(1, &Limits::default())
+                                let region = <TestRegion as RegionCreate>::create(1, &Limits::default())
                                     .expect("region can be created");
                                 let mut inst = region
                                     .new_instance(module)
@@ -778,7 +778,7 @@ macro_rules! guest_fault_tests {
                                 // gets re-raised.
                                 std::thread::spawn(|| {
                                     let module = mock_traps_module();
-                                    let region = TestRegion::create(1, &Limits::default())
+                                    let region = <TestRegion as RegionCreate>::create(1, &Limits::default())
                                         .expect("region can be created");
                                     let mut inst = region
                                         .new_instance(module)
@@ -814,7 +814,7 @@ macro_rules! guest_fault_tests {
                     test_ex(|| {
                         let module = mock_traps_module();
                         let region =
-                            TestRegion::create(1, &Limits::default()).expect("region can be created");
+                            <TestRegion as RegionCreate>::create(1, &Limits::default()).expect("region can be created");
                         let mut inst = region
                             .new_instance(module)
                             .expect("instance can be created");
@@ -850,7 +850,7 @@ macro_rules! guest_fault_tests {
                         match fork().expect("can fork") {
                             ForkResult::Child => {
                                 let region =
-                                    TestRegion::create(1, &Limits::default()).expect("region can be created");
+                                    <TestRegion as RegionCreate>::create(1, &Limits::default()).expect("region can be created");
                                 let mut inst = region
                                     .new_instance(module)
                                     .expect("instance can be created");
@@ -885,7 +885,7 @@ macro_rules! guest_fault_tests {
                     test_ex(|| {
                         let module = mock_traps_module();
                         let region =
-                            TestRegion::create(1, &Limits::default()).expect("region can be created");
+                            <TestRegion as RegionCreate>::create(1, &Limits::default()).expect("region can be created");
                         let mut inst = region
                             .new_instance(module)
                             .expect("instance can be created");
@@ -927,7 +927,7 @@ macro_rules! guest_fault_tests {
 
                         let module = mock_traps_module();
                         let region =
-                            TestRegion::create(1, &Limits::default()).expect("region can be created");
+                            <TestRegion as RegionCreate>::create(1, &Limits::default()).expect("region can be created");
                         let mut inst = region
                             .new_instance(module)
                             .expect("instance can be created");

--- a/lucet-runtime/lucet-runtime-tests/src/host.rs
+++ b/lucet-runtime/lucet-runtime-tests/src/host.rs
@@ -148,7 +148,7 @@ macro_rules! host_tests {
                 use lucet_runtime::vmctx::{lucet_vmctx, Vmctx};
                 use lucet_runtime::{
                     lucet_hostcall, lucet_hostcall_terminate, DlModule, Error, Limits, Region,
-                    TerminationDetails, TrapCode,
+                    RegionCreate, TerminationDetails, TrapCode,
                 };
                 use std::sync::{Arc, Mutex};
                 use $crate::build::test_module_c;
@@ -173,7 +173,7 @@ macro_rules! host_tests {
                 #[test]
                 fn instantiate_trivial() {
                     let module = test_module_c("host", "trivial.c").expect("build and load module");
-                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let region = <TestRegion as RegionCreate>::create(1, &Limits::default()).expect("region can be created");
                     let inst = region
                         .new_instance(module)
                         .expect("instance can be created");
@@ -182,7 +182,7 @@ macro_rules! host_tests {
                 #[test]
                 fn run_trivial() {
                     let module = test_module_c("host", "trivial.c").expect("build and load module");
-                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let region = <TestRegion as RegionCreate>::create(1, &Limits::default()).expect("region can be created");
                     let mut inst = region
                         .new_instance(module)
                         .expect("instance can be created");
@@ -193,7 +193,7 @@ macro_rules! host_tests {
                 #[test]
                 fn run_hello() {
                     let module = test_module_c("host", "hello.c").expect("build and load module");
-                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let region = <TestRegion as RegionCreate>::create(1, &Limits::default()).expect("region can be created");
 
                     let mut inst = region
                         .new_instance_builder(module)
@@ -210,7 +210,7 @@ macro_rules! host_tests {
                 #[test]
                 fn run_hostcall_error() {
                     let module = test_module_c("host", "hostcall_error.c").expect("build and load module");
-                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let region = <TestRegion as RegionCreate>::create(1, &Limits::default()).expect("region can be created");
                     let mut inst = region
                         .new_instance(module)
                         .expect("instance can be created");
@@ -234,7 +234,7 @@ macro_rules! host_tests {
                 fn run_hostcall_error_unwind() {
                     let module =
                         test_module_c("host", "hostcall_error_unwind.c").expect("build and load module");
-                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let region = <TestRegion as RegionCreate>::create(1, &Limits::default()).expect("region can be created");
 
                     let mut inst = region
                         .new_instance_builder(module)
@@ -262,7 +262,7 @@ macro_rules! host_tests {
                 #[test]
                 fn run_fpe() {
                     let module = test_module_c("host", "fpe.c").expect("build and load module");
-                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let region = <TestRegion as RegionCreate>::create(1, &Limits::default()).expect("region can be created");
                     let mut inst = region
                         .new_instance(module)
                         .expect("instance can be created");
@@ -294,7 +294,7 @@ macro_rules! host_tests {
                         ))
                         .build();
 
-                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let region = <TestRegion as RegionCreate>::create(1, &Limits::default()).expect("region can be created");
                     let mut inst = region
                         .new_instance(module)
                         .expect("instance can be created");
@@ -326,7 +326,7 @@ macro_rules! host_tests {
                         ))
                         .build();
 
-                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let region = <TestRegion as RegionCreate>::create(1, &Limits::default()).expect("region can be created");
                     let mut inst = region
                         .new_instance(module)
                         .expect("instance can be created");
@@ -358,7 +358,7 @@ macro_rules! host_tests {
                         ))
                         .build();
 
-                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let region = <TestRegion as RegionCreate>::create(1, &Limits::default()).expect("region can be created");
                     let mut inst = region
                         .new_instance(module)
                         .expect("instance can be created");
@@ -387,7 +387,7 @@ macro_rules! host_tests {
                         ))
                         .build();
 
-                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let region = <TestRegion as RegionCreate>::create(1, &Limits::default()).expect("region can be created");
                     let mut inst = region
                         .new_instance(module)
                         .expect("instance can be created");
@@ -420,7 +420,7 @@ macro_rules! host_tests {
                         ))
                         .build();
 
-                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let region = <TestRegion as RegionCreate>::create(1, &Limits::default()).expect("region can be created");
                     let mut inst = region
                         .new_instance(module)
                         .expect("instance can be created");
@@ -451,7 +451,7 @@ macro_rules! host_tests {
                         ))
                         .build();
 
-                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let region = <TestRegion as RegionCreate>::create(1, &Limits::default()).expect("region can be created");
                     let mut inst = region
                         .new_instance(module)
                         .expect("instance can be created");
@@ -486,7 +486,7 @@ macro_rules! host_tests {
                         ))
                         .build();
 
-                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let region = <TestRegion as RegionCreate>::create(1, &Limits::default()).expect("region can be created");
                     let mut inst = region
                         .new_instance(module)
                         .expect("instance can be created");
@@ -534,7 +534,7 @@ macro_rules! host_tests {
                         ))
                         .build();
 
-                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let region = <TestRegion as RegionCreate>::create(1, &Limits::default()).expect("region can be created");
                     let mut inst = region
                         .new_instance(module)
                         .expect("instance can be created");
@@ -573,7 +573,7 @@ macro_rules! host_tests {
                         ))
                         .build();
 
-                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let region = <TestRegion as RegionCreate>::create(1, &Limits::default()).expect("region can be created");
                     let mut inst = region
                         .new_instance(module)
                         .expect("instance can be created");
@@ -604,7 +604,7 @@ macro_rules! host_tests {
                         ))
                         .build();
 
-                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let region = <TestRegion as RegionCreate>::create(1, &Limits::default()).expect("region can be created");
                     let mut inst = region
                         .new_instance(module)
                         .expect("instance can be created");
@@ -638,7 +638,7 @@ macro_rules! host_tests {
                         ))
                         .build();
 
-                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let region = <TestRegion as RegionCreate>::create(1, &Limits::default()).expect("region can be created");
                     let mut inst = region
                         .new_instance(module)
                         .expect("instance can be created");

--- a/lucet-runtime/lucet-runtime-tests/src/host.rs
+++ b/lucet-runtime/lucet-runtime-tests/src/host.rs
@@ -665,12 +665,11 @@ macro_rules! host_tests {
                         .unwrap();
                     assert_eq!(u64::from(res), 42u64);
                 }
-            }
 
-
-            #[test]
-            fn ensure_linked() {
-                lucet_runtime::lucet_internal_ensure_linked();
+                #[test]
+                fn ensure_linked() {
+                    lucet_runtime::lucet_internal_ensure_linked();
+                }
             }
         )*
     };

--- a/lucet-runtime/lucet-runtime-tests/src/host.rs
+++ b/lucet-runtime/lucet-runtime-tests/src/host.rs
@@ -1,6 +1,6 @@
 #[macro_export]
 macro_rules! host_tests {
-    ( $TestRegion:path ) => {
+    ( $( $region_id:ident => $TestRegion:path ),* ) => {
         use lazy_static::lazy_static;
         use libc::c_void;
         use lucet_runtime::vmctx::{lucet_vmctx, Vmctx};
@@ -9,7 +9,7 @@ macro_rules! host_tests {
             TerminationDetails, TrapCode,
         };
         use std::sync::{Arc, Mutex};
-        use $TestRegion as TestRegion;
+        use std::cell::RefCell;
         use $crate::build::test_module_c;
         use $crate::helpers::{FunctionPointer, MockExportBuilder, MockModuleBuilder};
 
@@ -25,10 +25,6 @@ macro_rules! host_tests {
         }
 
         const ERROR_MESSAGE: &'static str = "hostcall_test_func_hostcall_error";
-
-        lazy_static! {
-            static ref HOSTCALL_MUTEX: Mutex<()> = Mutex::new(());
-        }
 
         #[lucet_hostcall]
         #[no_mangle]
@@ -54,12 +50,11 @@ macro_rules! host_tests {
         #[lucet_hostcall]
         #[allow(unreachable_code)]
         #[no_mangle]
-        pub fn hostcall_test_func_hostcall_error_unwind(_vmctx: &mut Vmctx) {
-            let _lock = HOSTCALL_MUTEX.lock().unwrap();
-            unsafe {
-                lucet_hostcall_terminate!(ERROR_MESSAGE);
-            }
-            drop(_lock);
+        pub fn hostcall_test_func_hostcall_error_unwind(vmctx: &mut Vmctx) {
+            let lock = vmctx.get_embed_ctx::<Arc<Mutex<()>>>();
+            let _mutex_guard = lock.lock().unwrap();
+            lucet_hostcall_terminate!(ERROR_MESSAGE);
+            drop(_mutex_guard);
         }
 
         #[lucet_hostcall]
@@ -144,502 +139,539 @@ macro_rules! host_tests {
             fact(vmctx, n)
         }
 
-        #[test]
-        fn instantiate_trivial() {
-            let module = test_module_c("host", "trivial.c").expect("build and load module");
-            let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
-            let inst = region
-                .new_instance(module)
-                .expect("instance can be created");
-        }
 
-        #[test]
-        fn run_trivial() {
-            let module = test_module_c("host", "trivial.c").expect("build and load module");
-            let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
-            let mut inst = region
-                .new_instance(module)
-                .expect("instance can be created");
-            inst.run("main", &[0u32.into(), 0i32.into()])
-                .expect("instance runs");
-        }
+        $(
+            mod $region_id {
 
-        #[test]
-        fn run_hello() {
-            let module = test_module_c("host", "hello.c").expect("build and load module");
-            let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                use lazy_static::lazy_static;
+                use libc::c_void;
+                use lucet_runtime::vmctx::{lucet_vmctx, Vmctx};
+                use lucet_runtime::{
+                    lucet_hostcall, lucet_hostcall_terminate, DlModule, Error, Limits, Region,
+                    TerminationDetails, TrapCode,
+                };
+                use std::sync::{Arc, Mutex};
+                use $crate::build::test_module_c;
+                use $crate::helpers::{FunctionPointer, MockExportBuilder, MockModuleBuilder};
+                use $TestRegion as TestRegion;
 
-            let mut inst = region
-                .new_instance_builder(module)
-                .with_embed_ctx(false)
-                .build()
-                .expect("instance can be created");
-
-            inst.run("main", &[0u32.into(), 0i32.into()])
-                .expect("instance runs");
-
-            assert!(*inst.get_embed_ctx::<bool>().unwrap().unwrap());
-        }
-
-        #[test]
-        fn run_hostcall_error() {
-            let module = test_module_c("host", "hostcall_error.c").expect("build and load module");
-            let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
-            let mut inst = region
-                .new_instance(module)
-                .expect("instance can be created");
-
-            match inst.run("main", &[0u32.into(), 0i32.into()]) {
-                Err(Error::RuntimeTerminated(term)) => {
-                    assert_eq!(
-                        *term
-                            .provided_details()
-                            .expect("user provided termination reason")
-                            .downcast_ref::<&'static str>()
-                            .expect("error was static str"),
-                        ERROR_MESSAGE
-                    );
+                lazy_static! {
+                    static ref HOSTCALL_MUTEX: Arc<Mutex<()>> = Arc::new(Mutex::new(()));
                 }
-                res => panic!("unexpected result: {:?}", res),
-            }
-        }
 
-        #[test]
-        fn run_hostcall_error_unwind() {
-            let module =
-                test_module_c("host", "hostcall_error_unwind.c").expect("build and load module");
-            let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
-            let mut inst = region
-                .new_instance(module)
-                .expect("instance can be created");
-
-            match inst.run("main", &[0u32.into(), 0u32.into()]) {
-                Err(Error::RuntimeTerminated(term)) => {
-                    assert_eq!(
-                        *term
-                            .provided_details()
-                            .expect("user provided termination reason")
-                            .downcast_ref::<&'static str>()
-                            .expect("error was static str"),
-                        ERROR_MESSAGE
-                    );
+                #[test]
+                fn load_module() {
+                    let _module = test_module_c("host", "trivial.c").expect("build and load module");
                 }
-                res => panic!("unexpected result: {:?}", res),
-            }
 
-            assert!(HOSTCALL_MUTEX.is_poisoned());
-        }
-
-        #[test]
-        fn run_fpe() {
-            let module = test_module_c("host", "fpe.c").expect("build and load module");
-            let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
-            let mut inst = region
-                .new_instance(module)
-                .expect("instance can be created");
-
-            match inst.run("trigger_div_error", &[0u32.into()]) {
-                Err(Error::RuntimeFault(details)) => {
-                    assert_eq!(details.trapcode, Some(TrapCode::IntegerDivByZero));
+                #[test]
+                fn load_nonexistent_module() {
+                    let module = DlModule::load("/non/existient/file");
+                    assert!(module.is_err());
                 }
-                res => {
-                    panic!("unexpected result: {:?}", res);
+
+                #[test]
+                fn instantiate_trivial() {
+                    let module = test_module_c("host", "trivial.c").expect("build and load module");
+                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let inst = region
+                        .new_instance(module)
+                        .expect("instance can be created");
                 }
-            }
-        }
 
-        #[test]
-        fn run_hostcall_bad_borrow() {
-            extern "C" {
-                fn hostcall_bad_borrow(vmctx: *mut lucet_vmctx) -> bool;
-            }
-
-            unsafe extern "C" fn f(vmctx: *mut lucet_vmctx) {
-                hostcall_bad_borrow(vmctx);
-            }
-
-            let module = MockModuleBuilder::new()
-                .with_export_func(MockExportBuilder::new(
-                    "f",
-                    FunctionPointer::from_usize(f as usize),
-                ))
-                .build();
-
-            let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
-            let mut inst = region
-                .new_instance(module)
-                .expect("instance can be created");
-
-            match inst.run("f", &[]) {
-                Err(Error::RuntimeTerminated(details)) => {
-                    assert_eq!(details, TerminationDetails::BorrowError("heap_mut"));
+                #[test]
+                fn run_trivial() {
+                    let module = test_module_c("host", "trivial.c").expect("build and load module");
+                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let mut inst = region
+                        .new_instance(module)
+                        .expect("instance can be created");
+                    inst.run("main", &[0u32.into(), 0i32.into()])
+                        .expect("instance runs");
                 }
-                res => {
-                    panic!("unexpected result: {:?}", res);
+
+                #[test]
+                fn run_hello() {
+                    let module = test_module_c("host", "hello.c").expect("build and load module");
+                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+
+                    let mut inst = region
+                        .new_instance_builder(module)
+                        .with_embed_ctx(false)
+                        .build()
+                        .expect("instance can be created");
+
+                    inst.run("main", &[0u32.into(), 0i32.into()])
+                        .expect("instance runs");
+
+                    assert!(*inst.get_embed_ctx::<bool>().unwrap().unwrap());
                 }
-            }
-        }
 
-        #[test]
-        fn run_hostcall_missing_embed_ctx() {
-            extern "C" {
-                fn hostcall_missing_embed_ctx(vmctx: *mut lucet_vmctx) -> bool;
-            }
+                #[test]
+                fn run_hostcall_error() {
+                    let module = test_module_c("host", "hostcall_error.c").expect("build and load module");
+                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let mut inst = region
+                        .new_instance(module)
+                        .expect("instance can be created");
 
-            unsafe extern "C" fn f(vmctx: *mut lucet_vmctx) {
-                hostcall_missing_embed_ctx(vmctx);
-            }
-
-            let module = MockModuleBuilder::new()
-                .with_export_func(MockExportBuilder::new(
-                    "f",
-                    FunctionPointer::from_usize(f as usize),
-                ))
-                .build();
-
-            let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
-            let mut inst = region
-                .new_instance(module)
-                .expect("instance can be created");
-
-            match inst.run("f", &[]) {
-                Err(Error::RuntimeTerminated(details)) => {
-                    assert_eq!(details, TerminationDetails::CtxNotFound);
-                }
-                res => {
-                    panic!("unexpected result: {:?}", res);
-                }
-            }
-        }
-
-        #[test]
-        fn run_hostcall_multiple_vmctx() {
-            extern "C" {
-                fn hostcall_multiple_vmctx(vmctx: *mut lucet_vmctx) -> bool;
-            }
-
-            unsafe extern "C" fn f(vmctx: *mut lucet_vmctx) {
-                hostcall_multiple_vmctx(vmctx);
-            }
-
-            let module = MockModuleBuilder::new()
-                .with_export_func(MockExportBuilder::new(
-                    "f",
-                    FunctionPointer::from_usize(f as usize),
-                ))
-                .build();
-
-            let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
-            let mut inst = region
-                .new_instance(module)
-                .expect("instance can be created");
-
-            let retval = inst
-                .run("f", &[])
-                .expect("instance runs")
-                .expect_returned("instance returned");
-            assert_eq!(bool::from(retval), true);
-        }
-
-        #[test]
-        fn run_hostcall_yields_5() {
-            extern "C" {
-                fn hostcall_yields_5(vmctx: *mut lucet_vmctx);
-            }
-
-            unsafe extern "C" fn f(vmctx: *mut lucet_vmctx) {
-                hostcall_yields_5(vmctx);
-            }
-
-            let module = MockModuleBuilder::new()
-                .with_export_func(MockExportBuilder::new(
-                    "f",
-                    FunctionPointer::from_usize(f as usize),
-                ))
-                .build();
-
-            let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
-            let mut inst = region
-                .new_instance(module)
-                .expect("instance can be created");
-
-            assert_eq!(
-                *inst
-                    .run("f", &[])
-                    .unwrap()
-                    .unwrap_yielded()
-                    .downcast::<u64>()
-                    .unwrap(),
-                5u64
-            );
-        }
-
-        #[test]
-        fn run_hostcall_yield_expects_5() {
-            extern "C" {
-                fn hostcall_yield_expects_5(vmctx: *mut lucet_vmctx) -> u64;
-            }
-
-            unsafe extern "C" fn f(vmctx: *mut lucet_vmctx) -> u64 {
-                hostcall_yield_expects_5(vmctx)
-            }
-
-            let module = MockModuleBuilder::new()
-                .with_export_func(MockExportBuilder::new(
-                    "f",
-                    FunctionPointer::from_usize(f as usize),
-                ))
-                .build();
-
-            let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
-            let mut inst = region
-                .new_instance(module)
-                .expect("instance can be created");
-
-            assert!(inst.run("f", &[]).unwrap().unwrap_yielded().is_none());
-
-            let retval = inst
-                .resume_with_val(5u64)
-                .expect("instance resumes")
-                .unwrap_returned();
-            assert_eq!(u64::from(retval), 5u64);
-        }
-
-        #[test]
-        fn yield_factorials() {
-            extern "C" {
-                fn hostcall_yield_facts(vmctx: *mut lucet_vmctx, n: u64) -> u64;
-            }
-
-            unsafe extern "C" fn f(vmctx: *mut lucet_vmctx) -> u64 {
-                hostcall_yield_facts(vmctx, 5)
-            }
-
-            let module = MockModuleBuilder::new()
-                .with_export_func(MockExportBuilder::new(
-                    "f",
-                    FunctionPointer::from_usize(f as usize),
-                ))
-                .build();
-
-            let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
-            let mut inst = region
-                .new_instance(module)
-                .expect("instance can be created");
-
-            let mut facts = vec![];
-
-            let mut res = inst.run("f", &[]).unwrap();
-
-            while res.is_yielded() {
-                facts.push(*res.unwrap_yielded().downcast::<u64>().unwrap());
-                res = inst.resume().unwrap();
-            }
-
-            assert_eq!(facts.as_slice(), &[1, 2, 6, 24, 120]);
-            assert_eq!(u64::from(res.unwrap_returned()), 120u64);
-        }
-
-        #[test]
-        fn coop_factorials() {
-            extern "C" {
-                fn hostcall_coop_facts(vmctx: *mut lucet_vmctx, n: u64) -> u64;
-            }
-
-            unsafe extern "C" fn f(vmctx: *mut lucet_vmctx) -> u64 {
-                hostcall_coop_facts(vmctx, 5)
-            }
-
-            let module = MockModuleBuilder::new()
-                .with_export_func(MockExportBuilder::new(
-                    "f",
-                    FunctionPointer::from_usize(f as usize),
-                ))
-                .build();
-
-            let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
-            let mut inst = region
-                .new_instance(module)
-                .expect("instance can be created");
-
-            let mut facts = vec![];
-
-            let mut res = inst.run("f", &[]).unwrap();
-
-            while let Ok(val) = res.yielded_ref() {
-                if let Some(k) = val.downcast_ref::<CoopFactsK>() {
-                    match k {
-                        CoopFactsK::Mult(n, n_rec) => {
-                            // guest wants us to multiply for it
-                            res = inst.resume_with_val(n * n_rec).unwrap();
+                    match inst.run("main", &[0u32.into(), 0i32.into()]) {
+                        Err(Error::RuntimeTerminated(term)) => {
+                            assert_eq!(
+                                *term
+                                    .provided_details()
+                                    .expect("user provided termination reason")
+                                    .downcast_ref::<&'static str>()
+                                    .expect("error was static str"),
+                                super::ERROR_MESSAGE
+                            );
                         }
-                        CoopFactsK::Result(n) => {
-                            // guest is returning an answer
-                            facts.push(*n);
-                            res = inst.resume().unwrap();
+                        res => panic!("unexpected result: {:?}", res),
+                    }
+                }
+
+                #[test]
+                fn run_hostcall_error_unwind() {
+                    let module =
+                        test_module_c("host", "hostcall_error_unwind.c").expect("build and load module");
+                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+
+                    let mut inst = region
+                        .new_instance_builder(module)
+                        .with_embed_ctx(HOSTCALL_MUTEX.clone())
+                        .build()
+                        .expect("instance can be created");
+
+                    match inst.run("main", &[0u32.into(), 0u32.into()]) {
+                        Err(Error::RuntimeTerminated(term)) => {
+                            assert_eq!(
+                                *term
+                                    .provided_details()
+                                    .expect("user provided termination reason")
+                                    .downcast_ref::<&'static str>()
+                                    .expect("error was static str"),
+                                super::ERROR_MESSAGE
+                            );
+                        }
+                        res => panic!("unexpected result: {:?}", res),
+                    }
+
+                    assert!(HOSTCALL_MUTEX.is_poisoned());
+                }
+
+                #[test]
+                fn run_fpe() {
+                    let module = test_module_c("host", "fpe.c").expect("build and load module");
+                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let mut inst = region
+                        .new_instance(module)
+                        .expect("instance can be created");
+
+                    match inst.run("trigger_div_error", &[0u32.into()]) {
+                        Err(Error::RuntimeFault(details)) => {
+                            assert_eq!(details.trapcode, Some(TrapCode::IntegerDivByZero));
+                        }
+                        res => {
+                            panic!("unexpected result: {:?}", res);
                         }
                     }
-                } else {
-                    panic!("didn't yield with expected type");
+                }
+
+                #[test]
+                fn run_hostcall_bad_borrow() {
+                    extern "C" {
+                        fn hostcall_bad_borrow(vmctx: *mut lucet_vmctx) -> bool;
+                    }
+
+                    unsafe extern "C" fn f(vmctx: *mut lucet_vmctx) {
+                        hostcall_bad_borrow(vmctx);
+                    }
+
+                    let module = MockModuleBuilder::new()
+                        .with_export_func(MockExportBuilder::new(
+                            "f",
+                            FunctionPointer::from_usize(f as usize),
+                        ))
+                        .build();
+
+                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let mut inst = region
+                        .new_instance(module)
+                        .expect("instance can be created");
+
+                    match inst.run("f", &[]) {
+                        Err(Error::RuntimeTerminated(details)) => {
+                            assert_eq!(details, TerminationDetails::BorrowError("heap_mut"));
+                        }
+                        res => {
+                            panic!("unexpected result: {:?}", res);
+                        }
+                    }
+                }
+
+                #[test]
+                fn run_hostcall_missing_embed_ctx() {
+                    extern "C" {
+                        fn hostcall_missing_embed_ctx(vmctx: *mut lucet_vmctx) -> bool;
+                    }
+
+                    unsafe extern "C" fn f(vmctx: *mut lucet_vmctx) {
+                        hostcall_missing_embed_ctx(vmctx);
+                    }
+
+                    let module = MockModuleBuilder::new()
+                        .with_export_func(MockExportBuilder::new(
+                            "f",
+                            FunctionPointer::from_usize(f as usize),
+                        ))
+                        .build();
+
+                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let mut inst = region
+                        .new_instance(module)
+                        .expect("instance can be created");
+
+                    match inst.run("f", &[]) {
+                        Err(Error::RuntimeTerminated(details)) => {
+                            assert_eq!(details, TerminationDetails::CtxNotFound);
+                        }
+                        res => {
+                            panic!("unexpected result: {:?}", res);
+                        }
+                    }
+                }
+
+                #[test]
+                fn run_hostcall_multiple_vmctx() {
+                    extern "C" {
+                        fn hostcall_multiple_vmctx(vmctx: *mut lucet_vmctx) -> bool;
+                    }
+
+                    unsafe extern "C" fn f(vmctx: *mut lucet_vmctx) {
+                        hostcall_multiple_vmctx(vmctx);
+                    }
+
+                    let module = MockModuleBuilder::new()
+                        .with_export_func(MockExportBuilder::new(
+                            "f",
+                            FunctionPointer::from_usize(f as usize),
+                        ))
+                        .build();
+
+                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let mut inst = region
+                        .new_instance(module)
+                        .expect("instance can be created");
+
+                    let retval = inst
+                        .run("f", &[])
+                        .expect("instance runs")
+                        .expect_returned("instance returned");
+                    assert_eq!(bool::from(retval), true);
+                }
+
+                #[test]
+                fn run_hostcall_yields_5() {
+                    extern "C" {
+                        fn hostcall_yields_5(vmctx: *mut lucet_vmctx);
+                    }
+
+                    unsafe extern "C" fn f(vmctx: *mut lucet_vmctx) {
+                        hostcall_yields_5(vmctx);
+                    }
+
+                    let module = MockModuleBuilder::new()
+                        .with_export_func(MockExportBuilder::new(
+                            "f",
+                            FunctionPointer::from_usize(f as usize),
+                        ))
+                        .build();
+
+                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let mut inst = region
+                        .new_instance(module)
+                        .expect("instance can be created");
+
+                    assert_eq!(
+                        *inst
+                            .run("f", &[])
+                            .unwrap()
+                            .unwrap_yielded()
+                            .downcast::<u64>()
+                            .unwrap(),
+                        5u64
+                    );
+                }
+
+                #[test]
+                fn run_hostcall_yield_expects_5() {
+                    extern "C" {
+                        fn hostcall_yield_expects_5(vmctx: *mut lucet_vmctx) -> u64;
+                    }
+
+                    unsafe extern "C" fn f(vmctx: *mut lucet_vmctx) -> u64 {
+                        hostcall_yield_expects_5(vmctx)
+                    }
+
+                    let module = MockModuleBuilder::new()
+                        .with_export_func(MockExportBuilder::new(
+                            "f",
+                            FunctionPointer::from_usize(f as usize),
+                        ))
+                        .build();
+
+                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let mut inst = region
+                        .new_instance(module)
+                        .expect("instance can be created");
+
+                    assert!(inst.run("f", &[]).unwrap().unwrap_yielded().is_none());
+
+                    let retval = inst
+                        .resume_with_val(5u64)
+                        .expect("instance resumes")
+                        .unwrap_returned();
+                    assert_eq!(u64::from(retval), 5u64);
+                }
+
+                #[test]
+                fn yield_factorials() {
+                    extern "C" {
+                        fn hostcall_yield_facts(vmctx: *mut lucet_vmctx, n: u64) -> u64;
+                    }
+
+                    unsafe extern "C" fn f(vmctx: *mut lucet_vmctx) -> u64 {
+                        hostcall_yield_facts(vmctx, 5)
+                    }
+
+                    let module = MockModuleBuilder::new()
+                        .with_export_func(MockExportBuilder::new(
+                            "f",
+                            FunctionPointer::from_usize(f as usize),
+                        ))
+                        .build();
+
+                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let mut inst = region
+                        .new_instance(module)
+                        .expect("instance can be created");
+
+                    let mut facts = vec![];
+
+                    let mut res = inst.run("f", &[]).unwrap();
+
+                    while res.is_yielded() {
+                        facts.push(*res.unwrap_yielded().downcast::<u64>().unwrap());
+                        res = inst.resume().unwrap();
+                    }
+
+                    assert_eq!(facts.as_slice(), &[1, 2, 6, 24, 120]);
+                    assert_eq!(u64::from(res.unwrap_returned()), 120u64);
+                }
+
+                #[test]
+                fn coop_factorials() {
+                    extern "C" {
+                        fn hostcall_coop_facts(vmctx: *mut lucet_vmctx, n: u64) -> u64;
+                    }
+
+                    unsafe extern "C" fn f(vmctx: *mut lucet_vmctx) -> u64 {
+                        hostcall_coop_facts(vmctx, 5)
+                    }
+
+                    let module = MockModuleBuilder::new()
+                        .with_export_func(MockExportBuilder::new(
+                            "f",
+                            FunctionPointer::from_usize(f as usize),
+                        ))
+                        .build();
+
+                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let mut inst = region
+                        .new_instance(module)
+                        .expect("instance can be created");
+
+                    let mut facts = vec![];
+
+                    let mut res = inst.run("f", &[]).unwrap();
+
+                    while let Ok(val) = res.yielded_ref() {
+                        if let Some(k) = val.downcast_ref::<super::CoopFactsK>() {
+                            match k {
+                                super::CoopFactsK::Mult(n, n_rec) => {
+                                    // guest wants us to multiply for it
+                                    res = inst.resume_with_val(n * n_rec).unwrap();
+                                }
+                                super::CoopFactsK::Result(n) => {
+                                    // guest is returning an answer
+                                    facts.push(*n);
+                                    res = inst.resume().unwrap();
+                                }
+                            }
+                        } else {
+                            panic!("didn't yield with expected type");
+                        }
+                    }
+
+                    assert_eq!(facts.as_slice(), &[1, 2, 6, 24, 120]);
+                    assert_eq!(u64::from(res.unwrap_returned()), 120u64);
+                }
+
+                #[test]
+                fn resume_unexpected() {
+                    extern "C" {
+                        fn hostcall_yields_5(vmctx: *mut lucet_vmctx);
+                    }
+
+                    unsafe extern "C" fn f(vmctx: *mut lucet_vmctx) {
+                        hostcall_yields_5(vmctx);
+                    }
+
+                    let module = MockModuleBuilder::new()
+                        .with_export_func(MockExportBuilder::new(
+                            "f",
+                            FunctionPointer::from_usize(f as usize),
+                        ))
+                        .build();
+
+                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let mut inst = region
+                        .new_instance(module)
+                        .expect("instance can be created");
+
+                    assert_eq!(
+                        *inst
+                            .run("f", &[])
+                            .unwrap()
+                            .unwrap_yielded()
+                            .downcast::<u64>()
+                            .unwrap(),
+                        5u64
+                    );
+
+                    match inst.resume_with_val(5u64) {
+                        Err(Error::InvalidArgument(_)) => (),
+                        Err(e) => panic!("unexpected error: {}", e),
+                        Ok(_) => panic!("unexpected success"),
+                    }
+                }
+
+                #[test]
+                fn missing_resume_val() {
+                    extern "C" {
+                        fn hostcall_yield_expects_5(vmctx: *mut lucet_vmctx) -> u64;
+                    }
+
+                    unsafe extern "C" fn f(vmctx: *mut lucet_vmctx) -> u64 {
+                        hostcall_yield_expects_5(vmctx)
+                    }
+
+                    let module = MockModuleBuilder::new()
+                        .with_export_func(MockExportBuilder::new(
+                            "f",
+                            FunctionPointer::from_usize(f as usize),
+                        ))
+                        .build();
+
+                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let mut inst = region
+                        .new_instance(module)
+                        .expect("instance can be created");
+
+                    assert!(inst.run("f", &[]).unwrap().unwrap_yielded().is_none());
+
+                    match inst.resume() {
+                        Err(Error::InvalidArgument(_)) => (),
+                        Err(e) => panic!("unexpected error: {}", e),
+                        Ok(_) => panic!("unexpected success"),
+                    }
+                }
+
+                #[test]
+                fn resume_wrong_type() {
+                    extern "C" {
+                        fn hostcall_yield_expects_5(vmctx: *mut lucet_vmctx) -> u64;
+                    }
+
+                    unsafe extern "C" fn f(vmctx: *mut lucet_vmctx) -> u64 {
+                        hostcall_yield_expects_5(vmctx)
+                    }
+
+                    let module = MockModuleBuilder::new()
+                        .with_export_func(MockExportBuilder::new(
+                            "f",
+                            FunctionPointer::from_usize(f as usize),
+                        ))
+                        .build();
+
+                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let mut inst = region
+                        .new_instance(module)
+                        .expect("instance can be created");
+
+                    assert!(inst.run("f", &[]).unwrap().unwrap_yielded().is_none());
+
+                    match inst.resume_with_val(true) {
+                        Err(Error::InvalidArgument(_)) => (),
+                        Err(e) => panic!("unexpected error: {}", e),
+                        Ok(_) => panic!("unexpected success"),
+                    }
+                }
+
+                /// This test shows that we can send an `InstanceHandle` to another thread while a guest is
+                /// yielded, and it resumes successfully.
+                #[test]
+                fn switch_threads_resume() {
+                    extern "C" {
+                        fn hostcall_yields_5(vmctx: *mut lucet_vmctx);
+                    }
+
+                    unsafe extern "C" fn f(vmctx: *mut lucet_vmctx) -> u64 {
+                        hostcall_yields_5(vmctx);
+                        42
+                    }
+
+                    let module = MockModuleBuilder::new()
+                        .with_export_func(MockExportBuilder::new(
+                            "f",
+                            FunctionPointer::from_usize(f as usize),
+                        ))
+                        .build();
+
+                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let mut inst = region
+                        .new_instance(module)
+                        .expect("instance can be created");
+
+                    // make sure we yield with 5 on the original thread
+                    assert_eq!(
+                        *inst
+                            .run("f", &[])
+                            .unwrap()
+                            .unwrap_yielded()
+                            .downcast::<u64>()
+                            .unwrap(),
+                        5u64
+                    );
+
+                    let res = std::thread::spawn(move || {
+                        // but then move the instance to another thread and resume it from there
+                        inst.resume()
+                            .expect("instance resumes")
+                            .returned()
+                            .expect("returns 42")
+                    })
+                        .join()
+                        .unwrap();
+                    assert_eq!(u64::from(res), 42u64);
                 }
             }
 
-            assert_eq!(facts.as_slice(), &[1, 2, 6, 24, 120]);
-            assert_eq!(u64::from(res.unwrap_returned()), 120u64);
-        }
 
-        #[test]
-        fn resume_unexpected() {
-            extern "C" {
-                fn hostcall_yields_5(vmctx: *mut lucet_vmctx);
+            #[test]
+            fn ensure_linked() {
+                lucet_runtime::lucet_internal_ensure_linked();
             }
-
-            unsafe extern "C" fn f(vmctx: *mut lucet_vmctx) {
-                hostcall_yields_5(vmctx);
-            }
-
-            let module = MockModuleBuilder::new()
-                .with_export_func(MockExportBuilder::new(
-                    "f",
-                    FunctionPointer::from_usize(f as usize),
-                ))
-                .build();
-
-            let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
-            let mut inst = region
-                .new_instance(module)
-                .expect("instance can be created");
-
-            assert_eq!(
-                *inst
-                    .run("f", &[])
-                    .unwrap()
-                    .unwrap_yielded()
-                    .downcast::<u64>()
-                    .unwrap(),
-                5u64
-            );
-
-            match inst.resume_with_val(5u64) {
-                Err(Error::InvalidArgument(_)) => (),
-                Err(e) => panic!("unexpected error: {}", e),
-                Ok(_) => panic!("unexpected success"),
-            }
-        }
-
-        #[test]
-        fn missing_resume_val() {
-            extern "C" {
-                fn hostcall_yield_expects_5(vmctx: *mut lucet_vmctx) -> u64;
-            }
-
-            unsafe extern "C" fn f(vmctx: *mut lucet_vmctx) -> u64 {
-                hostcall_yield_expects_5(vmctx)
-            }
-
-            let module = MockModuleBuilder::new()
-                .with_export_func(MockExportBuilder::new(
-                    "f",
-                    FunctionPointer::from_usize(f as usize),
-                ))
-                .build();
-
-            let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
-            let mut inst = region
-                .new_instance(module)
-                .expect("instance can be created");
-
-            assert!(inst.run("f", &[]).unwrap().unwrap_yielded().is_none());
-
-            match inst.resume() {
-                Err(Error::InvalidArgument(_)) => (),
-                Err(e) => panic!("unexpected error: {}", e),
-                Ok(_) => panic!("unexpected success"),
-            }
-        }
-
-        #[test]
-        fn resume_wrong_type() {
-            extern "C" {
-                fn hostcall_yield_expects_5(vmctx: *mut lucet_vmctx) -> u64;
-            }
-
-            unsafe extern "C" fn f(vmctx: *mut lucet_vmctx) -> u64 {
-                hostcall_yield_expects_5(vmctx)
-            }
-
-            let module = MockModuleBuilder::new()
-                .with_export_func(MockExportBuilder::new(
-                    "f",
-                    FunctionPointer::from_usize(f as usize),
-                ))
-                .build();
-
-            let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
-            let mut inst = region
-                .new_instance(module)
-                .expect("instance can be created");
-
-            assert!(inst.run("f", &[]).unwrap().unwrap_yielded().is_none());
-
-            match inst.resume_with_val(true) {
-                Err(Error::InvalidArgument(_)) => (),
-                Err(e) => panic!("unexpected error: {}", e),
-                Ok(_) => panic!("unexpected success"),
-            }
-        }
-
-        /// This test shows that we can send an `InstanceHandle` to another thread while a guest is
-        /// yielded, and it resumes successfully.
-        #[test]
-        fn switch_threads_resume() {
-            extern "C" {
-                fn hostcall_yields_5(vmctx: *mut lucet_vmctx);
-            }
-
-            unsafe extern "C" fn f(vmctx: *mut lucet_vmctx) -> u64 {
-                hostcall_yields_5(vmctx);
-                42
-            }
-
-            let module = MockModuleBuilder::new()
-                .with_export_func(MockExportBuilder::new(
-                    "f",
-                    FunctionPointer::from_usize(f as usize),
-                ))
-                .build();
-
-            let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
-            let mut inst = region
-                .new_instance(module)
-                .expect("instance can be created");
-
-            // make sure we yield with 5 on the original thread
-            assert_eq!(
-                *inst
-                    .run("f", &[])
-                    .unwrap()
-                    .unwrap_yielded()
-                    .downcast::<u64>()
-                    .unwrap(),
-                5u64
-            );
-
-            let res = std::thread::spawn(move || {
-                // but then move the instance to another thread and resume it from there
-                inst.resume()
-                    .expect("instance resumes")
-                    .returned()
-                    .expect("returns 42")
-            })
-            .join()
-            .unwrap();
-            assert_eq!(u64::from(res), 42u64);
-        }
-
-        #[test]
-        fn ensure_linked() {
-            lucet_runtime::lucet_internal_ensure_linked();
-        }
+        )*
     };
 }

--- a/lucet-runtime/lucet-runtime-tests/src/memory.rs
+++ b/lucet-runtime/lucet-runtime-tests/src/memory.rs
@@ -1,50 +1,55 @@
 #[macro_export]
 macro_rules! memory_tests {
-    ( $TestRegion:path ) => {
-        use lazy_static::lazy_static;
-        use lucet_runtime::{DlModule, Limits, Region};
-        use std::sync::Mutex;
-        use $TestRegion as TestRegion;
-        use $crate::build::test_module_wasm;
+    ( $( $region_id:ident => $TestRegion:path ),* ) => {
+        $(
+            mod $region_id {
+                use lazy_static::lazy_static;
+                use lucet_runtime::{DlModule, Limits, Region};
+                use std::sync::Mutex;
+                use $TestRegion as TestRegion;
+                use $crate::build::test_module_wasm;
 
-        #[test]
-        fn ensure_linked() {
-            lucet_runtime::lucet_internal_ensure_linked();
-        }
 
-        #[test]
-        fn current_memory_hostcall() {
-            let module = test_module_wasm("memory", "current_memory.wat")
-                .expect("compile and load current_memory.wasm");
-            let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
-            let mut inst = region
-                .new_instance(module)
-                .expect("instance can be created");
+                #[test]
+                fn ensure_linked() {
+                    lucet_runtime::lucet_internal_ensure_linked();
+                }
 
-            let retval = inst
-                .run("main", &[])
-                .expect("instance runs")
-                .unwrap_returned();
-            assert_eq!(u32::from(retval), 4);
-        }
+                #[test]
+                fn current_memory_hostcall() {
+                    let module = test_module_wasm("memory", "current_memory.wat")
+                        .expect("compile and load current_memory.wasm");
+                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let mut inst = region
+                        .new_instance(module)
+                        .expect("instance can be created");
 
-        #[test]
-        fn grow_memory_hostcall() {
-            let module = test_module_wasm("memory", "grow_memory.wat")
-                .expect("compile and load grow_memory.wasm");
-            let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
-            let mut inst = region
-                .new_instance(module)
-                .expect("instance can be created");
+                    let retval = inst
+                        .run("main", &[])
+                        .expect("instance runs")
+                        .unwrap_returned();
+                    assert_eq!(u32::from(retval), 4);
+                }
 
-            inst.run("main", &[]).expect("instance runs");
+                #[test]
+                fn grow_memory_hostcall() {
+                    let module = test_module_wasm("memory", "grow_memory.wat")
+                        .expect("compile and load grow_memory.wasm");
+                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let mut inst = region
+                        .new_instance(module)
+                        .expect("instance can be created");
 
-            let heap = inst.heap_u32();
-            // guest puts the result of the grow_memory(1) call in heap[0]; based on the current settings,
-            // growing by 1 returns prev size 4
-            assert_eq!(heap[0], 4);
-            // guest then puts the result of the current memory call in heap[4] (indexed by bytes)
-            assert_eq!(heap[1], 5);
-        }
+                    inst.run("main", &[]).expect("instance runs");
+
+                    let heap = inst.heap_u32();
+                    // guest puts the result of the grow_memory(1) call in heap[0]; based on the current settings,
+                    // growing by 1 returns prev size 4
+                    assert_eq!(heap[0], 4);
+                    // guest then puts the result of the current memory call in heap[4] (indexed by bytes)
+                    assert_eq!(heap[1], 5);
+                }
+            }
+        )*
     };
 }

--- a/lucet-runtime/lucet-runtime-tests/src/memory.rs
+++ b/lucet-runtime/lucet-runtime-tests/src/memory.rs
@@ -4,7 +4,7 @@ macro_rules! memory_tests {
         $(
             mod $region_id {
                 use lazy_static::lazy_static;
-                use lucet_runtime::{DlModule, Limits, Region};
+                use lucet_runtime::{DlModule, Limits, Region, RegionCreate};
                 use std::sync::Mutex;
                 use $TestRegion as TestRegion;
                 use $crate::build::test_module_wasm;
@@ -19,7 +19,7 @@ macro_rules! memory_tests {
                 fn current_memory_hostcall() {
                     let module = test_module_wasm("memory", "current_memory.wat")
                         .expect("compile and load current_memory.wasm");
-                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let region = <TestRegion as RegionCreate>::create(1, &Limits::default()).expect("region can be created");
                     let mut inst = region
                         .new_instance(module)
                         .expect("instance can be created");
@@ -35,7 +35,7 @@ macro_rules! memory_tests {
                 fn grow_memory_hostcall() {
                     let module = test_module_wasm("memory", "grow_memory.wat")
                         .expect("compile and load grow_memory.wasm");
-                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let region = <TestRegion as RegionCreate>::create(1, &Limits::default()).expect("region can be created");
                     let mut inst = region
                         .new_instance(module)
                         .expect("instance can be created");

--- a/lucet-runtime/lucet-runtime-tests/src/stack.rs
+++ b/lucet-runtime/lucet-runtime-tests/src/stack.rs
@@ -77,166 +77,170 @@ fn generate_test_wat(num_locals: usize) -> String {
 
 #[macro_export]
 macro_rules! stack_tests {
-    ( $TestRegion:path ) => {
-        use lucet_runtime::{
-            DlModule, Error, InstanceHandle, Limits, Region, TrapCode, UntypedRetVal, Val,
-        };
-        use std::sync::Arc;
-        use $TestRegion as TestRegion;
-        use $crate::stack::stack_testcase;
+    ( $( $region_id:ident => $TestRegion:path ),* ) => {
+        $(
+            mod $region_id {
+                use lucet_runtime::{
+                    DlModule, Error, InstanceHandle, Limits, Region, TrapCode, UntypedRetVal, Val,
+                };
+                use std::sync::Arc;
+                use $TestRegion as TestRegion;
+                use $crate::stack::stack_testcase;
 
-        fn run(module: Arc<DlModule>, recursion_depth: i32) -> Result<UntypedRetVal, Error> {
-            let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
-            let mut inst = region
-                .new_instance(module)
-                .expect("instance can be created");
+                fn run(module: Arc<DlModule>, recursion_depth: i32) -> Result<UntypedRetVal, Error> {
+                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let mut inst = region
+                        .new_instance(module)
+                        .expect("instance can be created");
 
-            inst.run("localpalooza", &[recursion_depth.into()])
-                .and_then(|rr| rr.returned())
-        }
+                    inst.run("localpalooza", &[recursion_depth.into()])
+                        .and_then(|rr| rr.returned())
+                }
 
-        fn expect_ok(module: Arc<DlModule>, recursion_depth: i32) {
-            assert!(run(module, recursion_depth).is_ok());
-        }
+                fn expect_ok(module: Arc<DlModule>, recursion_depth: i32) {
+                    assert!(run(module, recursion_depth).is_ok());
+                }
 
-        fn expect_stack_overflow(module: Arc<DlModule>, recursion_depth: i32, probestack: bool) {
-            match run(module, recursion_depth) {
-                Err(Error::RuntimeFault(details)) => {
-                    // We should get a nonfatal trap due to the stack overflow.
-                    assert_eq!(details.fatal, false);
-                    assert_eq!(details.trapcode, Some(TrapCode::StackOverflow));
-                    if probestack {
-                        // Make sure we overflowed in the stack probe as expected
-                        //
-                        // TODO: this no longer differentiates between different stack overflow
-                        // sites after moving the stack probe into lucetc; figure out a way to
-                        // provide that information or just wait till we can do the stack probe as a
-                        // global symbol again
-                        let addr_details =
-                            details.rip_addr_details.expect("can look up addr details");
-                        assert!(addr_details.in_module_code);
+                fn expect_stack_overflow(module: Arc<DlModule>, recursion_depth: i32, probestack: bool) {
+                    match run(module, recursion_depth) {
+                        Err(Error::RuntimeFault(details)) => {
+                            // We should get a nonfatal trap due to the stack overflow.
+                            assert_eq!(details.fatal, false);
+                            assert_eq!(details.trapcode, Some(TrapCode::StackOverflow));
+                            if probestack {
+                                // Make sure we overflowed in the stack probe as expected
+                                //
+                                // TODO: this no longer differentiates between different stack overflow
+                                // sites after moving the stack probe into lucetc; figure out a way to
+                                // provide that information or just wait till we can do the stack probe as a
+                                // global symbol again
+                                let addr_details =
+                                    details.rip_addr_details.expect("can look up addr details");
+                                assert!(addr_details.in_module_code);
+                            }
+                        }
+                        res => panic!("unexpected result: {:?}", res),
                     }
                 }
-                res => panic!("unexpected result: {:?}", res),
+
+                #[test]
+                fn ensure_linked() {
+                    lucet_runtime::lucet_internal_ensure_linked();
+                }
+
+                #[test]
+                fn expect_ok_locals3_1() {
+                    expect_ok(stack_testcase(3).expect("generate stack_testcase 3"), 1);
+                }
+
+                // The test with 64 locals should cause a stack overflow on the 481st recursion.  The trap
+                // table knows about all of the instructions in the function that manipulate the stack, so
+                // the catch mechanism for this is the usual one.
+
+                #[test]
+                fn expect_ok_locals64_1() {
+                    expect_ok(stack_testcase(64).expect("generate stack_testcase 64"), 1);
+                }
+
+                #[test]
+                fn expect_ok_locals64_2() {
+                    expect_ok(stack_testcase(64).expect("generate stack_testcase 64"), 2);
+                }
+
+                #[test]
+                fn expect_ok_locals64_481() {
+                    // We use 64 local variables, but cranelift optimizes many of them into registers
+                    // rather than stack space. Four of those are callee-saved, for n > 18 local
+                    // variables, we actually use n + 4 stack spaces. So we use 64 spaces at 64 - 4 = 60
+                    // local variables.
+                    expect_ok(
+                        stack_testcase(64 - 4).expect("generate stack_testcase 64"),
+                        480,
+                    );
+                }
+
+                #[test]
+                fn expect_stack_overflow_locals64_481() {
+                    expect_stack_overflow(
+                        // Same note as `expect_ok_locals64_481`
+                        stack_testcase(64 - 4).expect("generate stack_testcase 64"),
+                        481,
+                        true,
+                    );
+                }
+
+                // 1050 locals is about 1 page (4k) on the stack - just enough for Cranelift to use probestack to grow
+                // the stack. The 31st recursion should cause a stack overflow.
+
+                #[test]
+                fn expect_ok_locals_1page_1() {
+                    expect_ok(
+                        stack_testcase(1050).expect("generate stack_testcase 1050"),
+                        1,
+                    );
+                }
+
+                #[test]
+                fn expect_ok_locals_1page_2() {
+                    expect_ok(
+                        stack_testcase(1050).expect("generate stack_testcase 1050"),
+                        2,
+                    );
+                }
+
+                #[test]
+                fn expect_ok_locals_1page_30() {
+                    expect_ok(
+                        stack_testcase(1050).expect("generate stack_testcase 1050"),
+                        30,
+                    );
+                }
+
+                #[test]
+                fn expect_stack_overflow_locals_1page_31() {
+                    expect_stack_overflow(
+                        stack_testcase(1050).expect("generate stack_testcase 1050"),
+                        31,
+                        true,
+                    );
+                }
+
+                // This test has 5000 locals - over 4 pages worth. Cranelift will use probestack here as well. The
+                // 6th recursion should cause a stack overflow.
+
+                #[test]
+                fn expect_ok_locals_multipage_1() {
+                    expect_ok(
+                        stack_testcase(5000).expect("generate stack_testcase 5000"),
+                        1,
+                    );
+                }
+
+                #[test]
+                fn expect_ok_locals_multipage_2() {
+                    expect_ok(
+                        stack_testcase(5000).expect("generate stack_testcase 5000"),
+                        2,
+                    );
+                }
+
+                #[test]
+                fn expect_ok_locals_multipage_5() {
+                    expect_ok(
+                        stack_testcase(5000).expect("generate stack_testcase 5000"),
+                        5,
+                    );
+                }
+
+                #[test]
+                fn expect_stack_overflow_locals_multipage_6() {
+                    expect_stack_overflow(
+                        stack_testcase(5000).expect("generate stack_testcase 5000"),
+                        6,
+                        true,
+                    );
+                }
             }
-        }
-
-        #[test]
-        fn ensure_linked() {
-            lucet_runtime::lucet_internal_ensure_linked();
-        }
-
-        #[test]
-        fn expect_ok_locals3_1() {
-            expect_ok(stack_testcase(3).expect("generate stack_testcase 3"), 1);
-        }
-
-        // The test with 64 locals should cause a stack overflow on the 481st recursion.  The trap
-        // table knows about all of the instructions in the function that manipulate the stack, so
-        // the catch mechanism for this is the usual one.
-
-        #[test]
-        fn expect_ok_locals64_1() {
-            expect_ok(stack_testcase(64).expect("generate stack_testcase 64"), 1);
-        }
-
-        #[test]
-        fn expect_ok_locals64_2() {
-            expect_ok(stack_testcase(64).expect("generate stack_testcase 64"), 2);
-        }
-
-        #[test]
-        fn expect_ok_locals64_481() {
-            // We use 64 local variables, but cranelift optimizes many of them into registers
-            // rather than stack space. Four of those are callee-saved, for n > 18 local
-            // variables, we actually use n + 4 stack spaces. So we use 64 spaces at 64 - 4 = 60
-            // local variables.
-            expect_ok(
-                stack_testcase(64 - 4).expect("generate stack_testcase 64"),
-                480,
-            );
-        }
-
-        #[test]
-        fn expect_stack_overflow_locals64_481() {
-            expect_stack_overflow(
-                // Same note as `expect_ok_locals64_481`
-                stack_testcase(64 - 4).expect("generate stack_testcase 64"),
-                481,
-                true,
-            );
-        }
-
-        // 1050 locals is about 1 page (4k) on the stack - just enough for Cranelift to use probestack to grow
-        // the stack. The 31st recursion should cause a stack overflow.
-
-        #[test]
-        fn expect_ok_locals_1page_1() {
-            expect_ok(
-                stack_testcase(1050).expect("generate stack_testcase 1050"),
-                1,
-            );
-        }
-
-        #[test]
-        fn expect_ok_locals_1page_2() {
-            expect_ok(
-                stack_testcase(1050).expect("generate stack_testcase 1050"),
-                2,
-            );
-        }
-
-        #[test]
-        fn expect_ok_locals_1page_30() {
-            expect_ok(
-                stack_testcase(1050).expect("generate stack_testcase 1050"),
-                30,
-            );
-        }
-
-        #[test]
-        fn expect_stack_overflow_locals_1page_31() {
-            expect_stack_overflow(
-                stack_testcase(1050).expect("generate stack_testcase 1050"),
-                31,
-                true,
-            );
-        }
-
-        // This test has 5000 locals - over 4 pages worth. Cranelift will use probestack here as well. The
-        // 6th recursion should cause a stack overflow.
-
-        #[test]
-        fn expect_ok_locals_multipage_1() {
-            expect_ok(
-                stack_testcase(5000).expect("generate stack_testcase 5000"),
-                1,
-            );
-        }
-
-        #[test]
-        fn expect_ok_locals_multipage_2() {
-            expect_ok(
-                stack_testcase(5000).expect("generate stack_testcase 5000"),
-                2,
-            );
-        }
-
-        #[test]
-        fn expect_ok_locals_multipage_5() {
-            expect_ok(
-                stack_testcase(5000).expect("generate stack_testcase 5000"),
-                5,
-            );
-        }
-
-        #[test]
-        fn expect_stack_overflow_locals_multipage_6() {
-            expect_stack_overflow(
-                stack_testcase(5000).expect("generate stack_testcase 5000"),
-                6,
-                true,
-            );
-        }
+        )*
     };
 }

--- a/lucet-runtime/lucet-runtime-tests/src/stack.rs
+++ b/lucet-runtime/lucet-runtime-tests/src/stack.rs
@@ -81,14 +81,14 @@ macro_rules! stack_tests {
         $(
             mod $region_id {
                 use lucet_runtime::{
-                    DlModule, Error, InstanceHandle, Limits, Region, TrapCode, UntypedRetVal, Val,
+                    DlModule, Error, InstanceHandle, Limits, Region, RegionCreate, TrapCode, UntypedRetVal, Val,
                 };
                 use std::sync::Arc;
                 use $TestRegion as TestRegion;
                 use $crate::stack::stack_testcase;
 
                 fn run(module: Arc<DlModule>, recursion_depth: i32) -> Result<UntypedRetVal, Error> {
-                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let region = <TestRegion as RegionCreate>::create(1, &Limits::default()).expect("region can be created");
                     let mut inst = region
                         .new_instance(module)
                         .expect("instance can be created");

--- a/lucet-runtime/lucet-runtime-tests/src/start.rs
+++ b/lucet-runtime/lucet-runtime-tests/src/start.rs
@@ -1,169 +1,63 @@
 #[macro_export]
 macro_rules! start_tests {
-    ( $TestRegion:path ) => {
-        use lucet_runtime::{DlModule, Error, Limits, Region};
-        use std::sync::Arc;
-        use $TestRegion as TestRegion;
-        use $crate::build::test_module_wasm;
-        use $crate::helpers::{test_ex, test_nonex, with_unchanged_signal_handlers};
+    ( $( $region_id:ident => $TestRegion:path ),* ) => {
+        $(
+            mod $region_id {
+                use lucet_runtime::{DlModule, Limits, Region};
+                use std::sync::Arc;
+                use $TestRegion as TestRegion;
+                use $crate::build::test_module_wasm;
 
-        #[test]
-        fn ensure_linked() {
-            lucet_runtime::lucet_internal_ensure_linked();
-        }
-
-        #[test]
-        fn global_init() {
-            test_nonex(|| {
-                let module = test_module_wasm("start", "global_init.wat")
-                    .expect("module compiled and loaded");
-                let region =
-                    TestRegion::create(1, &Limits::default()).expect("region can be created");
-                let mut inst = region
-                    .new_instance(module)
-                    .expect("instance can be created");
-
-                inst.run_start().expect("start section runs");
-                inst.run("main", &[]).expect("instance runs");
-
-                // Now the globals should be:
-                // $flossie = 17
-                // and heap should be:
-                // [0] = 17
-
-                let heap = inst.heap_u32();
-                assert_eq!(heap[0], 17);
-            });
-        }
-
-        #[test]
-        fn start_and_call() {
-            test_nonex(|| {
-                let module = test_module_wasm("start", "start_and_call.wat")
-                    .expect("module compiled and loaded");
-                let region =
-                    TestRegion::create(1, &Limits::default()).expect("region can be created");
-                let mut inst = region
-                    .new_instance(module)
-                    .expect("instance can be created");
-
-                inst.run_start().expect("start section runs");
-                inst.run("main", &[]).expect("instance runs");
-
-                // Now the globals should be:
-                // $flossie = 17
-                // and heap should be:
-                // [0] = 17
-
-                let heap = inst.heap_u32();
-                assert_eq!(heap[0], 17);
-            });
-        }
-
-        #[test]
-        fn start_is_required() {
-            test_nonex(|| {
-                let module = test_module_wasm("start", "start_and_call.wat")
-                    .expect("module compiled and loaded");
-                let region =
-                    TestRegion::create(1, &Limits::default()).expect("region can be created");
-                let mut inst = region
-                    .new_instance(module)
-                    .expect("instance can be created");
-
-                match inst.run("main", &[]).unwrap_err() {
-                    Error::InstanceNeedsStart => (),
-                    e => panic!("unexpected error: {}", e),
+                #[test]
+                fn ensure_linked() {
+                    lucet_runtime::lucet_internal_ensure_linked();
                 }
-            });
-        }
 
-        #[test]
-        fn no_start_without_reset() {
-            test_nonex(|| {
-                let module = test_module_wasm("start", "start_and_call.wat")
-                    .expect("module compiled and loaded");
-                let region =
-                    TestRegion::create(1, &Limits::default()).expect("region can be created");
-                let mut inst = region
-                    .new_instance(module)
-                    .expect("instance can be created");
+                #[test]
+                fn global_init() {
+                    let module =
+                        test_module_wasm("start", "global_init.wat").expect("module compiled and loaded");
+                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let mut inst = region
+                        .new_instance(module)
+                        .expect("instance can be created");
 
-                inst.run_start().expect("start section runs");
-                match inst.run_start().unwrap_err() {
-                    Error::StartAlreadyRun => (),
-                    e => panic!("unexpected error: {}", e),
+                    inst.run("main", &[]).expect("instance runs");
+
+                    // Now the globals should be:
+                    // $flossie = 17
+                    // and heap should be:
+                    // [0] = 17
+
+                    let heap = inst.heap_u32();
+                    assert_eq!(heap[0], 17);
                 }
-            });
-        }
 
-        #[test]
-        fn start_and_reset() {
-            test_nonex(|| {
-                let module = test_module_wasm("start", "start_and_call.wat")
-                    .expect("module compiled and loaded");
-                let region =
-                    TestRegion::create(1, &Limits::default()).expect("region can be created");
-                let mut inst = region
-                    .new_instance(module)
-                    .expect("instance can be created");
-
-                inst.run_start().expect("start section runs");
-                inst.run("main", &[]).expect("instance runs");
-
-                // Now the globals should be:
-                // $flossie = 17
-                // and heap should be:
-                // [0] = 17
-
-                let heap = inst.heap_u32();
-                assert_eq!(heap[0], 17);
-
-                inst.reset().expect("instance resets");
-
-                let heap = inst.heap_u32();
-                assert_eq!(heap[0], 0);
-
-                inst.run_start().expect("start section runs again");
-                inst.run("main", &[]).expect("instance runs again");
-
-                let heap = inst.heap_u32();
-                assert_eq!(heap[0], 17);
-            });
-        }
-
-        #[test]
-        fn no_start() {
-            test_nonex(|| {
-                let module =
-                    test_module_wasm("start", "no_start.wat").expect("module compiled and loaded");
-                let region =
-                    TestRegion::create(1, &Limits::default()).expect("region can be created");
-                let mut inst = region
-                    .new_instance(module)
-                    .expect("instance can be created");
-
-                inst.run_start().expect("start section doesn't run");
-                inst.run("main", &[]).expect("instance runs");
-
-                // Now the globals should be:
-                // $flossie = 17
-                // and heap should be:
-                // [0] = 17
-
-                let heap = inst.heap_u32();
-                assert_eq!(heap[0], 17);
-            });
-        }
-
-        #[test]
-        fn manual_signal_handler_ok() {
-            test_ex(|| {
-                with_unchanged_signal_handlers(|| {
+                #[test]
+                fn start_and_call() {
                     let module = test_module_wasm("start", "start_and_call.wat")
                         .expect("module compiled and loaded");
-                    let region =
-                        TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
+                    let mut inst = region
+                        .new_instance(module)
+                        .expect("instance can be created");
+
+                    inst.run("main", &[]).expect("instance runs");
+
+                    // Now the globals should be:
+                    // $flossie = 17
+                    // and heap should be:
+                    // [0] = 17
+
+                    let heap = inst.heap_u32();
+                    assert_eq!(heap[0], 17);
+                }
+
+                #[test]
+                fn no_start() {
+                    let module =
+                        test_module_wasm("start", "no_start.wat").expect("module compiled and loaded");
+                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
                     let mut inst = region
                         .new_instance(module)
                         .expect("instance can be created");
@@ -194,72 +88,72 @@ macro_rules! start_tests {
                     assert_eq!(heap[0], 17);
 
                     lucet_runtime::remove_lucet_signal_handler();
-                })
-            });
-        }
+                }
 
-        #[test]
-        fn manual_sigstack_ok() {
-            test_nonex(|| {
-                use libc::*;
-                use std::mem::MaybeUninit;
-
-                let mut our_sigstack_alloc = vec![0; lucet_runtime::DEFAULT_SIGNAL_STACK_SIZE];
-                let our_sigstack = stack_t {
-                    ss_sp: our_sigstack_alloc.as_mut_ptr() as *mut _,
-                    ss_flags: 0,
-                    ss_size: lucet_runtime::DEFAULT_SIGNAL_STACK_SIZE,
-                };
-                let mut beforestack = MaybeUninit::<stack_t>::uninit();
-                let beforestack = unsafe {
-                    sigaltstack(&our_sigstack, beforestack.as_mut_ptr());
-                    beforestack.assume_init()
-                };
-
-                let module = test_module_wasm("start", "start_and_call.wat")
-                    .expect("module compiled and loaded");
-                let limits_no_sigstack = Limits {
-                    signal_stack_size: 0,
-                    ..Limits::default()
-                };
-                let region =
-                    TestRegion::create(1, &limits_no_sigstack).expect("region can be created");
-                let mut inst = region
-                    .new_instance(module)
-                    .expect("instance can be created");
-
-                inst.ensure_sigstack_installed(false);
-
-                inst.run_start().expect("start section runs");
-                inst.run("main", &[]).expect("instance runs");
-
-                // Now the globals should be:
-                // $flossie = 17
-                // and heap should be:
-                // [0] = 17
-
-                let heap = inst.heap_u32();
-                assert_eq!(heap[0], 17);
-
-                inst.reset().expect("instance resets");
-
-                let heap = inst.heap_u32();
-                assert_eq!(heap[0], 0);
-
-                inst.run_start().expect("start section runs again");
-                inst.run("main", &[]).expect("instance runs again");
-
-                let heap = inst.heap_u32();
-                assert_eq!(heap[0], 17);
-
-                let mut afterstack = MaybeUninit::<stack_t>::uninit();
-                let afterstack = unsafe {
-                    sigaltstack(&beforestack, afterstack.as_mut_ptr());
-                    afterstack.assume_init()
-                };
-
-                assert_eq!(afterstack.ss_sp, our_sigstack_alloc.as_mut_ptr() as *mut _);
-            });
-        }
+                #[test]
+                fn manual_sigstack_ok() {
+                    test_nonex(|| {
+                        use libc::*;
+                        use std::mem::MaybeUninit;
+                        
+                        let mut our_sigstack_alloc = vec![0; lucet_runtime::DEFAULT_SIGNAL_STACK_SIZE];
+                        let our_sigstack = stack_t {
+                            ss_sp: our_sigstack_alloc.as_mut_ptr() as *mut _,
+                            ss_flags: 0,
+                            ss_size: lucet_runtime::DEFAULT_SIGNAL_STACK_SIZE,
+                        };
+                        let mut beforestack = MaybeUninit::<stack_t>::uninit();
+                        let beforestack = unsafe {
+                            sigaltstack(&our_sigstack, beforestack.as_mut_ptr());
+                            beforestack.assume_init()
+                        };
+                        
+                        let module = test_module_wasm("start", "start_and_call.wat")
+                            .expect("module compiled and loaded");
+                        let limits_no_sigstack = Limits {
+                            signal_stack_size: 0,
+                            ..Limits::default()
+                        };
+                        let region =
+                            TestRegion::create(1, &limits_no_sigstack).expect("region can be created");
+                        let mut inst = region
+                            .new_instance(module)
+                            .expect("instance can be created");
+                        
+                        inst.ensure_sigstack_installed(false);
+                        
+                        inst.run_start().expect("start section runs");
+                        inst.run("main", &[]).expect("instance runs");
+                        
+                        // Now the globals should be:
+                        // $flossie = 17
+                        // and heap should be:
+                        // [0] = 17
+                        
+                        let heap = inst.heap_u32();
+                        assert_eq!(heap[0], 17);
+                        
+                        inst.reset().expect("instance resets");
+                        
+                        let heap = inst.heap_u32();
+                        assert_eq!(heap[0], 0);
+                        
+                        inst.run_start().expect("start section runs again");
+                        inst.run("main", &[]).expect("instance runs again");
+                        
+                        let heap = inst.heap_u32();
+                        assert_eq!(heap[0], 17);
+                        
+                        let mut afterstack = MaybeUninit::<stack_t>::uninit();
+                        let afterstack = unsafe {
+                            sigaltstack(&beforestack, afterstack.as_mut_ptr());
+                            afterstack.assume_init()
+                        };
+                        
+                        assert_eq!(afterstack.ss_sp, our_sigstack_alloc.as_mut_ptr() as *mut _);
+                    });
+                }
+            }
+        )*
     };
 }

--- a/lucet-runtime/lucet-runtime-tests/src/start.rs
+++ b/lucet-runtime/lucet-runtime-tests/src/start.rs
@@ -3,7 +3,7 @@ macro_rules! start_tests {
     ( $( $region_id:ident => $TestRegion:path ),* ) => {
         $(
             mod $region_id {
-                use lucet_runtime::{DlModule, Error, Limits, Region};
+                use lucet_runtime::{DlModule, Error, Limits, Region, RegionCreate};
                 use std::sync::Arc;
                 use $TestRegion as TestRegion;
                 use $crate::build::test_module_wasm;
@@ -20,7 +20,7 @@ macro_rules! start_tests {
                         let module = test_module_wasm("start", "global_init.wat")
                             .expect("module compiled and loaded");
                         let region =
-                            TestRegion::create(1, &Limits::default()).expect("region can be created");
+                            <TestRegion as RegionCreate>::create(1, &Limits::default()).expect("region can be created");
                         let mut inst = region
                             .new_instance(module)
                             .expect("instance can be created");
@@ -44,7 +44,7 @@ macro_rules! start_tests {
                         let module = test_module_wasm("start", "start_and_call.wat")
                             .expect("module compiled and loaded");
                         let region =
-                            TestRegion::create(1, &Limits::default()).expect("region can be created");
+                            <TestRegion as RegionCreate>::create(1, &Limits::default()).expect("region can be created");
                         let mut inst = region
                             .new_instance(module)
                             .expect("instance can be created");
@@ -68,7 +68,7 @@ macro_rules! start_tests {
                         let module = test_module_wasm("start", "start_and_call.wat")
                             .expect("module compiled and loaded");
                         let region =
-                            TestRegion::create(1, &Limits::default()).expect("region can be created");
+                            <TestRegion as RegionCreate>::create(1, &Limits::default()).expect("region can be created");
                         let mut inst = region
                             .new_instance(module)
                             .expect("instance can be created");
@@ -86,7 +86,7 @@ macro_rules! start_tests {
                         let module = test_module_wasm("start", "start_and_call.wat")
                             .expect("module compiled and loaded");
                         let region =
-                            TestRegion::create(1, &Limits::default()).expect("region can be created");
+                            <TestRegion as RegionCreate>::create(1, &Limits::default()).expect("region can be created");
                         let mut inst = region
                             .new_instance(module)
                             .expect("instance can be created");
@@ -105,7 +105,7 @@ macro_rules! start_tests {
                         let module = test_module_wasm("start", "start_and_call.wat")
                             .expect("module compiled and loaded");
                         let region =
-                            TestRegion::create(1, &Limits::default()).expect("region can be created");
+                            <TestRegion as RegionCreate>::create(1, &Limits::default()).expect("region can be created");
                         let mut inst = region
                             .new_instance(module)
                             .expect("instance can be created");
@@ -140,7 +140,7 @@ macro_rules! start_tests {
                         let module =
                             test_module_wasm("start", "no_start.wat").expect("module compiled and loaded");
                         let region =
-                            TestRegion::create(1, &Limits::default()).expect("region can be created");
+                            <TestRegion as RegionCreate>::create(1, &Limits::default()).expect("region can be created");
                         let mut inst = region
                             .new_instance(module)
                             .expect("instance can be created");
@@ -165,7 +165,7 @@ macro_rules! start_tests {
                             let module = test_module_wasm("start", "start_and_call.wat")
                                 .expect("module compiled and loaded");
                             let region =
-                                TestRegion::create(1, &Limits::default()).expect("region can be created");
+                                <TestRegion as RegionCreate>::create(1, &Limits::default()).expect("region can be created");
                             let mut inst = region
                                 .new_instance(module)
                                 .expect("instance can be created");
@@ -225,7 +225,7 @@ macro_rules! start_tests {
                             ..Limits::default()
                         };
                         let region =
-                            TestRegion::create(1, &limits_no_sigstack).expect("region can be created");
+                            <TestRegion as RegionCreate>::create(1, &limits_no_sigstack).expect("region can be created");
                         let mut inst = region
                             .new_instance(module)
                             .expect("instance can be created");

--- a/lucet-runtime/lucet-runtime-tests/src/start.rs
+++ b/lucet-runtime/lucet-runtime-tests/src/start.rs
@@ -3,10 +3,11 @@ macro_rules! start_tests {
     ( $( $region_id:ident => $TestRegion:path ),* ) => {
         $(
             mod $region_id {
-                use lucet_runtime::{DlModule, Limits, Region};
+                use lucet_runtime::{DlModule, Error, Limits, Region};
                 use std::sync::Arc;
                 use $TestRegion as TestRegion;
                 use $crate::build::test_module_wasm;
+                use $crate::helpers::{test_ex, test_nonex, with_unchanged_signal_handlers};
 
                 #[test]
                 fn ensure_linked() {
@@ -15,79 +16,188 @@ macro_rules! start_tests {
 
                 #[test]
                 fn global_init() {
-                    let module =
-                        test_module_wasm("start", "global_init.wat").expect("module compiled and loaded");
-                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
-                    let mut inst = region
-                        .new_instance(module)
-                        .expect("instance can be created");
+                    test_nonex(|| {
+                        let module = test_module_wasm("start", "global_init.wat")
+                            .expect("module compiled and loaded");
+                        let region =
+                            TestRegion::create(1, &Limits::default()).expect("region can be created");
+                        let mut inst = region
+                            .new_instance(module)
+                            .expect("instance can be created");
 
-                    inst.run("main", &[]).expect("instance runs");
+                        inst.run_start().expect("start section runs");
+                        inst.run("main", &[]).expect("instance runs");
 
-                    // Now the globals should be:
-                    // $flossie = 17
-                    // and heap should be:
-                    // [0] = 17
+                        // Now the globals should be:
+                        // $flossie = 17
+                        // and heap should be:
+                        // [0] = 17
 
-                    let heap = inst.heap_u32();
-                    assert_eq!(heap[0], 17);
+                        let heap = inst.heap_u32();
+                        assert_eq!(heap[0], 17);
+                    });
                 }
 
                 #[test]
                 fn start_and_call() {
-                    let module = test_module_wasm("start", "start_and_call.wat")
-                        .expect("module compiled and loaded");
-                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
-                    let mut inst = region
-                        .new_instance(module)
-                        .expect("instance can be created");
+                    test_nonex(|| {
+                        let module = test_module_wasm("start", "start_and_call.wat")
+                            .expect("module compiled and loaded");
+                        let region =
+                            TestRegion::create(1, &Limits::default()).expect("region can be created");
+                        let mut inst = region
+                            .new_instance(module)
+                            .expect("instance can be created");
 
-                    inst.run("main", &[]).expect("instance runs");
+                        inst.run_start().expect("start section runs");
+                        inst.run("main", &[]).expect("instance runs");
 
-                    // Now the globals should be:
-                    // $flossie = 17
-                    // and heap should be:
-                    // [0] = 17
+                        // Now the globals should be:
+                        // $flossie = 17
+                        // and heap should be:
+                        // [0] = 17
 
-                    let heap = inst.heap_u32();
-                    assert_eq!(heap[0], 17);
+                        let heap = inst.heap_u32();
+                        assert_eq!(heap[0], 17);
+                    });
+                }
+
+                #[test]
+                fn start_is_required() {
+                    test_nonex(|| {
+                        let module = test_module_wasm("start", "start_and_call.wat")
+                            .expect("module compiled and loaded");
+                        let region =
+                            TestRegion::create(1, &Limits::default()).expect("region can be created");
+                        let mut inst = region
+                            .new_instance(module)
+                            .expect("instance can be created");
+
+                        match inst.run("main", &[]).unwrap_err() {
+                            Error::InstanceNeedsStart => (),
+                            e => panic!("unexpected error: {}", e),
+                        }
+                    });
+                }
+
+                #[test]
+                fn no_start_without_reset() {
+                    test_nonex(|| {
+                        let module = test_module_wasm("start", "start_and_call.wat")
+                            .expect("module compiled and loaded");
+                        let region =
+                            TestRegion::create(1, &Limits::default()).expect("region can be created");
+                        let mut inst = region
+                            .new_instance(module)
+                            .expect("instance can be created");
+
+                        inst.run_start().expect("start section runs");
+                        match inst.run_start().unwrap_err() {
+                            Error::StartAlreadyRun => (),
+                            e => panic!("unexpected error: {}", e),
+                        }
+                    });
+                }
+
+                #[test]
+                fn start_and_reset() {
+                    test_nonex(|| {
+                        let module = test_module_wasm("start", "start_and_call.wat")
+                            .expect("module compiled and loaded");
+                        let region =
+                            TestRegion::create(1, &Limits::default()).expect("region can be created");
+                        let mut inst = region
+                            .new_instance(module)
+                            .expect("instance can be created");
+
+                        inst.run_start().expect("start section runs");
+                        inst.run("main", &[]).expect("instance runs");
+
+                        // Now the globals should be:
+                        // $flossie = 17
+                        // and heap should be:
+                        // [0] = 17
+
+                        let heap = inst.heap_u32();
+                        assert_eq!(heap[0], 17);
+
+                        inst.reset().expect("instance resets");
+
+                        let heap = inst.heap_u32();
+                        assert_eq!(heap[0], 0);
+
+                        inst.run_start().expect("start section runs again");
+                        inst.run("main", &[]).expect("instance runs again");
+
+                        let heap = inst.heap_u32();
+                        assert_eq!(heap[0], 17);
+                    });
                 }
 
                 #[test]
                 fn no_start() {
-                    let module =
-                        test_module_wasm("start", "no_start.wat").expect("module compiled and loaded");
-                    let region = TestRegion::create(1, &Limits::default()).expect("region can be created");
-                    let mut inst = region
-                        .new_instance(module)
-                        .expect("instance can be created");
+                    test_nonex(|| {
+                        let module =
+                            test_module_wasm("start", "no_start.wat").expect("module compiled and loaded");
+                        let region =
+                            TestRegion::create(1, &Limits::default()).expect("region can be created");
+                        let mut inst = region
+                            .new_instance(module)
+                            .expect("instance can be created");
 
-                    inst.ensure_signal_handler_installed(false);
-                    lucet_runtime::install_lucet_signal_handler();
+                        inst.run_start().expect("start section doesn't run");
+                        inst.run("main", &[]).expect("instance runs");
 
-                    inst.run_start().expect("start section runs");
-                    inst.run("main", &[]).expect("instance runs");
+                        // Now the globals should be:
+                        // $flossie = 17
+                        // and heap should be:
+                        // [0] = 17
 
-                    // Now the globals should be:
-                    // $flossie = 17
-                    // and heap should be:
-                    // [0] = 17
+                        let heap = inst.heap_u32();
+                        assert_eq!(heap[0], 17);
+                    });
+                }
 
-                    let heap = inst.heap_u32();
-                    assert_eq!(heap[0], 17);
+                #[test]
+                fn manual_signal_handler_ok() {
+                    test_ex(|| {
+                        with_unchanged_signal_handlers(|| {
+                            let module = test_module_wasm("start", "start_and_call.wat")
+                                .expect("module compiled and loaded");
+                            let region =
+                                TestRegion::create(1, &Limits::default()).expect("region can be created");
+                            let mut inst = region
+                                .new_instance(module)
+                                .expect("instance can be created");
 
-                    inst.reset().expect("instance resets");
+                            inst.ensure_signal_handler_installed(false);
+                            lucet_runtime::install_lucet_signal_handler();
 
-                    let heap = inst.heap_u32();
-                    assert_eq!(heap[0], 0);
+                            inst.run_start().expect("start section runs");
+                            inst.run("main", &[]).expect("instance runs");
 
-                    inst.run_start().expect("start section runs again");
-                    inst.run("main", &[]).expect("instance runs again");
+                            // Now the globals should be:
+                            // $flossie = 17
+                            // and heap should be:
+                            // [0] = 17
 
-                    let heap = inst.heap_u32();
-                    assert_eq!(heap[0], 17);
+                            let heap = inst.heap_u32();
+                            assert_eq!(heap[0], 17);
 
-                    lucet_runtime::remove_lucet_signal_handler();
+                            inst.reset().expect("instance resets");
+
+                            let heap = inst.heap_u32();
+                            assert_eq!(heap[0], 0);
+
+                            inst.run_start().expect("start section runs again");
+                            inst.run("main", &[]).expect("instance runs again");
+
+                            let heap = inst.heap_u32();
+                            assert_eq!(heap[0], 17);
+
+                            lucet_runtime::remove_lucet_signal_handler();
+                        })
+                    });
                 }
 
                 #[test]
@@ -95,7 +205,7 @@ macro_rules! start_tests {
                     test_nonex(|| {
                         use libc::*;
                         use std::mem::MaybeUninit;
-                        
+
                         let mut our_sigstack_alloc = vec![0; lucet_runtime::DEFAULT_SIGNAL_STACK_SIZE];
                         let our_sigstack = stack_t {
                             ss_sp: our_sigstack_alloc.as_mut_ptr() as *mut _,
@@ -107,7 +217,7 @@ macro_rules! start_tests {
                             sigaltstack(&our_sigstack, beforestack.as_mut_ptr());
                             beforestack.assume_init()
                         };
-                        
+
                         let module = test_module_wasm("start", "start_and_call.wat")
                             .expect("module compiled and loaded");
                         let limits_no_sigstack = Limits {
@@ -119,37 +229,37 @@ macro_rules! start_tests {
                         let mut inst = region
                             .new_instance(module)
                             .expect("instance can be created");
-                        
+
                         inst.ensure_sigstack_installed(false);
-                        
+
                         inst.run_start().expect("start section runs");
                         inst.run("main", &[]).expect("instance runs");
-                        
+
                         // Now the globals should be:
                         // $flossie = 17
                         // and heap should be:
                         // [0] = 17
-                        
+
                         let heap = inst.heap_u32();
                         assert_eq!(heap[0], 17);
-                        
+
                         inst.reset().expect("instance resets");
-                        
+
                         let heap = inst.heap_u32();
                         assert_eq!(heap[0], 0);
-                        
+
                         inst.run_start().expect("start section runs again");
                         inst.run("main", &[]).expect("instance runs again");
-                        
+
                         let heap = inst.heap_u32();
                         assert_eq!(heap[0], 17);
-                        
+
                         let mut afterstack = MaybeUninit::<stack_t>::uninit();
                         let afterstack = unsafe {
                             sigaltstack(&beforestack, afterstack.as_mut_ptr());
                             afterstack.assume_init()
                         };
-                        
+
                         assert_eq!(afterstack.ss_sp, our_sigstack_alloc.as_mut_ptr() as *mut _);
                     });
                 }

--- a/lucet-runtime/lucet-runtime-tests/src/strcmp.rs
+++ b/lucet-runtime/lucet-runtime-tests/src/strcmp.rs
@@ -17,7 +17,7 @@ macro_rules! strcmp_tests {
             mod $region_id {
                 use libc::{c_char, c_int, c_void, strcmp};
                 use lucet_runtime::vmctx::{lucet_vmctx, Vmctx};
-                use lucet_runtime::{Error, Limits, Region, Val, WASM_PAGE_SIZE};
+                use lucet_runtime::{Error, Limits, Region, RegionCreate, Val, WASM_PAGE_SIZE};
                 use std::ffi::CString;
                 use std::sync::Arc;
                 use $TestRegion as TestRegion;
@@ -35,7 +35,7 @@ macro_rules! strcmp_tests {
                     assert!(s1.len() + s2.len() < WASM_PAGE_SIZE as usize);
 
                     let module = test_module_c("strcmp", "guest.c").expect("compile module");
-                    let region = TestRegion::create(10, &Limits::default()).expect("region can be created");
+                    let region = <TestRegion as RegionCreate>::create(10, &Limits::default()).expect("region can be created");
                     let mut inst = region
                         .new_instance(module)
                         .expect("instance can be created");
@@ -85,7 +85,7 @@ macro_rules! strcmp_tests {
                 #[test]
                 fn strcmp_fault_test() {
                     let module = test_module_c("strcmp", "guest.c").expect("compile module");
-                    let region = TestRegion::create(10, &Limits::default()).expect("region can be created");
+                    let region = <TestRegion as RegionCreate>::create(10, &Limits::default()).expect("region can be created");
                     let mut inst = region
                         .new_instance(module)
                         .expect("instance can be created");
@@ -95,7 +95,7 @@ macro_rules! strcmp_tests {
                         res => panic!("unexpected result: {:?}", res),
                     }
                 }
-                
+
                 #[test]
                 fn ensure_linked() {
                     lucet_runtime::lucet_internal_ensure_linked();

--- a/lucet-runtime/lucet-runtime-tests/src/strcmp.rs
+++ b/lucet-runtime/lucet-runtime-tests/src/strcmp.rs
@@ -1,14 +1,9 @@
 #[macro_export]
 macro_rules! strcmp_tests {
-    ( $TestRegion:path ) => {
-        use libc::{c_char, c_int, c_void, strcmp};
-        use lucet_runtime::vmctx::{lucet_vmctx, Vmctx};
-        use lucet_runtime::{lucet_hostcall, Error, Limits, Region, Val, WASM_PAGE_SIZE};
-        use std::ffi::CString;
-        use std::sync::Arc;
-        use $TestRegion as TestRegion;
-        use $crate::build::test_module_c;
-
+    ( $( $region_id:ident => $TestRegion:path ),* ) => {
+        use libc::c_char;
+        use lucet_runtime::vmctx::Vmctx;
+        use lucet_runtime::lucet_hostcall;
         #[lucet_hostcall]
         #[no_mangle]
         pub fn hostcall_host_fault(_vmctx: &mut Vmctx) {
@@ -18,81 +13,94 @@ macro_rules! strcmp_tests {
             }
         }
 
-        fn strcmp_compare(s1: &str, s2: &str) {
-            let s1 = CString::new(s1)
-                .expect("s1 is a valid CString")
-                .into_bytes_with_nul();
-            let s2 = CString::new(s2)
-                .expect("s2 is a valid CString")
-                .into_bytes_with_nul();
+        $(
+            mod $region_id {
+                use libc::{c_char, c_int, c_void, strcmp};
+                use lucet_runtime::vmctx::{lucet_vmctx, Vmctx};
+                use lucet_runtime::{Error, Limits, Region, Val, WASM_PAGE_SIZE};
+                use std::ffi::CString;
+                use std::sync::Arc;
+                use $TestRegion as TestRegion;
+                use $crate::build::test_module_c;
 
-            assert!(s1.len() + s2.len() < WASM_PAGE_SIZE as usize);
 
-            let module = test_module_c("strcmp", "guest.c").expect("compile module");
-            let region = TestRegion::create(10, &Limits::default()).expect("region can be created");
-            let mut inst = region
-                .new_instance(module)
-                .expect("instance can be created");
+                fn strcmp_compare(s1: &str, s2: &str) {
+                    let s1 = CString::new(s1)
+                        .expect("s1 is a valid CString")
+                        .into_bytes_with_nul();
+                    let s2 = CString::new(s2)
+                        .expect("s2 is a valid CString")
+                        .into_bytes_with_nul();
 
-            let newpage_start = inst.grow_memory(1).expect("grow_memory succeeds");
-            let heap = inst.heap_mut();
+                    assert!(s1.len() + s2.len() < WASM_PAGE_SIZE as usize);
 
-            let s1_ptr = (newpage_start * WASM_PAGE_SIZE) as usize;
-            let s2_ptr = s1_ptr + s1.len();
-            heap[s1_ptr..s2_ptr].copy_from_slice(&s1);
-            heap[s2_ptr..s2_ptr + s2.len()].copy_from_slice(&s2);
+                    let module = test_module_c("strcmp", "guest.c").expect("compile module");
+                    let region = TestRegion::create(10, &Limits::default()).expect("region can be created");
+                    let mut inst = region
+                        .new_instance(module)
+                        .expect("instance can be created");
 
-            let res = c_int::from(
-                inst.run(
-                    "run_strcmp",
-                    &[Val::GuestPtr(s1_ptr as u32), Val::GuestPtr(s2_ptr as u32)],
-                )
-                .expect("instance runs")
-                .unwrap_returned(),
-            );
+                    let newpage_start = inst.grow_memory(1).expect("grow_memory succeeds");
+                    let heap = inst.heap_mut();
 
-            let host_strcmp_res =
-                unsafe { strcmp(s1.as_ptr() as *const c_char, s2.as_ptr() as *const c_char) };
-            assert_eq!(res, host_strcmp_res);
-        }
+                    let s1_ptr = (newpage_start * WASM_PAGE_SIZE) as usize;
+                    let s2_ptr = s1_ptr + s1.len();
+                    heap[s1_ptr..s2_ptr].copy_from_slice(&s1);
+                    heap[s2_ptr..s2_ptr + s2.len()].copy_from_slice(&s2);
 
-        #[test]
-        fn strcmp_abc_abc() {
-            strcmp_compare("abc", "abc");
-        }
+                    let res = c_int::from(
+                        inst.run(
+                            "run_strcmp",
+                            &[Val::GuestPtr(s1_ptr as u32), Val::GuestPtr(s2_ptr as u32)],
+                        )
+                            .expect("instance runs")
+                            .unwrap_returned(),
+                    );
 
-        #[test]
-        fn strcmp_def_abc() {
-            strcmp_compare("def", "abc");
-        }
+                    let host_strcmp_res =
+                        unsafe { strcmp(s1.as_ptr() as *const c_char, s2.as_ptr() as *const c_char) };
+                    assert_eq!(res, host_strcmp_res);
+                }
 
-        #[test]
-        fn strcmp_abcd_abc() {
-            strcmp_compare("abcd", "abc");
-        }
+                #[test]
+                fn strcmp_abc_abc() {
+                    strcmp_compare("abc", "abc");
+                }
 
-        #[test]
-        fn strcmp_abc_abcd() {
-            strcmp_compare("abc", "abcd");
-        }
+                #[test]
+                fn strcmp_def_abc() {
+                    strcmp_compare("def", "abc");
+                }
 
-        #[test]
-        fn strcmp_fault_test() {
-            let module = test_module_c("strcmp", "guest.c").expect("compile module");
-            let region = TestRegion::create(10, &Limits::default()).expect("region can be created");
-            let mut inst = region
-                .new_instance(module)
-                .expect("instance can be created");
+                #[test]
+                fn strcmp_abcd_abc() {
+                    strcmp_compare("abcd", "abc");
+                }
 
-            match inst.run("wasm_fault", &[]) {
-                Err(Error::RuntimeFault { .. }) => (),
-                res => panic!("unexpected result: {:?}", res),
+                #[test]
+                fn strcmp_abc_abcd() {
+                    strcmp_compare("abc", "abcd");
+                }
+
+                #[test]
+                fn strcmp_fault_test() {
+                    let module = test_module_c("strcmp", "guest.c").expect("compile module");
+                    let region = TestRegion::create(10, &Limits::default()).expect("region can be created");
+                    let mut inst = region
+                        .new_instance(module)
+                        .expect("instance can be created");
+
+                    match inst.run("wasm_fault", &[]) {
+                        Err(Error::RuntimeFault { .. }) => (),
+                        res => panic!("unexpected result: {:?}", res),
+                    }
+                }
+                
+                #[test]
+                fn ensure_linked() {
+                    lucet_runtime::lucet_internal_ensure_linked();
+                }
             }
-        }
-
-        #[test]
-        fn ensure_linked() {
-            lucet_runtime::lucet_internal_ensure_linked();
-        }
+        )*
     };
 }

--- a/lucet-runtime/src/c_api.rs
+++ b/lucet-runtime/src/c_api.rs
@@ -1,6 +1,6 @@
-#[cfg(all(target_os = "linux", feature = "uffd"))]
-use crate::{DefaultUffdStrategy, UffdRegion};
 use crate::{DlModule, Instance, Limits, MmapRegion, Module, Region};
+#[cfg(all(target_os = "linux", feature = "uffd"))]
+use crate::{UffdRegion, WasmPageSizedUffdStrategy};
 use libc::{c_char, c_int, c_void};
 use lucet_module::TrapCode;
 use lucet_runtime_internals::c_api::*;
@@ -111,7 +111,7 @@ pub unsafe extern "C" fn lucet_uffd_region_create(
                 .as_ref()
                 .map(|l| l.into())
                 .unwrap_or(Limits::default());
-            match UffdRegion::create(instance_capacity as usize, &limits, DefaultUffdStrategy {}) {
+            match UffdRegion::create(instance_capacity as usize, &limits, WasmPageSizedUffdStrategy {}) {
                 Ok(region) => {
                     let region_thin = Arc::into_raw(Arc::new(region as Arc<dyn Region>));
                     region_out.write(region_thin as _);

--- a/lucet-runtime/src/c_api.rs
+++ b/lucet-runtime/src/c_api.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "uffd")]
+#[cfg(all(target_os = "linux", feature = "uffd"))]
 use crate::UffdRegion;
 use crate::{DlModule, Instance, Limits, MmapRegion, Module, Region};
 use libc::{c_char, c_int, c_void};
@@ -105,7 +105,7 @@ pub unsafe extern "C" fn lucet_uffd_region_create(
     region_out: *mut *mut lucet_region,
 ) -> lucet_error {
     cfg_if::cfg_if! {
-        if #[cfg(feature = "uffd")] {
+        if #[cfg(all(target_os = "linux", feature = "uffd"))] {
             assert_nonnull!(region_out);
             let limits = limits
                 .as_ref()

--- a/lucet-runtime/src/c_api.rs
+++ b/lucet-runtime/src/c_api.rs
@@ -1,5 +1,5 @@
 #[cfg(all(target_os = "linux", feature = "uffd"))]
-use crate::UffdRegion;
+use crate::{DefaultUffdStrategy, UffdRegion};
 use crate::{DlModule, Instance, Limits, MmapRegion, Module, Region};
 use libc::{c_char, c_int, c_void};
 use lucet_module::TrapCode;
@@ -111,7 +111,7 @@ pub unsafe extern "C" fn lucet_uffd_region_create(
                 .as_ref()
                 .map(|l| l.into())
                 .unwrap_or(Limits::default());
-            match UffdRegion::create(instance_capacity as usize, &limits) {
+            match UffdRegion::create(instance_capacity as usize, &limits, DefaultUffdStrategy {}) {
                 Ok(region) => {
                     let region_thin = Arc::into_raw(Arc::new(region as Arc<dyn Region>));
                     region_out.write(region_thin as _);

--- a/lucet-runtime/src/lib.rs
+++ b/lucet-runtime/src/lib.rs
@@ -23,7 +23,10 @@
 //! [`InstanceHandle`](struct.InstanceHandle.html) smart pointer.
 //!
 //! - [`Region`](trait.Region.html): the memory from which instances are created. This crate
-//! includes [`MmapRegion`](struct.MmapRegion.html), an implementation backed by `mmap`.
+//! includes [`MmapRegion`](struct.MmapRegion.html), an implementation backed by `mmap`, and
+//! optionally [`UffdRegion`](struct.UffdRegion.html), which is backed by the
+//! [`userfaultfd`](http://man7.org/linux/man-pages/man2/userfaultfd.2.html) feature available on
+//! newer Linux kernels ([see below](index.html#userfaultfd-backed-region)).
 //!
 //! - [`Limits`](struct.Limits.html): upper bounds for the resources a Lucet instance may
 //! consume. These may be larger or smaller than the limits described in the WebAssembly module
@@ -374,6 +377,16 @@
 //! this number could change between Lucet releases or even Rust compiler versions.
 //!
 //! [default-sigstack-size]: constant.DEFAULT_SIGNAL_STACK_SIZE.html
+//!
+//! ## `userfaultfd`-Backed Region
+//!
+//! [`UffdRegion`](struct.UffdRegion.html) is a [`Region`](trait.Region.html) backed by the
+//! [`userfaultfd`](http://man7.org/linux/man-pages/man2/userfaultfd.2.html) feature available in
+//! newer Linux kernels. It allows Lucet instances to lazily copy in the initial heap contents of an
+//! `Instance`, reducing startup time. Instance stack pages can also be lazily initialized, reducing
+//! the memory footprint of instances that only use a small portion of their available stack space.
+//!
+//! To use `UffdRegion`, enable the `uffd` Cargo feature, which is off by default.
 
 #![deny(bare_trait_objects)]
 

--- a/lucet-runtime/src/lib.rs
+++ b/lucet-runtime/src/lib.rs
@@ -386,7 +386,14 @@
 //! `Instance`, reducing startup time. Instance stack pages can also be lazily initialized, reducing
 //! the memory footprint of instances that only use a small portion of their available stack space.
 //!
-//! To use `UffdRegion`, enable the `uffd` Cargo feature, which is off by default.
+//! `UffdRegion` is enabled by default on Linux platforms, but can be disabled by disabling default
+//! features for this crate and `lucet-runtime-internals`:
+//!
+//! ```toml
+//! [dependencies]
+//! lucet-runtime = { version = "0.6.1", default-features = false }
+//! lucet-runtime-internals = { version = "0.6.1", default-features = false }
+//! ```
 
 #![deny(bare_trait_objects)]
 
@@ -410,7 +417,7 @@ pub use lucet_runtime_internals::instance::{
 pub use lucet_runtime_internals::lucet_hostcalls;
 pub use lucet_runtime_internals::module::{DlModule, Module};
 pub use lucet_runtime_internals::region::mmap::MmapRegion;
-#[cfg(feature = "uffd")]
+#[cfg(all(target_os = "linux", feature = "uffd"))]
 pub use lucet_runtime_internals::region::uffd::UffdRegion;
 pub use lucet_runtime_internals::region::{InstanceBuilder, Region, RegionCreate};
 pub use lucet_runtime_internals::val::{UntypedRetVal, Val};

--- a/lucet-runtime/src/lib.rs
+++ b/lucet-runtime/src/lib.rs
@@ -418,7 +418,9 @@ pub use lucet_runtime_internals::lucet_hostcalls;
 pub use lucet_runtime_internals::module::{DlModule, Module};
 pub use lucet_runtime_internals::region::mmap::MmapRegion;
 #[cfg(all(target_os = "linux", feature = "uffd"))]
-pub use lucet_runtime_internals::region::uffd::{DefaultUffdStrategy, UffdRegion, UffdStrategy};
+pub use lucet_runtime_internals::region::uffd::{
+    HostPageSizedUffdStrategy, UffdRegion, UffdStrategy, WasmPageSizedUffdStrategy,
+};
 pub use lucet_runtime_internals::region::{InstanceBuilder, Region, RegionCreate};
 pub use lucet_runtime_internals::val::{UntypedRetVal, Val};
 pub use lucet_runtime_internals::{lucet_hostcall, lucet_hostcall_terminate, WASM_PAGE_SIZE};

--- a/lucet-runtime/src/lib.rs
+++ b/lucet-runtime/src/lib.rs
@@ -397,6 +397,7 @@ pub use lucet_runtime_internals::instance::{
 pub use lucet_runtime_internals::lucet_hostcalls;
 pub use lucet_runtime_internals::module::{DlModule, Module};
 pub use lucet_runtime_internals::region::mmap::MmapRegion;
+#[cfg(feature = "uffd")]
 pub use lucet_runtime_internals::region::uffd::UffdRegion;
 pub use lucet_runtime_internals::region::{InstanceBuilder, Region, RegionCreate};
 pub use lucet_runtime_internals::val::{UntypedRetVal, Val};

--- a/lucet-runtime/src/lib.rs
+++ b/lucet-runtime/src/lib.rs
@@ -418,7 +418,7 @@ pub use lucet_runtime_internals::lucet_hostcalls;
 pub use lucet_runtime_internals::module::{DlModule, Module};
 pub use lucet_runtime_internals::region::mmap::MmapRegion;
 #[cfg(all(target_os = "linux", feature = "uffd"))]
-pub use lucet_runtime_internals::region::uffd::UffdRegion;
+pub use lucet_runtime_internals::region::uffd::{DefaultUffdStrategy, UffdRegion, UffdStrategy};
 pub use lucet_runtime_internals::region::{InstanceBuilder, Region, RegionCreate};
 pub use lucet_runtime_internals::val::{UntypedRetVal, Val};
 pub use lucet_runtime_internals::{lucet_hostcall, lucet_hostcall_terminate, WASM_PAGE_SIZE};

--- a/lucet-runtime/src/lib.rs
+++ b/lucet-runtime/src/lib.rs
@@ -397,6 +397,7 @@ pub use lucet_runtime_internals::instance::{
 pub use lucet_runtime_internals::lucet_hostcalls;
 pub use lucet_runtime_internals::module::{DlModule, Module};
 pub use lucet_runtime_internals::region::mmap::MmapRegion;
+pub use lucet_runtime_internals::region::uffd::UffdRegion;
 pub use lucet_runtime_internals::region::{InstanceBuilder, Region, RegionCreate};
 pub use lucet_runtime_internals::val::{UntypedRetVal, Val};
 pub use lucet_runtime_internals::{lucet_hostcall, lucet_hostcall_terminate, WASM_PAGE_SIZE};

--- a/lucet-runtime/tests/c_api.c
+++ b/lucet-runtime/tests/c_api.c
@@ -3,7 +3,7 @@
 
 #include "lucet.h"
 
-bool lucet_runtime_test_expand_heap(struct lucet_dl_module *mod)
+bool lucet_runtime_test_mmap_expand_heap(struct lucet_dl_module *mod)
 {
     struct lucet_region *     region;
     struct lucet_alloc_limits limits = {
@@ -17,6 +17,54 @@ bool lucet_runtime_test_expand_heap(struct lucet_dl_module *mod)
     enum lucet_error err;
 
     err = lucet_mmap_region_create(1, &limits, &region);
+    if (err != lucet_error_ok) {
+        fprintf(stderr, "failed to create region\n");
+        goto fail1;
+    }
+
+    struct lucet_instance *inst;
+    err = lucet_region_new_instance(region, mod, &inst);
+    if (err != lucet_error_ok) {
+        fprintf(stderr, "failed to create instance\n");
+        goto fail2;
+    }
+
+    uint32_t newpage_start;
+    err = lucet_instance_grow_heap(inst, 1, &newpage_start);
+    if (err != lucet_error_ok) {
+        fprintf(stderr, "failed to grow memory\n");
+        goto fail3;
+    }
+
+    lucet_instance_release(inst);
+    lucet_region_release(region);
+    lucet_dl_module_release(mod);
+
+    return true;
+
+fail3:
+    lucet_instance_release(inst);
+fail2:
+    lucet_region_release(region);
+fail1:
+    lucet_dl_module_release(mod);
+    return false;
+}
+
+bool lucet_runtime_test_uffd_expand_heap(struct lucet_dl_module *mod)
+{
+    struct lucet_region *     region;
+    struct lucet_alloc_limits limits = {
+        .heap_memory_size        = 4 * 1024 * 1024,
+        .heap_address_space_size = 8 * 1024 * 1024,
+        .stack_size              = 64 * 1024,
+        .globals_size            = 4096,
+        .signal_stack_size       = 12 * 1024,
+    };
+
+    enum lucet_error err;
+
+    err = lucet_uffd_region_create(1, &limits, &region);
     if (err != lucet_error_ok) {
         fprintf(stderr, "failed to create region\n");
         goto fail1;

--- a/lucet-runtime/tests/c_api.c
+++ b/lucet-runtime/tests/c_api.c
@@ -65,7 +65,10 @@ bool lucet_runtime_test_uffd_expand_heap(struct lucet_dl_module *mod)
     enum lucet_error err;
 
     err = lucet_uffd_region_create(1, &limits, &region);
-    if (err != lucet_error_ok) {
+    if (err == lucet_error_unsupported) {
+        fprintf(stderr, "UFFD not supported in this build\n");
+        return true;
+    } else if (err != lucet_error_ok) {
         fprintf(stderr, "failed to create region\n");
         goto fail1;
     }

--- a/lucet-runtime/tests/entrypoint.rs
+++ b/lucet-runtime/tests/entrypoint.rs
@@ -1,7 +1,7 @@
 use lucet_runtime_tests::entrypoint_tests;
 
 cfg_if::cfg_if! {
-    if #[cfg(feature = "uffd")] {
+    if #[cfg(all(target_os = "linux", feature = "uffd"))] {
         entrypoint_tests!(
             mmap => lucet_runtime::MmapRegion,
             uffd => lucet_runtime::UffdRegion

--- a/lucet-runtime/tests/entrypoint.rs
+++ b/lucet-runtime/tests/entrypoint.rs
@@ -1,6 +1,12 @@
 use lucet_runtime_tests::entrypoint_tests;
 
-entrypoint_tests!(
-    mmap => lucet_runtime::MmapRegion,
-    uffd => lucet_runtime::UffdRegion
-);
+cfg_if::cfg_if! {
+    if #[cfg(feature = "uffd")] {
+        entrypoint_tests!(
+            mmap => lucet_runtime::MmapRegion,
+            uffd => lucet_runtime::UffdRegion
+        );
+    } else {
+        entrypoint_tests!(mmap => lucet_runtime::MmapRegion);
+    }
+}

--- a/lucet-runtime/tests/entrypoint.rs
+++ b/lucet-runtime/tests/entrypoint.rs
@@ -1,3 +1,6 @@
 use lucet_runtime_tests::entrypoint_tests;
 
-entrypoint_tests!(lucet_runtime::MmapRegion);
+entrypoint_tests!(
+    lucet_runtime::MmapRegion => mmap,
+    lucet_runtime::UffdRegion => uffd
+);

--- a/lucet-runtime/tests/entrypoint.rs
+++ b/lucet-runtime/tests/entrypoint.rs
@@ -1,6 +1,6 @@
 use lucet_runtime_tests::entrypoint_tests;
 
 entrypoint_tests!(
-    lucet_runtime::MmapRegion => mmap,
-    lucet_runtime::UffdRegion => uffd
+    mmap => lucet_runtime::MmapRegion,
+    uffd => lucet_runtime::UffdRegion
 );

--- a/lucet-runtime/tests/globals.rs
+++ b/lucet-runtime/tests/globals.rs
@@ -1,7 +1,7 @@
 use lucet_runtime_tests::globals_tests;
 
 cfg_if::cfg_if! {
-    if #[cfg(feature = "uffd")] {
+    if #[cfg(all(target_os = "linux", feature = "uffd"))] {
         globals_tests!(
             mmap => lucet_runtime::MmapRegion,
             uffd => lucet_runtime::UffdRegion

--- a/lucet-runtime/tests/globals.rs
+++ b/lucet-runtime/tests/globals.rs
@@ -1,6 +1,12 @@
 use lucet_runtime_tests::globals_tests;
 
-globals_tests!(
-    mmap => lucet_runtime::MmapRegion,
-    uffd => lucet_runtime::UffdRegion
-);
+cfg_if::cfg_if! {
+    if #[cfg(feature = "uffd")] {
+        globals_tests!(
+            mmap => lucet_runtime::MmapRegion,
+            uffd => lucet_runtime::UffdRegion
+        );
+    } else {
+        globals_tests!(mmap => lucet_runtime::MmapRegion);
+    }
+}

--- a/lucet-runtime/tests/globals.rs
+++ b/lucet-runtime/tests/globals.rs
@@ -1,3 +1,6 @@
 use lucet_runtime_tests::globals_tests;
 
-globals_tests!(lucet_runtime::MmapRegion);
+globals_tests!(
+    mmap => lucet_runtime::MmapRegion,
+    uffd => lucet_runtime::UffdRegion
+);

--- a/lucet-runtime/tests/guest_fault.rs
+++ b/lucet-runtime/tests/guest_fault.rs
@@ -2,4 +2,7 @@ use lucet_runtime_tests::{guest_fault_common_defs, guest_fault_tests};
 
 guest_fault_common_defs!();
 
-guest_fault_tests!(lucet_runtime::MmapRegion);
+guest_fault_tests!(
+    mmap => lucet_runtime::MmapRegion,
+    uffd => lucet_runtime::UffdRegion
+);

--- a/lucet-runtime/tests/guest_fault.rs
+++ b/lucet-runtime/tests/guest_fault.rs
@@ -3,7 +3,7 @@ use lucet_runtime_tests::{guest_fault_common_defs, guest_fault_tests};
 guest_fault_common_defs!();
 
 cfg_if::cfg_if! {
-    if #[cfg(feature = "uffd")] {
+    if #[cfg(all(target_os = "linux", feature = "uffd"))] {
         guest_fault_tests!(
             mmap => lucet_runtime::MmapRegion,
             uffd => lucet_runtime::UffdRegion

--- a/lucet-runtime/tests/guest_fault.rs
+++ b/lucet-runtime/tests/guest_fault.rs
@@ -2,7 +2,13 @@ use lucet_runtime_tests::{guest_fault_common_defs, guest_fault_tests};
 
 guest_fault_common_defs!();
 
-guest_fault_tests!(
-    mmap => lucet_runtime::MmapRegion,
-    uffd => lucet_runtime::UffdRegion
-);
+cfg_if::cfg_if! {
+    if #[cfg(feature = "uffd")] {
+        guest_fault_tests!(
+            mmap => lucet_runtime::MmapRegion,
+            uffd => lucet_runtime::UffdRegion
+        );
+    } else {
+        guest_fault_tests!(mmap => lucet_runtime::MmapRegion);
+    }
+}

--- a/lucet-runtime/tests/host.rs
+++ b/lucet-runtime/tests/host.rs
@@ -1,7 +1,7 @@
 use lucet_runtime_tests::host_tests;
 
 cfg_if::cfg_if! {
-    if #[cfg(feature = "uffd")] {
+    if #[cfg(all(target_os = "linux", feature = "uffd"))] {
         host_tests!(
             mmap => lucet_runtime::MmapRegion,
             uffd => lucet_runtime::UffdRegion

--- a/lucet-runtime/tests/host.rs
+++ b/lucet-runtime/tests/host.rs
@@ -1,3 +1,6 @@
 use lucet_runtime_tests::host_tests;
 
-host_tests!(lucet_runtime::MmapRegion);
+host_tests!(
+    mmap => lucet_runtime::MmapRegion,
+    uffd => lucet_runtime::UffdRegion
+);

--- a/lucet-runtime/tests/host.rs
+++ b/lucet-runtime/tests/host.rs
@@ -1,6 +1,12 @@
 use lucet_runtime_tests::host_tests;
 
-host_tests!(
-    mmap => lucet_runtime::MmapRegion,
-    uffd => lucet_runtime::UffdRegion
-);
+cfg_if::cfg_if! {
+    if #[cfg(feature = "uffd")] {
+        host_tests!(
+            mmap => lucet_runtime::MmapRegion,
+            uffd => lucet_runtime::UffdRegion
+        );
+    } else {
+        host_tests!(mmap => lucet_runtime::MmapRegion);
+    }
+}

--- a/lucet-runtime/tests/memory.rs
+++ b/lucet-runtime/tests/memory.rs
@@ -1,7 +1,7 @@
 use lucet_runtime_tests::memory_tests;
 
 cfg_if::cfg_if! {
-    if #[cfg(feature = "uffd")] {
+    if #[cfg(all(target_os = "linux", feature = "uffd"))] {
         memory_tests!(
             mmap => lucet_runtime::MmapRegion,
             uffd => lucet_runtime::UffdRegion

--- a/lucet-runtime/tests/memory.rs
+++ b/lucet-runtime/tests/memory.rs
@@ -1,6 +1,12 @@
 use lucet_runtime_tests::memory_tests;
 
-memory_tests!(
-    mmap => lucet_runtime::MmapRegion,
-    uffd => lucet_runtime::UffdRegion
-);
+cfg_if::cfg_if! {
+    if #[cfg(feature = "uffd")] {
+        memory_tests!(
+            mmap => lucet_runtime::MmapRegion,
+            uffd => lucet_runtime::UffdRegion
+        );
+    } else {
+        memory_tests!(mmap => lucet_runtime::MmapRegion);
+    }
+}

--- a/lucet-runtime/tests/memory.rs
+++ b/lucet-runtime/tests/memory.rs
@@ -1,3 +1,6 @@
 use lucet_runtime_tests::memory_tests;
 
-memory_tests!(lucet_runtime::MmapRegion);
+memory_tests!(
+    mmap => lucet_runtime::MmapRegion,
+    uffd => lucet_runtime::UffdRegion
+);

--- a/lucet-runtime/tests/memory.rs
+++ b/lucet-runtime/tests/memory.rs
@@ -10,3 +10,58 @@ cfg_if::cfg_if! {
         memory_tests!(mmap => lucet_runtime::MmapRegion);
     }
 }
+
+#[cfg(all(target_os = "linux", feature = "uffd"))]
+mod uffd_specific {
+    use libc::{c_void, mincore};
+    use lucet_runtime::{Limits, Region};
+    use lucet_runtime::{UffdRegion, WasmPageSizedUffdStrategy};
+    use lucet_runtime_tests::build::test_module_wasm;
+
+    #[test]
+    fn ensure_linked() {
+        lucet_runtime::lucet_internal_ensure_linked();
+    }
+    #[test]
+    fn lazy_memory() {
+        let module = test_module_wasm("memory", "uffd_memory.wat")
+            .expect("compile and load uffd_memory.wasm");
+        let region = UffdRegion::create(1, &Limits::default(), WasmPageSizedUffdStrategy {})
+            .expect("region can be created");
+        let mut inst = region
+            .new_instance(module)
+            .expect("instance can be created");
+
+        inst.run("main", &[]).expect("instance runs");
+
+        let heap = inst.heap_u32();
+        // guest puts 1 at the start of the second page
+        assert_eq!(heap[16384], 1);
+        // guest then puts 2 at the start of the fourth page
+        assert_eq!(heap[49152], 2);
+
+        const HEAP_LEN: usize = 4 * 65536; // 4 WebAssembly Pages
+        const VEC_LEN: usize = HEAP_LEN / 4096; // 1 u8 per host page
+
+        let mut result_vec: [u8; VEC_LEN] = [0; VEC_LEN];
+
+        // We use `mincore` here to determine which pages of the heap actually
+        // exist in memory, and which are just empty virtual pages.
+        let result = unsafe {
+            mincore(
+                inst.heap_mut().as_mut_ptr() as *mut c_void,
+                HEAP_LEN,
+                result_vec.as_mut_ptr(),
+            )
+        };
+        assert_eq!(result, 0);
+
+        // As noted above, the instance wrote to the second and fourth wasm
+        // pages. So, host pages 16-31 and 48-63 should be mapped to memory
+        // and nothing else should be.
+        assert_eq!(&result_vec[0..16], &[0; 16]);
+        assert_eq!(&result_vec[16..32], &[1; 16]);
+        assert_eq!(&result_vec[32..48], &[0; 16]);
+        assert_eq!(&result_vec[48..64], &[1; 16]);
+    }
+}

--- a/lucet-runtime/tests/stack.rs
+++ b/lucet-runtime/tests/stack.rs
@@ -1,7 +1,7 @@
 use lucet_runtime_tests::stack_tests;
 
 cfg_if::cfg_if! {
-    if #[cfg(feature = "uffd")] {
+    if #[cfg(all(target_os = "linux", feature = "uffd"))] {
         stack_tests!(
             mmap => lucet_runtime::MmapRegion,
             uffd => lucet_runtime::UffdRegion

--- a/lucet-runtime/tests/stack.rs
+++ b/lucet-runtime/tests/stack.rs
@@ -1,6 +1,12 @@
 use lucet_runtime_tests::stack_tests;
 
-stack_tests!(
-    mmap => lucet_runtime::MmapRegion,
-    uffd => lucet_runtime::UffdRegion
-);
+cfg_if::cfg_if! {
+    if #[cfg(feature = "uffd")] {
+        stack_tests!(
+            mmap => lucet_runtime::MmapRegion,
+            uffd => lucet_runtime::UffdRegion
+        );
+    } else {
+        stack_tests!(mmap => lucet_runtime::MmapRegion);
+    }
+}

--- a/lucet-runtime/tests/stack.rs
+++ b/lucet-runtime/tests/stack.rs
@@ -1,3 +1,6 @@
 use lucet_runtime_tests::stack_tests;
 
-stack_tests!(lucet_runtime::MmapRegion);
+stack_tests!(
+    mmap => lucet_runtime::MmapRegion,
+    uffd => lucet_runtime::UffdRegion
+);

--- a/lucet-runtime/tests/start.rs
+++ b/lucet-runtime/tests/start.rs
@@ -1,7 +1,7 @@
 use lucet_runtime_tests::start_tests;
 
 cfg_if::cfg_if! {
-    if #[cfg(feature = "uffd")] {
+    if #[cfg(all(target_os = "linux", feature = "uffd"))] {
         start_tests!(
             mmap => lucet_runtime::MmapRegion,
             uffd => lucet_runtime::UffdRegion

--- a/lucet-runtime/tests/start.rs
+++ b/lucet-runtime/tests/start.rs
@@ -1,6 +1,12 @@
 use lucet_runtime_tests::start_tests;
 
-start_tests!(
-    mmap => lucet_runtime::MmapRegion,
-    uffd => lucet_runtime::UffdRegion
-);
+cfg_if::cfg_if! {
+    if #[cfg(feature = "uffd")] {
+        start_tests!(
+            mmap => lucet_runtime::MmapRegion,
+            uffd => lucet_runtime::UffdRegion
+        );
+    } else {
+        start_tests!(mmap => lucet_runtime::MmapRegion);
+    }
+}

--- a/lucet-runtime/tests/start.rs
+++ b/lucet-runtime/tests/start.rs
@@ -1,3 +1,6 @@
 use lucet_runtime_tests::start_tests;
 
-start_tests!(lucet_runtime::MmapRegion);
+start_tests!(
+    mmap => lucet_runtime::MmapRegion,
+    uffd => lucet_runtime::UffdRegion
+);

--- a/lucet-runtime/tests/strcmp.rs
+++ b/lucet-runtime/tests/strcmp.rs
@@ -1,7 +1,7 @@
 use lucet_runtime_tests::strcmp_tests;
 
 cfg_if::cfg_if! {
-    if #[cfg(feature = "uffd")] {
+    if #[cfg(all(target_os = "linux", feature = "uffd"))] {
         strcmp_tests!(
             mmap => lucet_runtime::MmapRegion,
             uffd => lucet_runtime::UffdRegion

--- a/lucet-runtime/tests/strcmp.rs
+++ b/lucet-runtime/tests/strcmp.rs
@@ -1,3 +1,6 @@
 use lucet_runtime_tests::strcmp_tests;
 
-strcmp_tests!(lucet_runtime::MmapRegion);
+strcmp_tests!(
+    mmap => lucet_runtime::MmapRegion,
+    uffd => lucet_runtime::UffdRegion
+);

--- a/lucet-runtime/tests/strcmp.rs
+++ b/lucet-runtime/tests/strcmp.rs
@@ -1,6 +1,12 @@
 use lucet_runtime_tests::strcmp_tests;
 
-strcmp_tests!(
-    mmap => lucet_runtime::MmapRegion,
-    uffd => lucet_runtime::UffdRegion
-);
+cfg_if::cfg_if! {
+    if #[cfg(feature = "uffd")] {
+        strcmp_tests!(
+            mmap => lucet_runtime::MmapRegion,
+            uffd => lucet_runtime::UffdRegion
+        );
+    } else {
+        strcmp_tests!(mmap => lucet_runtime::MmapRegion);
+    }
+}


### PR DESCRIPTION
This adds a UffdStrategy trait to allow users of UffdRegion to configure the way faults are handled.

This will be important especially to Lucet users who have highly concurrent applications and potentially large linear memories. Uffd in its most naive form is likely to be slower than the Mmap region because of the additional work done to shunt faults back into userspace, and the reaction to those faults over to the kernel.

This can be dealt with by being smarter about how those faults are handled. For instance, work can be batched up. Instead of copying one host page per fault, one could copy a batch of them. This doesn't implement that, but does provide the facilities to make it possible.