### PR TITLE
Doc: recommend usage of wasi-sdk 10 instead of wasi-sdk 8

### DIFF
--- a/docs/src/Compiling-on-Linux.md
+++ b/docs/src/Compiling-on-Linux.md
@@ -3,23 +3,23 @@
 We successfully compiled Lucet on Arch Linux, Fedora, Gentoo and Ubuntu. Only x86_64 CPUs are
 supported at this time.
 
-## Installation on Ubuntu, with a sidecar installation of LLVM/clang
+## Option 1: installation on Ubuntu, with a sidecar installation of LLVM/clang
 
 The following instructions only work on Ubuntu. They install a recent version of LLVM and `clang`
 (in `/opt/wasi-sdk`), so that WebAssembly code can be compiled on Ubuntu versions older than 19.04.
 
-First, the `curl` and `cmake` package must be installed:
+First, the `curl` and `cmake` packages must be installed:
 
 ```sh
-apt install curl ca-certificates
+apt install curl ca-certificates cmake
 ```
 
 You will need to install `wasi-sdk` as well. Note that you may need to run `dpkg` with elevated
 privileges to install the package.
 
 ```sh
-curl -sS -L -O https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-8/wasi-sdk_8.0_amd64.deb \
-    && dpkg -i wasi-sdk_8.0_amd64.deb && rm -f wasi-sdk_8.0_amd64.deb
+curl -sS -L -O https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-10/wasi-sdk_10.0_amd64.deb \
+    && dpkg -i wasi-sdk_10.0_amd64.deb && rm -f wasi-sdk_10.0_amd64.deb
 ```
 
 Install the latest stable version of the Rust compiler:
@@ -47,12 +47,12 @@ In order to use `clang` to compile WebAssembly code, you need to adjust your `PA
 from `/opt/wasi-sdk/bin` instead of the system compiler. Or use set of commands prefixed by
 `wasm-wasi-`, such as `wasm32-wasi-clang` instead of `clang`.
 
-## Installation on any recent Linux system, using the base compiler
+## Option 2: installation on a recent Linux system, using the base compiler
 
 Support for WebAssembly was introduced in LLVM 8, released in March 2019.
 
 As a result, Lucet can be compiled with an existing LLVM installation, provided that it is up to
-date. Most distributions now include LLVM 8 or LLVM 9, so that an additional installation is not
+date. Most distributions now include LLVM >= 8, so that an additional installation is not
 required to compile to WebAssembly .
 
 On distributions such as Ubuntu (19.04 or newer) and Debian (bullseye or newer), the following
@@ -71,8 +71,8 @@ pacman -S curl clang lld cmake
 Next, install the WebAssembly compiler builtins:
 
 ```sh
-curl -sL https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-8/libclang_rt.builtins-wasm32-wasi-8.0.tar.gz | \
-sudo tar x -zf - -C /usr/lib/llvm-*/lib/clang/*
+curl -sL https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-10/libclang_rt.builtins-wasm32-wasi-10.0.tar.gz | \
+  sudo tar x -zf - -C /usr/lib/llvm-*/lib/clang/*
 ```
 
 Install the latest stable version of the Rust compiler:
@@ -86,8 +86,8 @@ Install the WASI sysroot:
 
 ```sh
 mkdir -p /opt
-curl -L https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-8/wasi-sdk-8.0-linux.tar.gz | \
-sudo tar x -zv -C /opt -f - wasi-sdk-8.0/share && \
+curl -L https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-10/wasi-sdk-10.0-linux.tar.gz | \
+sudo tar x -zv -C /opt -f - wasi-sdk-10.0/share && \
   sudo ln -s /opt/wasi-sdk-*/share/wasi-sysroot /opt/wasi-sysroot
 ```
 

--- a/docs/src/Compiling-on-macOS.md
+++ b/docs/src/Compiling-on-macOS.md
@@ -1,31 +1,30 @@
 # Compiling on macOS
 
+## Prerequisites
+
 Install `llvm`, `rust` and `cmake` using [Homebrew](https://brew.sh):
 
 ```sh
 brew install llvm rust cmake
 ```
 
-In order to compile applications to WebAssembly, builtins need to be installed
-as well:
+In order to compile applications written in C to WebAssembly, `clang` builtins need to be installed:
 
 ```sh
-curl -sL https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-8/libclang_rt.builtins-wasm32-wasi-8.0.tar.gz | \
-sudo tar x -zf - -C /usr/local/opt/llvm/lib/clang/10*
+curl -sL https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-10/libclang_rt.builtins-wasm32-wasi-10.0.tar.gz | \
+  tar x -zf - -C /usr/local/opt/llvm/lib/clang/10*
 ```
 
-Fetch, compile and install the WASI libc:
+As well as the WASI sysroot:
 
 ```sh
-git clone --recursive https://github.com/CraneStation/wasi-libc
+sudo mkdir -p /opt
 
-cd wasi-libc
-
-sudo env PATH=/usr/local/opt/llvm/bin:$PATH \
-  make INSTALL_DIR=/opt/wasi-sysroot install
-
-cd - && sudo rm -fr wasi-libc
+curl -sS -L https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-10/wasi-sysroot-10.0.tar.gz | \
+  sudo tar x -zf - -C /opt
 ```
+
+## Compiling and installing Lucet
 
 Enter the Lucet git repository clone, and fetch/update the submodules:
 
@@ -35,19 +34,39 @@ cd lucet
 git submodule update --init
 ```
 
-Set relevant environment variables:
+Define the location of the WASI sysroot installation:
 
 ```sh
 export WASI_SYSROOT=/opt/wasi-sysroot
-export CLANG_ROOT="$(echo /usr/local/opt/llvm/lib/clang/10*)"
-export CLANG=/usr/local/opt/llvm/bin/clang
 ```
 
-Finally, compile and install toolchain:
+Finally, compile and install the toolchain:
 
 ```sh
 env LUCET_PREFIX=/opt/lucet make install
 ```
 
 Change `LUCET_PREFIX` to the directory you would like to install Lucet into. `/opt/lucet` is the default directory.
-The Lucet executable files can be found in the `target/release/` directory.
+
+## Setting up the environment
+
+In order to add `/opt/lucet` to the command search path, as well register the library path for the Lucet runtime, the following command can be run interactively or added to the shell startup files:
+
+```sh
+source /opt/lucet/bin/setenv.sh
+```
+
+## Running the test suite
+
+If you want to run the test suite, and in addition to `WASI_SYSROOT`, the following environment variables must be set:
+
+```sh
+export CLANG_ROOT="$(echo /usr/local/opt/llvm/lib/clang/10*)"
+export CLANG=/usr/local/opt/llvm/bin/clang
+```
+
+And the test suite can then be run with the following command:
+
+ ```sh
+ make test
+```

--- a/docs/src/Compiling.md
+++ b/docs/src/Compiling.md
@@ -5,9 +5,5 @@ Specific instructions are available for [some flavors of Linux](./Compiling-on-L
 
 If you are using another platform, or if the provided instructions are not working, it may be
 helpful to try adapting the setup code in the `Dockerfile` that defines the Lucet continuous
-integration environment. While the image is defined in terms of Ubuntu, many of the packages are
-available through other package managers and operating systems.
-
-```Dockerfile
-{{#include ../../Dockerfile}}
-```
+integration environment. While the image is defined in terms of Ubuntu 18.04, many of the
+packages are available through other package managers and operating systems.


### PR DESCRIPTION
Remove the copy of the `Dockerfile` used for CI in order to discourage usage of that Docker file for other purposes..

Also, compiling `wasi-libc` is not needed any more.