### PR TITLE
install: also install liblucet_wasi

### DIFF
--- a/helpers/install.sh
+++ b/helpers/install.sh
@@ -39,7 +39,7 @@ else
 fi
 
 BINS="lucet-objdump lucet-validate lucet-wasi lucetc sightglass spec-test wasmonkey"
-LIBS="liblucet_runtime.${DYLIB_SUFFIX}"
+LIBS="liblucet_runtime.${DYLIB_SUFFIX} liblucet_wasi.${DYLIB_SUFFIX}"
 DOCS="sightglass/README.md"
 BUNDLE_DOCS="README.md"
 


### PR DESCRIPTION
The documentation on [lucet-wasi](https://bytecodealliance.github.io/lucet/lucet-wasi.html) specifies:

> It can be used as a library to support WASI in another application, or as an executable, lucet-wasi

However, liblucet_wasi isn't available as a library in `$LUCET_PREFIX/lib`.

Is this an overlook?