### PR TITLE
⭕ Add full CircleCI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,221 @@
+# https://circleci.com/docs/2.0/configuration-reference/
+
 version: 2.1
-jobs:
-  test:
+
+executors:
+  linux:
     machine:
-      image: ubuntu-1604:202004-01
+      image: "ubuntu-1604:202004-01"
+      # This is an expensive option! Do not use this machine type to run a large number of `jobs` in
+      # parallel, otherwise we'll get dinged for each one. It is usually not much slower to add a
+      # new step to the existing job commands.
+      docker_layer_caching: true
+    resource_class: xlarge
+  macos:
+    macos:
+      # Latest non-beta as of this writing.
+      xcode: "11.4.1"
+    resource_class: large
+
+jobs:
+  ##################################
+  # Linux `make test-full` targets #
+  ##################################
+  full_ci_branch:
+    executor: linux
     steps:
-      - checkout
+      - full_ci:
+          cache_target: true
+
+  full_ci_master:
+    executor: linux
+    steps:
+      - full_ci:
+          cache_target: false
+
+  ################################
+  # macOS `make test-ci` targets #
+  ################################
+  mac_ci_branch:
+    executor: macos
+    steps:
+      - mac_ci:
+          cache_target: true
+
+  mac_ci_master:
+    executor: macos
+    steps:
+      - mac_ci:
+          cache_target: false
 
 workflows:
-  version: 2.1
-  build_and_test:
+  build:
     jobs:
-      - test
+      ##################################
+      # Linux `make test-full` targets #
+      ##################################
+      - full_ci_branch:
+          filters:
+            branches:
+              ignore: master
+      - full_ci_master:
+          filters:
+            branches:
+              only: master
+      ################################
+      # macOS `make test-ci` targets #
+      ################################
+      - mac_ci_branch:
+          filters:
+            branches:
+              ignore: master
+      - mac_ci_master:
+          filters:
+            branches:
+              only: master
+
+commands:
+  full_ci:
+    description: "Run the full CI for Lucet"
+    parameters:
+      cache_target:
+        type: boolean
+        description: "If `true`, the target/ directory will be cached between builds"
+    steps:
+      - checkout_recursively
+      - when:
+          condition: << parameters.cache_target >>
+          steps:
+            - restore_cache:
+                keys:
+                  # These keys match by prefix, and the topmost matching pattern wins. Arranging the
+                  # patterns like this means that we prefer to restore cache from:
+                  #
+                  # 1. A Linux cache built on a matching branch name with a matching `Cargo.lock` checksum
+                  # 2. A Linux cache built on a matching branch name with any `Cargo.lock` checksum
+                  # 3. Any Linux cache
+                  #
+                  # The hope is that even if some of the dependencies change between branches and
+                  # revisions, that enough of the slow-changing dependencies will remain static that
+                  # Cargo won't have to rebuild them.
+                  - target_dir-linux-{{ .Branch }}-{{ checksum "Cargo.lock" }}
+                  - target_dir-linux-{{ .Branch }}-
+                  - target_dir-linux-
+      - build_container
+      - make_in_container:
+          target: test-full
+      - make_in_container:
+          target: test-release test-release-executables
+      - ensure_sources_unchanged
+      - when:
+          condition: << parameters.cache_target >>
+          steps:
+            - save_cache:
+                key: target_dir-linux-{{ .Branch }}-{{ checksum "Cargo.lock" }}
+                paths:
+                  - "target"
+
+  mac_ci:
+    description: "Run a subset of CI for Lucet on Mac"
+    parameters:
+      cache_target:
+        type: boolean
+        description: "If `true`, the target/ directory will be cached between builds"
+    steps:
+      - checkout_recursively
+      - when:
+          condition: << parameters.cache_target >>
+          steps:
+            - restore_cache:
+                keys:
+                  # These keys match by prefix, and the topmost matching pattern wins. Arranging the
+                  # patterns like this means that we prefer to restore cache from:
+                  #
+                  # 1. A macOS cache built on a matching branch name with a matching `Cargo.lock` checksum
+                  # 2. A macOS cache built on a matching branch name with any `Cargo.lock` checksum
+                  # 3. Any macOS cache
+                  #
+                  # The hope is that even if some of the dependencies change between branches and
+                  # revisions, that enough of the slow-changing dependencies will remain static that
+                  # Cargo won't have to rebuild them.
+                  - target_dir-macos-{{ .Branch }}-{{ checksum "Cargo.lock" }}
+                  - target_dir-macos-{{ .Branch }}-
+                  - target_dir-macos-
+      - run:
+          name: "Install Homebrew dependencies"
+          command: |
+            set -x
+            export HOMEBREW_NO_AUTO_UPDATE=1
+            export HOMEBREW_NO_INSTALL_CLEANUP=1
+            brew install cmake
+      - run:
+          name: "Install Rust"
+          command: |
+            set -x
+            curl https://sh.rustup.rs | sh -s -- --default-toolchain 1.43.1 -y
+            source $HOME/.cargo/env
+            rustup component add rustfmt
+            rustup target add wasm32-wasi
+      - run:
+          name: "Install wasi-sdk"
+          command: |
+            set -x
+            curl -sS -L -O https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-10/wasi-sdk-10.0-macos.tar.gz
+            tar xf wasi-sdk-10.0-macos.tar.gz
+            sudo mkdir -p /opt/wasi-sdk
+            sudo mv wasi-sdk-10.0/* /opt/wasi-sdk/
+      - run:
+          name: "Make target: test-ci"
+          command: |
+            set -x
+            source $HOME/.cargo/env
+            make test-ci
+      - ensure_sources_unchanged
+      - when:
+          condition: << parameters.cache_target >>
+          steps:
+            - save_cache:
+                key: target_dir-macos-{{ .Branch }}-{{ checksum "Cargo.lock" }}
+                paths:
+                  - "target"
+
+  checkout_recursively:
+    description: "Check out the git repository, and recursively initialize its submodules"
+    steps:
+      - checkout
+      - run:
+          name: "Sync and recursively update submodules"
+          command: |
+            set -x
+            git submodule sync
+            git submodule update --init --recursive
+
+  build_container:
+    description: "Build the Lucet development/CI Docker image"
+    steps:
+      - run:
+          name: "Build Docker image"
+          command: |
+            set -x
+            docker build -t lucet .
+
+  make_in_container:
+    description: "Run a make target in the Lucet development/CI Docker image"
+    parameters:
+      target:
+        type: string
+    steps:
+      - run:
+          name: "Run Make target in Docker: << parameters.target >>"
+          command: |
+            set -x
+            docker run --privileged -v `pwd`:/lucet -it lucet /bin/bash -c "make -C /lucet << parameters.target >>"
+
+  ensure_sources_unchanged:
+    description: "Make sure that previous steps did not change the source files from git"
+    steps:
+      - run:
+          name: "Ensure sources are unchanged"
+          command: |
+            set -x
+            git diff --exit-code

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,25 +87,6 @@ jobs:
     - name: Ensure testing did not change sources
       run: git diff --exit-code
 
-
-  package:
-    name: Package
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v1
-      with:
-        submodules: 'recursive'
-
-    # Testing uses the development environment Docker container.
-    # This action builds the container and executes the test suite inside it.
-    - uses: ./.github/actions/test
-      with:
-        target: package
-
-    - name: Ensure testing did not change sources
-      run: git diff --exit-code
-
-
   rustfmt:
     name: Rustfmt
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN rustup component add rustfmt
 RUN rustup target add wasm32-wasi
 
 # Optional additional Rust programs
-RUN cargo install --debug rsign2 cargo-deb
+RUN cargo install --debug rsign2 cargo-audit mdbook
 
 RUN curl -sSLO https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-10/wasi-sdk_10.0_amd64.deb \
 	&& dpkg -i wasi-sdk_10.0_amd64.deb && rm -f wasi-sdk_10.0_amd64.deb
@@ -46,10 +46,8 @@ ENV WASI_SDK=/opt/wasi-sdk
 # optional install of wasm-opt and wasm-reduce for fuzzing and benchmarking
 ENV BINARYEN_DIR=/opt/binaryen
 ENV BINARYEN_VERSION=86
-RUN curl -sS -L "https://github.com/WebAssembly/binaryen/archive/version_${BINARYEN_VERSION}.tar.gz" | tar xzf - && \
-    mkdir -p binaryen-build && ( cd binaryen-build && cmake "../binaryen-version_${BINARYEN_VERSION}" && \
-    make wasm-opt wasm-reduce ) && \
+RUN curl -sS -L "https://github.com/WebAssembly/binaryen/releases/download/version_${BINARYEN_VERSION}/binaryen-version_${BINARYEN_VERSION}-x86_64-linux.tar.gz" | tar xzf - && \
     install -d -v "${BINARYEN_DIR}/bin" && \
-    for tool in wasm-opt wasm-reduce; do install -v "binaryen-build/bin/${tool}" "${BINARYEN_DIR}/bin/"; done && \
-    rm -fr binaryen-build binaryen-version_${BINARYEN_VERSION}
-ENV PATH=$BINARYEN_DIR:$PATH
+    for tool in wasm-opt wasm-reduce; do install -v "binaryen-version_${BINARYEN_VERSION}/${tool}" "${BINARYEN_DIR}/bin/"; done && \
+    rm -fr binaryen-version_${BINARYEN_VERSION}
+ENV PATH=$BINARYEN_DIR/bin:$PATH

--- a/Makefile
+++ b/Makefile
@@ -38,9 +38,9 @@ test-release:
 
 .PHONY: test-release-executables
 test-release-executables:
-	cargo build --release
-	helpers/lucet-toolchain-tests/signature.sh
-	helpers/lucet-toolchain-tests/objdump.sh
+	cargo build --release -p lucetc -p lucet-wasi -p lucet-objdump
+	helpers/lucet-toolchain-tests/signature.sh release
+	helpers/lucet-toolchain-tests/objdump.sh release
 
 .PHONY: test-ci
 test-ci: test-packages test-objdump test-bitrot test-signature test-objdump

--- a/helpers/lucet-toolchain-tests/objdump.sh
+++ b/helpers/lucet-toolchain-tests/objdump.sh
@@ -1,21 +1,22 @@
 #! /bin/sh
 
+set -e
+set -x
+
 LUCET_DIR="."
 TMPDIR="$(mktemp -d)"
 
-if [ -x "${LUCET_DIR}/target/release/lucetc" ]; then
-    LUCETC="${LUCET_DIR}/target/release/lucetc"
-elif [ -x "${LUCET_DIR}/target/debug/lucetc" ]; then
-    LUCETC="${LUCET_DIR}/target/debug/lucetc"
+PROFILE="${1:-debug}"
+
+if [ -x "${LUCET_DIR}/target/${PROFILE}/lucetc" ]; then
+    LUCETC="${LUCET_DIR}/target/${PROFILE}/lucetc"
 else
     echo "lucetc not found" >&2
     exit 1
 fi
 
-if [ -x "${LUCET_DIR}/target/release/lucet-objdump" ]; then
-    LUCET_OBJDUMP="${LUCET_DIR}/target/release/lucet-objdump"
-elif [ -x "${LUCET_DIR}/target/debug/lucet-objdump" ]; then
-    LUCET_OBJDUMP="${LUCET_DIR}/target/debug/lucet-objdump"
+if [ -x "${LUCET_DIR}/target/${PROFILE}/lucet-objdump" ]; then
+    LUCET_OBJDUMP="${LUCET_DIR}/target/${PROFILE}/lucet-objdump"
 else
     echo "lucet-objdump not found" >&2
     exit 1

--- a/helpers/lucet-toolchain-tests/signature.sh
+++ b/helpers/lucet-toolchain-tests/signature.sh
@@ -1,21 +1,22 @@
 #! /bin/sh
 
+set -e
+set -x
+
 LUCET_DIR="."
 TMPDIR="$(mktemp -d)"
 
-if [ -x "${LUCET_DIR}/target/release/lucetc" ]; then
-    LUCETC="${LUCET_DIR}/target/release/lucetc"
-elif [ -x "${LUCET_DIR}/target/debug/lucetc" ]; then
-    LUCETC="${LUCET_DIR}/target/debug/lucetc"
+PROFILE="${1:-debug}"
+
+if [ -x "${LUCET_DIR}/target/${PROFILE}/lucetc" ]; then
+    LUCETC="${LUCET_DIR}/target/${PROFILE}/lucetc"
 else
     echo "lucetc not found" >&2
     exit 1
 fi
 
-if [ -x "${LUCET_DIR}/target/release/lucet-wasi" ]; then
-    LUCET_WASI="${LUCET_DIR}/target/release/lucet-wasi"
-elif [ -x "${LUCET_DIR}/target/debug/lucet-wasi" ]; then
-    LUCET_WASI="${LUCET_DIR}/target/debug/lucet-wasi"
+if [ -x "${LUCET_DIR}/target/${PROFILE}/lucet-wasi" ]; then
+    LUCET_WASI="${LUCET_DIR}/target/${PROFILE}/lucet-wasi"
 else
     echo "lucet-wasi not found" >&2
     exit 1


### PR DESCRIPTION
This patch ports our existing Github Actions CI to CircleCI, which allows us to test programs that use the `userfaultfd` syscall on Linux. Also, we're paying CircleCI to use their big machines and Docker layer cache, so CI overall will be much faster.

A significant change from the Github Actions setup is to revert to a single build job, rather than having a proliferation of smaller jobs. The latter approach was necessary to achieve good performance with Actions, but the way CircleCI's Docker caching works, the single job is much more cost effective.

These jobs cache the Cargo-generated `/target` directory for branch builds, which substantially helps run times. Cargo is pretty aggressive about rebuilding when files, environment variables, or moon phases change, but the cache is completely disabled for `master` builds. This will help to catch any bugs that might arise only from a completely fresh build context.

This also makes a couple of tweaks to eliminate CI cruft:

- Download a binary distribution of binaryen rather than building it from scratch in the Docker image.

- Parameterize the binary test scripts (`signature.sh` and `objdump.sh`) by release mode, so that we can test both with the same `/target` populated.

- Stop testing the `cargo deb` packaging step, and remove the `cargo-deb` install from the Dockerfile. As far as we know, this packaging is not currently used by anyone.