### PR TITLE
github config: move `env` that excludes crates into action

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -17,4 +17,4 @@ runs:
       # The test target of the Makefile is our standard CI.
     - 'export HOME=/root; make ${{ inputs.target }}'
   env:
-    CRATES_NOT_TESTED: lucet-runtime lucet-spectest lucet-benchmarks lucet-runtime-example
+    - 'CRATES_NOT_TESTED="lucet-runtime lucet-spectest lucet-benchmarks lucet-runtime-example lucet-runtime-internal"'

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -16,3 +16,5 @@ runs:
       # it was set to during container creation. Actions clears $HOME so we set it here.
       # The test target of the Makefile is our standard CI.
     - 'export HOME=/root; make ${{ inputs.target }}'
+  env:
+    CRATES_NOT_TESTED: lucet-runtime lucet-spectest lucet-benchmarks lucet-runtime-example

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -15,4 +15,4 @@ runs:
       # rustup expects $HOME to be set to /root during `docker run` because thats what
       # it was set to during container creation. Actions clears $HOME so we set it here.
       # The test target of the Makefile is our standard CI.
-    - 'export HOME=/root; CRATES_NOT_TESTED="lucet-runtime lucet-spectest lucet-benchmarks lucet-runtime-example lucet-runtime-internal" make ${{ inputs.target }}'
+    - 'export HOME=/root; CRATES_NOT_TESTED="lucet-runtime lucet-spectest lucet-benchmarks lucet-runtime-example lucet-runtime-internals" make ${{ inputs.target }}'

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -15,6 +15,4 @@ runs:
       # rustup expects $HOME to be set to /root during `docker run` because thats what
       # it was set to during container creation. Actions clears $HOME so we set it here.
       # The test target of the Makefile is our standard CI.
-    - 'export HOME=/root; make ${{ inputs.target }}'
-  env:
-      CRATES_NOT_TESTED: 'lucet-runtime lucet-spectest lucet-benchmarks lucet-runtime-example lucet-runtime-internal'
+    - 'export HOME=/root; CRATES_NOT_TESTED="lucet-runtime lucet-spectest lucet-benchmarks lucet-runtime-example lucet-runtime-internal" make ${{ inputs.target }}'

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -17,4 +17,4 @@ runs:
       # The test target of the Makefile is our standard CI.
     - 'export HOME=/root; make ${{ inputs.target }}'
   env:
-    - 'CRATES_NOT_TESTED="lucet-runtime lucet-spectest lucet-benchmarks lucet-runtime-example lucet-runtime-internal"'
+      CRATES_NOT_TESTED: 'lucet-runtime lucet-spectest lucet-benchmarks lucet-runtime-example lucet-runtime-internal'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,8 +55,6 @@ jobs:
 
   test_release:
     name: Test Release
-    env:
-      CRATES_NOT_TESTED: lucet-runtime lucet-spectest lucet-benchmarks lucet-runtime-example                                              
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
this will make it apply to each call of the makefile, and set the
environment inside the Docker container rather than outside. See also #528 