### PR TITLE
Add a few bits of polish to AllocStrategy so that it's easier to use elsewhere

### DIFF
--- a/lucet-runtime/lucet-runtime-internals/src/alloc/mod.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/alloc/mod.rs
@@ -5,6 +5,7 @@ use crate::sysdeps::host_page_size;
 use libc::c_void;
 use lucet_module::GlobalValue;
 use rand::{thread_rng, Rng, RngCore};
+use std::fmt;
 use std::sync::{Arc, Mutex, Weak};
 
 pub fn instance_heap_offset() -> usize {
@@ -79,7 +80,17 @@ pub enum AllocStrategy {
     /// supplied random number generator.
     ///
     /// This strategy is used to create reproducible behavior for testing.
-    CustomRandom(Arc<Mutex<dyn RngCore>>),
+    CustomRandom(Arc<Mutex<dyn RngCore + Send>>),
+}
+
+impl fmt::Debug for AllocStrategy {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            AllocStrategy::Linear => write!(f, "AllocStrategy::Linear"),
+            AllocStrategy::Random => write!(f, "AllocStrategy::Random"),
+            AllocStrategy::CustomRandom(_) => write!(f, "AllocStrategy::CustomRandom(...)"),
+        }
+    }
 }
 
 impl AllocStrategy {


### PR DESCRIPTION
Add a few bits of polish to AllocStrategy so that it's easier to use elsewhere.  

When AllocStrategy is used by a data structure passed across multiple threads, it would be handy to have both the AllocStrategy and its inner Mutex equipped with `Send`.  In times where one wants to use `#[derive(Debug)]`, it would also be handy for AllocStrategy to have an `impl` of `Debug`.