### PR TITLE
Integrate wiggle changes for automatic borrow checking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,14 +306,14 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "byteorder",
  "cranelift-bforest",
@@ -330,7 +330,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "cranelift-codegen-shared",
  "cranelift-entity",
@@ -338,15 +338,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.62.0"
+version = "0.63.0"
 
 [[package]]
 name = "cranelift-entity"
-version = "0.62.0"
+version = "0.63.0"
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -356,7 +356,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -367,7 +367,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "cranelift-codegen",
  "raw-cpuid 7.0.3",
@@ -376,7 +376,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-object"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "cranelift-codegen",
  "cranelift-module",
@@ -386,7 +386,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.62.0"
+version = "0.63.0"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1704,12 +1704,13 @@ checksum = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 
 [[package]]
 name = "regalloc"
-version = "0.0.17"
+version = "0.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ce0cd835fa6e91bbf5d010beee19d0c2e97e4ad5e13c399a31122cfc83bdd6"
+checksum = "b27b256b41986ac5141b37b8bbba85d314fbf546c182eb255af6720e07e4f804"
 dependencies = [
  "log",
  "rustc-hash",
+ "smallvec",
 ]
 
 [[package]]
@@ -2284,7 +2285,7 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi-common"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -2383,7 +2384,7 @@ dependencies = [
 
 [[package]]
 name = "wig"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "heck",
  "proc-macro2 1.0.13",
@@ -2393,7 +2394,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "thiserror",
  "wiggle-macro",
@@ -2402,7 +2403,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "heck",
@@ -2414,7 +2415,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "quote 1.0.6",
  "syn 1.0.22",
@@ -2424,7 +2425,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-test"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "proptest",
  "wiggle",
@@ -2475,7 +2476,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winx"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "bitflags 1.2.1",
  "cvt",
@@ -2500,7 +2501,7 @@ checksum = "da90eac47bf1d7871b75004b9b631d107df15f37669383b23f0b5297bc7516b6"
 
 [[package]]
 name = "yanix"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "bitflags 1.2.1",
  "cfg-if",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -904,8 +904,6 @@ dependencies = [
  "derivative",
  "memoffset",
  "minisign",
- "num-derive",
- "num-traits",
  "object 0.18.0",
  "serde",
  "serde-big-array",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -393,7 +393,7 @@ dependencies = [
  "cranelift-frontend",
  "log",
  "thiserror",
- "wasmparser",
+ "wasmparser 0.52.2",
 ]
 
 [[package]]
@@ -1028,7 +1028,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "wabt",
- "wasmparser",
+ "wasmparser 0.52.2",
  "witx",
 ]
 
@@ -1174,7 +1174,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "wabt",
- "wasmparser",
+ "wasmparser 0.52.2",
 ]
 
 [[package]]
@@ -1313,7 +1313,7 @@ dependencies = [
  "flate2",
  "indexmap",
  "target-lexicon",
- "wasmparser",
+ "wasmparser 0.51.4",
 ]
 
 [[package]]
@@ -1704,9 +1704,9 @@ checksum = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 
 [[package]]
 name = "regalloc"
-version = "0.0.21"
+version = "0.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b27b256b41986ac5141b37b8bbba85d314fbf546c182eb255af6720e07e4f804"
+checksum = "b36727ea09f6e363ddebb29b2d2620052267cc1fc6e0da7da63317938eb4104c"
 dependencies = [
  "log",
  "rustc-hash",
@@ -2362,6 +2362,12 @@ name = "wasmparser"
 version = "0.51.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aeb1956b19469d1c5e63e459d29e7b5aa0f558d9f16fcef09736f8a265e6c10a"
+
+[[package]]
+name = "wasmparser"
+version = "0.52.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "733954023c0b39602439e60a65126fd31b003196d3a1e8e4531b055165a79b31"
 
 [[package]]
 name = "wast"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -393,7 +393,7 @@ dependencies = [
  "cranelift-frontend",
  "log",
  "thiserror",
- "wasmparser 0.52.2",
+ "wasmparser 0.55.0",
 ]
 
 [[package]]
@@ -1174,7 +1174,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "wabt",
- "wasmparser 0.52.2",
+ "wasmparser 0.55.0",
 ]
 
 [[package]]
@@ -1704,9 +1704,9 @@ checksum = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 
 [[package]]
 name = "regalloc"
-version = "0.0.23"
+version = "0.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b36727ea09f6e363ddebb29b2d2620052267cc1fc6e0da7da63317938eb4104c"
+checksum = "5842bece8a4b1690ffa6d9d959081c1d5d851ee4337a36c0a121fafe8c16add2"
 dependencies = [
  "log",
  "rustc-hash",
@@ -2368,6 +2368,12 @@ name = "wasmparser"
 version = "0.52.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "733954023c0b39602439e60a65126fd31b003196d3a1e8e4531b055165a79b31"
+
+[[package]]
+name = "wasmparser"
+version = "0.55.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af931e2e1960c53f4a28b063fec4cacd036f35acbec8ff3a4739125b17382a87"
 
 [[package]]
 name = "wast"

--- a/lucet-module/Cargo.toml
+++ b/lucet-module/Cargo.toml
@@ -15,8 +15,6 @@ cranelift-entity = { path = "../wasmtime/cranelift/entity", version = "0.63.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bincode = "1.1.4"
-num-derive = "0.3.0"
-num-traits = "0.2.8"
 minisign = "0.5.19"
 object = "0.18.0"
 byteorder = "1.3"

--- a/lucet-module/Cargo.toml
+++ b/lucet-module/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
-cranelift-entity = { path = "../wasmtime/cranelift/entity", version = "0.62.0" }
+cranelift-entity = { path = "../wasmtime/cranelift/entity", version = "0.63.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bincode = "1.1.4"

--- a/lucet-module/src/traps.rs
+++ b/lucet-module/src/traps.rs
@@ -1,9 +1,7 @@
-use num_derive::FromPrimitive;
-
 /// The type of a WebAssembly
 /// [trap](http://webassembly.github.io/spec/core/intro/overview.html#trap).
 #[repr(u32)]
-#[derive(Copy, Clone, Debug, FromPrimitive, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub enum TrapCode {
     StackOverflow,
     HeapOutOfBounds,

--- a/lucet-module/src/traps.rs
+++ b/lucet-module/src/traps.rs
@@ -1,28 +1,20 @@
 use num_derive::FromPrimitive;
-use num_traits::FromPrimitive;
 
 /// The type of a WebAssembly
 /// [trap](http://webassembly.github.io/spec/core/intro/overview.html#trap).
 #[repr(u32)]
 #[derive(Copy, Clone, Debug, FromPrimitive, PartialEq)]
 pub enum TrapCode {
-    StackOverflow = 0,
-    HeapOutOfBounds = 1,
-    OutOfBounds = 2,
-    IndirectCallToNull = 3,
-    BadSignature = 4,
-    IntegerOverflow = 5,
-    IntegerDivByZero = 6,
-    BadConversionToInteger = 7,
-    Interrupt = 8,
-    TableOutOfBounds = 9,
-    Unreachable = 10,
-}
-
-impl TrapCode {
-    pub fn try_from_u32(v: u32) -> Option<TrapCode> {
-        Self::from_u32(v)
-    }
+    StackOverflow,
+    HeapOutOfBounds,
+    IndirectCallToNull,
+    BadSignature,
+    IntegerOverflow,
+    IntegerDivByZero,
+    BadConversionToInteger,
+    Interrupt,
+    TableOutOfBounds,
+    Unreachable,
 }
 
 /// Trap information for an address in a compiled function

--- a/lucet-runtime/include/lucet_types.h
+++ b/lucet-runtime/include/lucet_types.h
@@ -55,7 +55,6 @@ enum lucet_terminated_reason {
 enum lucet_trapcode {
     lucet_trapcode_stack_overflow,
     lucet_trapcode_heap_out_of_bounds,
-    lucet_trapcode_out_of_bounds,
     lucet_trapcode_indirect_call_to_null,
     lucet_trapcode_bad_signature,
     lucet_trapcode_integer_overflow,

--- a/lucet-runtime/lucet-runtime-internals/src/c_api.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/c_api.rs
@@ -391,7 +391,6 @@ pub mod lucet_result {
     pub enum lucet_trapcode {
         StackOverflow,
         HeapOutOfBounds,
-        OutOfBounds,
         IndirectCallToNull,
         BadSignature,
         IntegerOverflow,
@@ -415,7 +414,6 @@ pub mod lucet_result {
                 match ty {
                     TrapCode::StackOverflow => lucet_trapcode::StackOverflow,
                     TrapCode::HeapOutOfBounds => lucet_trapcode::HeapOutOfBounds,
-                    TrapCode::OutOfBounds => lucet_trapcode::OutOfBounds,
                     TrapCode::IndirectCallToNull => lucet_trapcode::IndirectCallToNull,
                     TrapCode::BadSignature => lucet_trapcode::BadSignature,
                     TrapCode::IntegerOverflow => lucet_trapcode::IntegerOverflow,

--- a/lucet-validate/Cargo.toml
+++ b/lucet-validate/Cargo.toml
@@ -21,7 +21,7 @@ clap = "2"
 witx = { path = "../wasmtime/crates/wasi-common/WASI/tools/witx", version = "0.8.5" }
 cranelift-entity = { path = "../wasmtime/cranelift/entity", version = "0.63.0" }
 thiserror = "1.0.4"
-wasmparser = "0.51.2"
+wasmparser = "0.52.0"
 
 [dev-dependencies]
 lucet-wasi = { path = "../lucet-wasi", version = "=0.7.0-dev" }

--- a/lucet-validate/Cargo.toml
+++ b/lucet-validate/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 [dependencies]
 clap = "2"
 witx = { path = "../wasmtime/crates/wasi-common/WASI/tools/witx", version = "0.8.5" }
-cranelift-entity = { path = "../wasmtime/cranelift/entity", version = "0.62.0" }
+cranelift-entity = { path = "../wasmtime/cranelift/entity", version = "0.63.0" }
 thiserror = "1.0.4"
 wasmparser = "0.51.2"
 

--- a/lucet-wasi/Cargo.toml
+++ b/lucet-wasi/Cargo.toml
@@ -22,7 +22,7 @@ lucet-wiggle = { path = "../lucet-wiggle", version = "=0.7.0-dev" }
 libc = "0.2.65"
 nix = "0.17"
 rand = "0.6"
-wasi-common = { path = "../wasmtime/crates/wasi-common", version = "0.15.0", features = ["wiggle_metadata"] }
+wasi-common = { path = "../wasmtime/crates/wasi-common", version = "0.16.0", features = ["wiggle_metadata"] }
 
 [dev-dependencies]
 lucet-wasi-sdk = { path = "../lucet-wasi-sdk" }

--- a/lucet-wasi/generate/Cargo.toml
+++ b/lucet-wasi/generate/Cargo.toml
@@ -13,8 +13,8 @@ proc-macro = true
 
 [dependencies]
 lucet-wiggle = { path = "../../lucet-wiggle", version = "0.7.0-dev" }
-wasi-common = { path = "../../wasmtime/crates/wasi-common",  version = "0.15.0", features = ["wiggle_metadata"] }
-wiggle-generate = { path = "../../wasmtime/crates/wiggle/generate",  version = "0.15.0" }
+wasi-common = { path = "../../wasmtime/crates/wasi-common",  version = "0.16.0", features = ["wiggle_metadata"] }
+wiggle-generate = { path = "../../wasmtime/crates/wiggle/generate",  version = "0.16.0" }
 syn = { version = "1.0", features = ["full"] }
 quote = "1.0"
 proc-macro2 = "1.0"

--- a/lucet-wiggle/Cargo.toml
+++ b/lucet-wiggle/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 lucet-wiggle-macro = { path = "./macro", version = "0.7.0-dev" }
 lucet-wiggle-generate = { path = "./generate", version = "0.7.0-dev" }
 lucet-runtime = { path = "../lucet-runtime", version = "0.7.0-dev" }
-wiggle =  { path = "../wasmtime/crates/wiggle", version = "0.15.0" }
+wiggle =  { path = "../wasmtime/crates/wiggle", version = "0.16.0" }
 
 [dev-dependencies]
 wiggle-test = { path = "../wasmtime/crates/wiggle/test-helpers" }

--- a/lucet-wiggle/generate/Cargo.toml
+++ b/lucet-wiggle/generate/Cargo.toml
@@ -9,7 +9,7 @@ authors = ["Lucet team <lucet@fastly.com>"]
 edition = "2018"
 
 [dependencies]
-wiggle-generate = { path = "../../wasmtime/crates/wiggle/generate", version = "0.15.0" }
+wiggle-generate = { path = "../../wasmtime/crates/wiggle/generate", version = "0.16.0" }
 lucet-module = { path = "../../lucet-module", version = "0.7.0-dev" }
 witx = { path = "../../wasmtime/crates/wasi-common/WASI/tools/witx", version = "0.8.4" }
 quote = "1.0"

--- a/lucet-wiggle/generate/src/lib.rs
+++ b/lucet-wiggle/generate/src/lib.rs
@@ -64,10 +64,7 @@ pub fn generate(
                 pub fn #name(vmctx: &lucet_runtime::vmctx::Vmctx, #(#func_args),*) -> #rets {
                     let memory = lucet_wiggle::runtime::LucetMemory::new(vmctx);
                     let mut ctx: #ctx_type = #ctx_constructor;
-                    // Safety requires exactly one BorrowChecker for a given WebAssembly memory.
-                    // Because we do not make recursive calls into WebAssembly, this is safe.
-                    let bc = unsafe { lucet_wiggle::BorrowChecker::new() };
-                    super::#mod_name::#method_name(&ctx, &memory, &bc, #(#call_args),*)
+                    super::#mod_name::#method_name(&ctx, &memory, #(#call_args),*)
                 }
             }
         });

--- a/lucet-wiggle/generate/src/lib.rs
+++ b/lucet-wiggle/generate/src/lib.rs
@@ -64,7 +64,10 @@ pub fn generate(
                 pub fn #name(vmctx: &lucet_runtime::vmctx::Vmctx, #(#func_args),*) -> #rets {
                     let memory = lucet_wiggle::runtime::LucetMemory::new(vmctx);
                     let mut ctx: #ctx_type = #ctx_constructor;
-                    super::#mod_name::#method_name(&ctx, &memory, #(#call_args),*)
+                    // Safety requires exactly one BorrowChecker for a given WebAssembly memory.
+                    // Because we do not make recursive calls into WebAssembly, this is safe.
+                    let bc = unsafe { lucet_wiggle::BorrowChecker::new() };
+                    super::#mod_name::#method_name(&ctx, &memory, &bc, #(#call_args),*)
                 }
             }
         });

--- a/lucet-wiggle/macro/Cargo.toml
+++ b/lucet-wiggle/macro/Cargo.toml
@@ -13,7 +13,7 @@ proc-macro = true
 
 [dependencies]
 lucet-wiggle-generate = { path = "../generate", version = "0.7.0-dev" }
-wiggle-generate = { path = "../../wasmtime/crates/wiggle/generate", version = "0.15.0" }
+wiggle-generate = { path = "../../wasmtime/crates/wiggle/generate", version = "0.16.0" }
 witx = { path = "../../wasmtime/crates/wasi-common/WASI/tools/witx", version = "0.8.4" }
 syn = { version = "1.0", features = ["full"] }
 quote = "1.0"

--- a/lucet-wiggle/src/lib.rs
+++ b/lucet-wiggle/src/lib.rs
@@ -1,7 +1,7 @@
 pub use lucet_wiggle_generate::bindings;
 pub use lucet_wiggle_macro::from_witx;
 pub use wiggle::{
-    witx, GuestBorrows, GuestError, GuestErrorType, GuestMemory, GuestPtr, GuestType,
+    witx, BorrowChecker, GuestError, GuestErrorType, GuestMemory, GuestPtr, GuestType,
     GuestTypeTransparent, Pointee,
 };
 

--- a/lucet-wiggle/src/lib.rs
+++ b/lucet-wiggle/src/lib.rs
@@ -1,8 +1,8 @@
 pub use lucet_wiggle_generate::bindings;
 pub use lucet_wiggle_macro::from_witx;
 pub use wiggle::{
-    witx, BorrowChecker, GuestError, GuestErrorType, GuestMemory, GuestPtr, GuestType,
-    GuestTypeTransparent, Pointee,
+    witx, BorrowChecker, GuestError, GuestErrorType, GuestMemory, GuestPtr, GuestSlice, GuestStr,
+    GuestType, GuestTypeTransparent, Pointee,
 };
 
 pub mod generate {

--- a/lucetc/Cargo.toml
+++ b/lucetc/Cargo.toml
@@ -27,7 +27,7 @@ target-lexicon = "0.10"
 lucet-module = { path = "../lucet-module", version = "=0.7.0-dev" }
 lucet-validate = { path = "../lucet-validate", version = "=0.7.0-dev" }
 lucet-wiggle-generate = { path = "../lucet-wiggle/generate", version = "=0.7.0-dev" }
-wasmparser = "0.52.0"
+wasmparser = "0.55.0"
 clap="2.32"
 log = "0.4"
 env_logger = "0.6"

--- a/lucetc/Cargo.toml
+++ b/lucetc/Cargo.toml
@@ -27,7 +27,7 @@ target-lexicon = "0.10"
 lucet-module = { path = "../lucet-module", version = "=0.7.0-dev" }
 lucet-validate = { path = "../lucet-validate", version = "=0.7.0-dev" }
 lucet-wiggle-generate = { path = "../lucet-wiggle/generate", version = "=0.7.0-dev" }
-wasmparser = "0.51.2"
+wasmparser = "0.52.0"
 clap="2.32"
 log = "0.4"
 env_logger = "0.6"

--- a/lucetc/Cargo.toml
+++ b/lucetc/Cargo.toml
@@ -16,13 +16,13 @@ path = "lucetc/main.rs"
 [dependencies]
 anyhow = "1"
 bincode = "1.1.4"
-cranelift-codegen = { path = "../wasmtime/cranelift/codegen", version = "0.62.0" }
-cranelift-entity = { path = "../wasmtime/cranelift/entity", version = "0.62.0" }
-cranelift-native = { path = "../wasmtime/cranelift/native", version = "0.62.0" }
-cranelift-frontend = { path = "../wasmtime/cranelift/frontend", version = "0.62.0" }
-cranelift-module = { path = "../wasmtime/cranelift/module", version = "0.62.0" }
-cranelift-object = { path = "../wasmtime/cranelift/object", version = "0.62.0" }
-cranelift-wasm = { path = "../wasmtime/cranelift/wasm", version = "0.62.0" }
+cranelift-codegen = { path = "../wasmtime/cranelift/codegen", version = "0.63.0" }
+cranelift-entity = { path = "../wasmtime/cranelift/entity", version = "0.63.0" }
+cranelift-native = { path = "../wasmtime/cranelift/native", version = "0.63.0" }
+cranelift-frontend = { path = "../wasmtime/cranelift/frontend", version = "0.63.0" }
+cranelift-module = { path = "../wasmtime/cranelift/module", version = "0.63.0" }
+cranelift-object = { path = "../wasmtime/cranelift/object", version = "0.63.0" }
+cranelift-wasm = { path = "../wasmtime/cranelift/wasm", version = "0.63.0" }
 target-lexicon = "0.10"
 lucet-module = { path = "../lucet-module", version = "=0.7.0-dev" }
 lucet-validate = { path = "../lucet-validate", version = "=0.7.0-dev" }

--- a/lucetc/src/traps.rs
+++ b/lucetc/src/traps.rs
@@ -15,7 +15,6 @@ pub(crate) fn translate_trapcode(code: ir::TrapCode) -> lucet_module::TrapCode {
     match code {
         ir::TrapCode::StackOverflow => lucet_module::TrapCode::StackOverflow,
         ir::TrapCode::HeapOutOfBounds => lucet_module::TrapCode::HeapOutOfBounds,
-        ir::TrapCode::OutOfBounds => lucet_module::TrapCode::OutOfBounds,
         ir::TrapCode::IndirectCallToNull => lucet_module::TrapCode::IndirectCallToNull,
         ir::TrapCode::BadSignature => lucet_module::TrapCode::BadSignature,
         ir::TrapCode::IntegerOverflow => lucet_module::TrapCode::IntegerOverflow,


### PR DESCRIPTION
Updates wasmtime past 0.16.0 - supercedes #510 

* lucet-wiggle gets updates for wiggle automatic borrow checking
* update wasmparser dep
* update trap enumerations to keep in sync with wasmtime.