### PR TITLE
Update the Dockerfile

### DIFF
--- a/docs/src/Compiling-on-Linux.md
+++ b/docs/src/Compiling-on-Linux.md
@@ -18,8 +18,8 @@ You will need to install `wasi-sdk` as well. Note that you may need to run `dpkg
 privileges to install the package.
 
 ```sh
-curl -sS -L -O https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-8/wasi-sdk_8.0_amd64.deb \
-    && dpkg -i wasi-sdk_8.0_amd64.deb && rm -f wasi-sdk_8.0_amd64.deb
+curl -sS -L -O https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-10/wasi-sdk_10.0_amd64.deb \
+    && dpkg -i wasi-sdk_10.0_amd64.deb && rm -f wasi-sdk_10.0_amd64.deb
 ```
 
 Install the latest stable version of the Rust compiler:
@@ -52,7 +52,7 @@ from `/opt/wasi-sdk/bin` instead of the system compiler. Or use set of commands 
 Support for WebAssembly was introduced in LLVM 8, released in March 2019.
 
 As a result, Lucet can be compiled with an existing LLVM installation, provided that it is up to
-date. Most distributions now include LLVM 8 or LLVM 9, so that an additional installation is not
+date. Most distributions now include LLVM >= 8, so that an additional installation is not
 required to compile to WebAssembly .
 
 On distributions such as Ubuntu (19.04 or newer) and Debian (bullseye or newer), the following
@@ -71,8 +71,8 @@ pacman -S curl clang lld cmake
 Next, install the WebAssembly compiler builtins:
 
 ```sh
-curl -sL https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-8/libclang_rt.builtins-wasm32-wasi-8.0.tar.gz | \
-sudo tar x -zf - -C /usr/lib/llvm-*/lib/clang/*
+curl -sL https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-10/libclang_rt.builtins-wasm32-wasi-10.0.tar.gz | \
+  sudo tar x -zf - -C /usr/lib/llvm-*/lib/clang/*
 ```
 
 Install the latest stable version of the Rust compiler:
@@ -86,9 +86,8 @@ Install the WASI sysroot:
 
 ```sh
 mkdir -p /opt
-curl -L https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-8/wasi-sdk-8.0-linux.tar.gz | \
-sudo tar x -zv -C /opt -f - wasi-sdk-8.0/share && \
-  sudo ln -s /opt/wasi-sdk-*/share/wasi-sysroot /opt/wasi-sysroot
+RUN curl -sS -L https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-10/wasi-sysroot-10.0.tar.gz | \
+  tar x -zf - -C /opt
 ```
 
 Enter your clone of the Lucet repository, and then fetch/update the submodules:

--- a/docs/src/Compiling-on-macOS.md
+++ b/docs/src/Compiling-on-macOS.md
@@ -10,21 +10,15 @@ In order to compile applications to WebAssembly, builtins need to be installed
 as well:
 
 ```sh
-curl -sL https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-8/libclang_rt.builtins-wasm32-wasi-8.0.tar.gz | \
-sudo tar x -zf - -C /usr/local/opt/llvm/lib/clang/10*
+curl -sL https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-10/libclang_rt.builtins-wasm32-wasi-10.0.tar.gz | \
+  sudo tar x -zf - -C /usr/local/opt/llvm/lib/clang/10*
 ```
 
-Fetch, compile and install the WASI libc:
+Install the WASI sysroot:
 
 ```sh
-git clone --recursive https://github.com/CraneStation/wasi-libc
-
-cd wasi-libc
-
-sudo env PATH=/usr/local/opt/llvm/bin:$PATH \
-  make INSTALL_DIR=/opt/wasi-sysroot install
-
-cd - && sudo rm -fr wasi-libc
+RUN curl -sS -L https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-10/wasi-sysroot-10.0.tar.gz | \
+  tar x -zf - -C /opt
 ```
 
 Enter the Lucet git repository clone, and fetch/update the submodules:

--- a/docs/src/lucet-wasi-sdk.md
+++ b/docs/src/lucet-wasi-sdk.md
@@ -3,7 +3,7 @@
 [docs-badge]: https://docs.rs/lucet-wasi-sdk/badge.svg
 [docs-rs]: https://docs.rs/lucet-wasi-sdk
 
-[`wasi-sdk`](https://github.com/cranestation/wasi-sdk) is a Cranelift project that packages a build
+[`wasi-sdk`](https://github.com/WebAssembly/wasi-sdk) is a Cranelift project that packages a build
 of the Clang toolchain, the WASI reference sysroot, and a libc based on WASI syscalls.
 
 `lucet-wasi-sdk` is a Rust crate that provides wrappers around these tools for building C programs

--- a/helpers/install.sh
+++ b/helpers/install.sh
@@ -85,11 +85,11 @@ echo "* WASI sysroot: [$WASI_SYSROOT]"
 # Find:
 # - A clang/llvm installation able to compile to WebAssmbly/WASI
 # - The base path to this installation
-# - The optional suffix added to clang (e.g. clang-8)
-# - The optional suffix added to LLVM tools (e.g. ar-8) that differs from the clang one on some Linux distributions
+# - The optional suffix added to clang (e.g. clang-10)
+# - The optional suffix added to LLVM tools (e.g. ar-10) that differs from the clang one on some Linux distributions
 
 TMP_OBJ=$(mktemp)
-for llvm_bin_path_candidate in "$LLVM_BIN" "${WASI_SDK_PREFIX}/bin" /usr/local/opt/llvm/bin $(echo "$PATH" | sed s/:/\ /g); do
+for llvm_bin_path_candidate in "$LLVM_BIN" "${WASI_SDK_PREFIX}/bin" /usr/local/opt/llvm/bin $(echo "$PATH" | sed s/:/\ /g) /usr/lib/llvm-*; do
     [ -d "$llvm_bin_path_candidate" ] || continue
     clang_candidate=$(find "$llvm_bin_path_candidate" -maxdepth 1 \( -type f -o -type l \) \( -name "clang" -o -name "clang-[0-9]*" \) -print |
         sort | while read -r clang_candidate; do
@@ -225,7 +225,7 @@ done
 if test -t 0; then
     echo
     echo "Lucet has been installed in [${LUCET_PREFIX}]"
-    if [ "$(basename $SHELL)" = "fish" ]; then
+    if [ -n "$SHELL" ] && [ "$(basename $SHELL)" = "fish" ]; then
         echo "Add ${LUCET_BIN_DIR} to your shell's search paths."
     else
         echo "Type 'source ${LUCET_BIN_DIR}/setenv.sh' to add the Lucet paths to your environment."


### PR DESCRIPTION
- Use the current Ubuntu LTS version
- Install and use the default LLVM/Clang versions. clang 6 is very old.
- Add wabt
- Update binaryen
- Update the install script to look for LLVM in /usr/lib/llvm-* by default
- Update the documentation. People should not install `wasi-sdk` version 8 any more, but version 10.

This also fixes #533