### PR TITLE
lucet-wiggle: only borrow heap inside GuestMemory::base

### DIFF
--- a/lucet-wiggle/src/lib.rs
+++ b/lucet-wiggle/src/lib.rs
@@ -11,25 +11,23 @@ pub mod generate {
 
 pub mod runtime {
     use lucet_runtime::vmctx::Vmctx;
-    use std::cell::RefMut;
     use wiggle::GuestMemory;
 
     pub struct LucetMemory<'a> {
-        mem: RefMut<'a, [u8]>,
+        vmctx: &'a Vmctx,
     }
 
     impl<'a> LucetMemory<'a> {
-        pub fn new(vmctx: &Vmctx) -> LucetMemory {
-            LucetMemory {
-                mem: vmctx.heap_mut(),
-            }
+        pub fn new(vmctx: &'a Vmctx) -> LucetMemory {
+            LucetMemory { vmctx }
         }
     }
 
     unsafe impl<'a> GuestMemory for LucetMemory<'a> {
         fn base(&self) -> (*mut u8, u32) {
-            let len = self.mem.len() as u32;
-            let ptr = self.mem.as_ptr();
+            let mem = self.vmctx.heap_mut();
+            let len = mem.len() as u32;
+            let ptr = mem.as_ptr();
             (ptr as *mut u8, len)
         }
     }


### PR DESCRIPTION
Changes Wiggle's borrow of vmctx's heap to be just at the use-site of a GuestPtr.

The GuestMemory::base function, which is only called by GuestMemory::validate_size_align, is in turn used by `GuestPtr::as_raw`, `GuestType::read`, and `GuestType::write`. The latter two only keep the resulting pointer for the lifetime of their stack frame. GuestPtr::as_raw does keep the resulting pointer alive as part of the `*mut [T]` returned, so that borrow *could* possibly be alive across the yield, though the current safety properties in the docs explicitly say it cannot be.

To resolve that safety hole, we need to move to a whole-hostcall GuestBorrows as we discussed on the call with Alex on monday. Will work on that as a subsequent PR upstream. For now, this means we can yield in wiggle without an unsafe `as_mut` on vmctx, which is brilliant.