### PR TITLE
Point to wasmtime 0.16.0 / cranelift 0.63.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,14 +312,14 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "byteorder",
  "cranelift-bforest",
@@ -336,7 +336,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "cranelift-codegen-shared",
  "cranelift-entity",
@@ -344,15 +344,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.62.0"
+version = "0.63.0"
 
 [[package]]
 name = "cranelift-entity"
-version = "0.62.0"
+version = "0.63.0"
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -362,7 +362,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -373,7 +373,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "cranelift-codegen",
  "raw-cpuid 7.0.3",
@@ -382,7 +382,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-object"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "cranelift-codegen",
  "cranelift-module",
@@ -392,7 +392,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1711,12 +1711,13 @@ checksum = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 
 [[package]]
 name = "regalloc"
-version = "0.0.17"
+version = "0.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ce0cd835fa6e91bbf5d010beee19d0c2e97e4ad5e13c399a31122cfc83bdd6"
+checksum = "b27b256b41986ac5141b37b8bbba85d314fbf546c182eb255af6720e07e4f804"
 dependencies = [
  "log",
  "rustc-hash",
+ "smallvec",
 ]
 
 [[package]]
@@ -2291,7 +2292,7 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi-common"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -2390,7 +2391,7 @@ dependencies = [
 
 [[package]]
 name = "wig"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "heck",
  "proc-macro2 1.0.13",
@@ -2400,7 +2401,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "thiserror",
  "wiggle-macro",
@@ -2409,7 +2410,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "heck",
@@ -2421,7 +2422,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "quote 1.0.6",
  "syn 1.0.22",
@@ -2431,7 +2432,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-test"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "proptest",
  "wiggle",
@@ -2482,7 +2483,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winx"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "bitflags 1.2.1",
  "cvt",
@@ -2507,7 +2508,7 @@ checksum = "da90eac47bf1d7871b75004b9b631d107df15f37669383b23f0b5297bc7516b6"
 
 [[package]]
 name = "yanix"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "bitflags 1.2.1",
  "cfg-if",

--- a/lucet-module/Cargo.toml
+++ b/lucet-module/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
-cranelift-entity = { path = "../wasmtime/cranelift/entity", version = "0.62.0" }
+cranelift-entity = { path = "../wasmtime/cranelift/entity", version = "0.63.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bincode = "1.1.4"

--- a/lucet-validate/Cargo.toml
+++ b/lucet-validate/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 [dependencies]
 clap = "2"
 witx = { path = "../wasmtime/crates/wasi-common/WASI/tools/witx", version = "0.8.5" }
-cranelift-entity = { path = "../wasmtime/cranelift/entity", version = "0.62.0" }
+cranelift-entity = { path = "../wasmtime/cranelift/entity", version = "0.63.0" }
 thiserror = "1.0.4"
 wasmparser = "0.51.2"
 

--- a/lucet-wasi/Cargo.toml
+++ b/lucet-wasi/Cargo.toml
@@ -22,7 +22,7 @@ lucet-wiggle = { path = "../lucet-wiggle", version = "=0.7.0-dev" }
 libc = "0.2.65"
 nix = "0.17"
 rand = "0.6"
-wasi-common = { path = "../wasmtime/crates/wasi-common", version = "0.15.0", features = ["wiggle_metadata"] }
+wasi-common = { path = "../wasmtime/crates/wasi-common", version = "0.16.0", features = ["wiggle_metadata"] }
 
 [dev-dependencies]
 lucet-wasi-sdk = { path = "../lucet-wasi-sdk" }

--- a/lucet-wasi/generate/Cargo.toml
+++ b/lucet-wasi/generate/Cargo.toml
@@ -13,8 +13,8 @@ proc-macro = true
 
 [dependencies]
 lucet-wiggle = { path = "../../lucet-wiggle", version = "0.7.0-dev" }
-wasi-common = { path = "../../wasmtime/crates/wasi-common",  version = "0.15.0", features = ["wiggle_metadata"] }
-wiggle-generate = { path = "../../wasmtime/crates/wiggle/generate",  version = "0.15.0" }
+wasi-common = { path = "../../wasmtime/crates/wasi-common",  version = "0.16.0", features = ["wiggle_metadata"] }
+wiggle-generate = { path = "../../wasmtime/crates/wiggle/generate",  version = "0.16.0" }
 syn = { version = "1.0", features = ["full"] }
 quote = "1.0"
 proc-macro2 = "1.0"

--- a/lucet-wiggle/Cargo.toml
+++ b/lucet-wiggle/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 lucet-wiggle-macro = { path = "./macro", version = "0.7.0-dev" }
 lucet-wiggle-generate = { path = "./generate", version = "0.7.0-dev" }
 lucet-runtime = { path = "../lucet-runtime", version = "0.7.0-dev" }
-wiggle =  { path = "../wasmtime/crates/wiggle", version = "0.15.0" }
+wiggle =  { path = "../wasmtime/crates/wiggle", version = "0.16.0" }
 
 [dev-dependencies]
 wiggle-test = { path = "../wasmtime/crates/wiggle/test-helpers" }

--- a/lucet-wiggle/generate/Cargo.toml
+++ b/lucet-wiggle/generate/Cargo.toml
@@ -9,7 +9,7 @@ authors = ["Lucet team <lucet@fastly.com>"]
 edition = "2018"
 
 [dependencies]
-wiggle-generate = { path = "../../wasmtime/crates/wiggle/generate", version = "0.15.0" }
+wiggle-generate = { path = "../../wasmtime/crates/wiggle/generate", version = "0.16.0" }
 lucet-module = { path = "../../lucet-module", version = "0.7.0-dev" }
 witx = { path = "../../wasmtime/crates/wasi-common/WASI/tools/witx", version = "0.8.4" }
 quote = "1.0"

--- a/lucet-wiggle/macro/Cargo.toml
+++ b/lucet-wiggle/macro/Cargo.toml
@@ -13,7 +13,7 @@ proc-macro = true
 
 [dependencies]
 lucet-wiggle-generate = { path = "../generate", version = "0.7.0-dev" }
-wiggle-generate = { path = "../../wasmtime/crates/wiggle/generate", version = "0.15.0" }
+wiggle-generate = { path = "../../wasmtime/crates/wiggle/generate", version = "0.16.0" }
 witx = { path = "../../wasmtime/crates/wasi-common/WASI/tools/witx", version = "0.8.4" }
 syn = { version = "1.0", features = ["full"] }
 quote = "1.0"

--- a/lucetc/Cargo.toml
+++ b/lucetc/Cargo.toml
@@ -16,13 +16,13 @@ path = "lucetc/main.rs"
 [dependencies]
 anyhow = "1"
 bincode = "1.1.4"
-cranelift-codegen = { path = "../wasmtime/cranelift/codegen", version = "0.62.0" }
-cranelift-entity = { path = "../wasmtime/cranelift/entity", version = "0.62.0" }
-cranelift-native = { path = "../wasmtime/cranelift/native", version = "0.62.0" }
-cranelift-frontend = { path = "../wasmtime/cranelift/frontend", version = "0.62.0" }
-cranelift-module = { path = "../wasmtime/cranelift/module", version = "0.62.0" }
-cranelift-object = { path = "../wasmtime/cranelift/object", version = "0.62.0" }
-cranelift-wasm = { path = "../wasmtime/cranelift/wasm", version = "0.62.0" }
+cranelift-codegen = { path = "../wasmtime/cranelift/codegen", version = "0.63.0" }
+cranelift-entity = { path = "../wasmtime/cranelift/entity", version = "0.63.0" }
+cranelift-native = { path = "../wasmtime/cranelift/native", version = "0.63.0" }
+cranelift-frontend = { path = "../wasmtime/cranelift/frontend", version = "0.63.0" }
+cranelift-module = { path = "../wasmtime/cranelift/module", version = "0.63.0" }
+cranelift-object = { path = "../wasmtime/cranelift/object", version = "0.63.0" }
+cranelift-wasm = { path = "../wasmtime/cranelift/wasm", version = "0.63.0" }
 target-lexicon = "0.10"
 lucet-module = { path = "../lucet-module", version = "=0.7.0-dev" }
 lucet-validate = { path = "../lucet-validate", version = "=0.7.0-dev" }


### PR DESCRIPTION
No code changes!

If we want to do a crates.io release soon, we should do so after merging this PR and before merging any other updates to the `wasmtime` submodule.