### PR TITLE
⭕ Add an empty circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,13 @@
+version: 2.1
+jobs:
+  test:
+    machine:
+      image: ubuntu-1604:202004-01
+    steps:
+      - checkout
+
+workflows:
+  version: 2.1
+  build_and_test:
+    jobs:
+      - test


### PR DESCRIPTION
We currently are building up our real config on the `circleci-project-setup` branch, but adding this empty config will make the Github checks interface stop showing a failure due to a missing config on `master`.