### PR TITLE
Make AllocStrategy public

### DIFF
--- a/lucet-runtime/src/lib.rs
+++ b/lucet-runtime/src/lib.rs
@@ -404,7 +404,7 @@ extern crate self as lucet_runtime;
 pub mod c_api;
 
 pub use lucet_module::{PublicKey, TrapCode};
-pub use lucet_runtime_internals::alloc::{Limits, DEFAULT_SIGNAL_STACK_SIZE};
+pub use lucet_runtime_internals::alloc::{AllocStrategy, Limits, DEFAULT_SIGNAL_STACK_SIZE};
 pub use lucet_runtime_internals::error::Error;
 pub use lucet_runtime_internals::instance::signals::{
     install_lucet_signal_handler, remove_lucet_signal_handler,


### PR DESCRIPTION
I would like to make the `AllocStrategy` public so that I may use it in code leveraging the `lucet-runtime`.