### PR TITLE
Remove `lucet-runtime` from crates tested by GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,6 +55,8 @@ jobs:
 
   test_release:
     name: Test Release
+    env:
+      CRATES_NOT_TESTED: lucet-runtime lucet-spectest lucet-benchmarks lucet-runtime-example                                              
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
@@ -69,8 +71,7 @@ jobs:
 
     - name: Ensure testing did not change sources
       run: git diff --exit-code
-      env:
-        CRATES_NOT_TESTED: lucet-runtime lucet-spectest lucet-benchmarks lucet-runtime-example                                              
+
   test_release_executables:
     name: Test Release Executables
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,7 +69,8 @@ jobs:
 
     - name: Ensure testing did not change sources
       run: git diff --exit-code
-
+      env:
+	CRATES_NOT_TESTED: lucet-runtime lucet-spectest lucet-benchmarks lucet-runtime-example                                              
   test_release_executables:
     name: Test Release Executables
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,7 +70,7 @@ jobs:
     - name: Ensure testing did not change sources
       run: git diff --exit-code
       env:
-	CRATES_NOT_TESTED: lucet-runtime lucet-spectest lucet-benchmarks lucet-runtime-example                                              
+        CRATES_NOT_TESTED: lucet-runtime lucet-spectest lucet-benchmarks lucet-runtime-example                                              
   test_release_executables:
     name: Test Release Executables
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 export GUEST_MODULE_PREFIX:=$(abspath .)
 
-CRATES_NOT_TESTED = lucet-spectest lucet-benchmarks lucet-runtime-example
+CRATES_NOT_TESTED ?= lucet-spectest lucet-benchmarks lucet-runtime-example
 
 .PHONY: build-dev
 build-dev:


### PR DESCRIPTION
Currently we are using CircleCI to test `lucet-runtime`.  We've been needing a way to test the `userfaultfd` implementation of Regions.  The tests can't run on the containers supplied by GitHub Actions because the containers don't have the privileges necessary to use the kernel mechanisms for `userfaultfd`.

The GitHub Actions tests are still failing, tho.  And I worry about conveying a wrong message in CI Results.  So I'd like to remove the failing tests that are tested by CircleCI.