### PR TITLE
integrate wiggle tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,14 +306,14 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "byteorder",
  "cranelift-bforest",
@@ -330,7 +330,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "cranelift-codegen-shared",
  "cranelift-entity",
@@ -338,15 +338,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.63.0"
+version = "0.64.0"
 
 [[package]]
 name = "cranelift-entity"
-version = "0.63.0"
+version = "0.64.0"
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -356,7 +356,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -367,7 +367,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "cranelift-codegen",
  "raw-cpuid 7.0.3",
@@ -376,7 +376,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-object"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "cranelift-codegen",
  "cranelift-module",
@@ -386,14 +386,14 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
  "cranelift-frontend",
  "log",
  "thiserror",
- "wasmparser 0.55.0",
+ "wasmparser 0.57.0",
 ]
 
 [[package]]
@@ -972,7 +972,7 @@ dependencies = [
  "rand 0.7.3",
  "raw-cpuid 6.1.0",
  "thiserror",
- "tracing 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing",
  "userfaultfd",
 ]
 
@@ -1172,7 +1172,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "wabt",
- "wasmparser 0.55.0",
+ "wasmparser 0.57.0",
 ]
 
 [[package]]
@@ -1702,9 +1702,9 @@ checksum = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 
 [[package]]
 name = "regalloc"
-version = "0.0.24"
+version = "0.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5842bece8a4b1690ffa6d9d959081c1d5d851ee4337a36c0a121fafe8c16add2"
+checksum = "cca5b48c9db66c5ba084e4660b4c0cfe8b551a96074bc04b7c11de86ad0bf1f9"
 dependencies = [
  "log",
  "rustc-hash",
@@ -2125,34 +2125,14 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.14"
-source = "git+https://github.com/tokio-rs/tracing#180e494c7a13c0a18c09f3c7b465e8734c51f5e2"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a41f40ed0e162c911ac6fcb53ecdc8134c46905fdbbae8c50add462a538b495f"
 dependencies = [
  "cfg-if",
  "log",
- "tracing-attributes 0.1.8 (git+https://github.com/tokio-rs/tracing)",
- "tracing-core 0.1.10 (git+https://github.com/tokio-rs/tracing)",
-]
-
-[[package]]
-name = "tracing"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7c6b59d116d218cb2d990eb06b77b64043e0268ef7323aae63d8b30ae462923"
-dependencies = [
- "cfg-if",
- "tracing-attributes 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing-core 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.8"
-source = "git+https://github.com/tokio-rs/tracing#180e494c7a13c0a18c09f3c7b465e8734c51f5e2"
-dependencies = [
- "proc-macro2 1.0.13",
- "quote 1.0.6",
- "syn 1.0.22",
+ "tracing-attributes",
+ "tracing-core",
 ]
 
 [[package]]
@@ -2164,14 +2144,6 @@ dependencies = [
  "proc-macro2 1.0.13",
  "quote 1.0.6",
  "syn 1.0.22",
-]
-
-[[package]]
-name = "tracing-core"
-version = "0.1.10"
-source = "git+https://github.com/tokio-rs/tracing#180e494c7a13c0a18c09f3c7b465e8734c51f5e2"
-dependencies = [
- "lazy_static",
 ]
 
 [[package]]
@@ -2312,7 +2284,7 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi-common"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -2398,9 +2370,9 @@ checksum = "733954023c0b39602439e60a65126fd31b003196d3a1e8e4531b055165a79b31"
 
 [[package]]
 name = "wasmparser"
-version = "0.55.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af931e2e1960c53f4a28b063fec4cacd036f35acbec8ff3a4739125b17382a87"
+checksum = "32fddd575d477c6e9702484139cf9f23dcd554b06d185ed0f56c857dd3a47aa6"
 
 [[package]]
 name = "wast"
@@ -2423,7 +2395,7 @@ dependencies = [
 
 [[package]]
 name = "wig"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "heck",
  "proc-macro2 1.0.13",
@@ -2433,17 +2405,17 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "thiserror",
- "tracing 0.1.14 (git+https://github.com/tokio-rs/tracing)",
+ "tracing",
  "wiggle-macro",
  "witx",
 ]
 
 [[package]]
 name = "wiggle-generate"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "heck",
@@ -2455,7 +2427,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "quote 1.0.6",
  "syn 1.0.22",
@@ -2465,7 +2437,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-test"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "proptest",
  "wiggle",
@@ -2516,7 +2488,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winx"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "bitflags 1.2.1",
  "cvt",
@@ -2541,7 +2513,7 @@ checksum = "da90eac47bf1d7871b75004b9b631d107df15f37669383b23f0b5297bc7516b6"
 
 [[package]]
 name = "yanix"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "bitflags 1.2.1",
  "cfg-if",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -972,7 +972,7 @@ dependencies = [
  "rand 0.7.3",
  "raw-cpuid 6.1.0",
  "thiserror",
- "tracing",
+ "tracing 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "userfaultfd",
 ]
 
@@ -2126,12 +2126,33 @@ dependencies = [
 [[package]]
 name = "tracing"
 version = "0.1.14"
+source = "git+https://github.com/tokio-rs/tracing#180e494c7a13c0a18c09f3c7b465e8734c51f5e2"
+dependencies = [
+ "cfg-if",
+ "log",
+ "tracing-attributes 0.1.8 (git+https://github.com/tokio-rs/tracing)",
+ "tracing-core 0.1.10 (git+https://github.com/tokio-rs/tracing)",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7c6b59d116d218cb2d990eb06b77b64043e0268ef7323aae63d8b30ae462923"
 dependencies = [
  "cfg-if",
- "tracing-attributes",
- "tracing-core",
+ "tracing-attributes 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-core 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.8"
+source = "git+https://github.com/tokio-rs/tracing#180e494c7a13c0a18c09f3c7b465e8734c51f5e2"
+dependencies = [
+ "proc-macro2 1.0.13",
+ "quote 1.0.6",
+ "syn 1.0.22",
 ]
 
 [[package]]
@@ -2143,6 +2164,14 @@ dependencies = [
  "proc-macro2 1.0.13",
  "quote 1.0.6",
  "syn 1.0.22",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.10"
+source = "git+https://github.com/tokio-rs/tracing#180e494c7a13c0a18c09f3c7b465e8734c51f5e2"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -2407,6 +2436,7 @@ name = "wiggle"
 version = "0.16.0"
 dependencies = [
  "thiserror",
+ "tracing 0.1.14 (git+https://github.com/tokio-rs/tracing)",
  "wiggle-macro",
  "witx",
 ]

--- a/lucet-module/Cargo.toml
+++ b/lucet-module/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
-cranelift-entity = { path = "../wasmtime/cranelift/entity", version = "0.63.0" }
+cranelift-entity = { path = "../wasmtime/cranelift/entity", version = "0.64.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bincode = "1.1.4"

--- a/lucet-validate/Cargo.toml
+++ b/lucet-validate/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 [dependencies]
 clap = "2"
 witx = { path = "../wasmtime/crates/wasi-common/WASI/tools/witx", version = "0.8.5" }
-cranelift-entity = { path = "../wasmtime/cranelift/entity", version = "0.63.0" }
+cranelift-entity = { path = "../wasmtime/cranelift/entity", version = "0.64.0" }
 thiserror = "1.0.4"
 wasmparser = "0.52.0"
 

--- a/lucet-wasi/Cargo.toml
+++ b/lucet-wasi/Cargo.toml
@@ -22,7 +22,7 @@ lucet-wiggle = { path = "../lucet-wiggle", version = "=0.7.0-dev" }
 libc = "0.2.65"
 nix = "0.17"
 rand = "0.6"
-wasi-common = { path = "../wasmtime/crates/wasi-common", version = "0.16.0", features = ["wiggle_metadata"] }
+wasi-common = { path = "../wasmtime/crates/wasi-common", version = "0.17.0", features = ["wiggle_metadata"] }
 
 [dev-dependencies]
 lucet-wasi-sdk = { path = "../lucet-wasi-sdk" }

--- a/lucet-wasi/generate/Cargo.toml
+++ b/lucet-wasi/generate/Cargo.toml
@@ -13,8 +13,8 @@ proc-macro = true
 
 [dependencies]
 lucet-wiggle = { path = "../../lucet-wiggle", version = "0.7.0-dev" }
-wasi-common = { path = "../../wasmtime/crates/wasi-common",  version = "0.16.0", features = ["wiggle_metadata"] }
-wiggle-generate = { path = "../../wasmtime/crates/wiggle/generate",  version = "0.16.0" }
+wasi-common = { path = "../../wasmtime/crates/wasi-common",  version = "0.17.0", features = ["wiggle_metadata"] }
+wiggle-generate = { path = "../../wasmtime/crates/wiggle/generate",  version = "0.17.0" }
 syn = { version = "1.0", features = ["full"] }
 quote = "1.0"
 proc-macro2 = "1.0"

--- a/lucet-wasi/generate/src/lib.rs
+++ b/lucet-wasi/generate/src/lib.rs
@@ -12,13 +12,14 @@ pub fn bindings(args: TokenStream) -> TokenStream {
     let doc = wasi_common::wasi::metadata::document();
     let names = Names::new(&config.ctx_name, quote!(lucet_wiggle));
 
+    let error_transform = wiggle_generate::ErrorTransform::empty();
+
     let modules = doc.modules().map(|module| {
         let modname = names.module(&module.name);
-        let trait_name = names.trait_name(&module.name);
         let fs = module
             .funcs()
-            .map(|f| define_func(&names, &f, quote!(#trait_name)));
-        let modtrait = define_module_trait(&names, &module);
+            .map(|f| define_func(&names, &module, &f, &error_transform));
+        let modtrait = define_module_trait(&names, &module, &error_transform);
         let ctx_type = names.ctx_type();
         quote! {
             pub mod #modname {

--- a/lucet-wasi/generate/src/lib.rs
+++ b/lucet-wasi/generate/src/lib.rs
@@ -40,6 +40,8 @@ pub fn bindings(args: TokenStream) -> TokenStream {
         &config.ctx_name,
         &config.constructor,
         &quote!(wasi_common::wasi),
+        &quote!(), // pre_hook,
+        &quote!(), // post_hook,
     ));
 
     TokenStream::from(ts)

--- a/lucet-wiggle/Cargo.toml
+++ b/lucet-wiggle/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 lucet-wiggle-macro = { path = "./macro", version = "0.7.0-dev" }
 lucet-wiggle-generate = { path = "./generate", version = "0.7.0-dev" }
 lucet-runtime = { path = "../lucet-runtime", version = "0.7.0-dev" }
-wiggle =  { path = "../wasmtime/crates/wiggle", version = "0.16.0" }
+wiggle =  { path = "../wasmtime/crates/wiggle", version = "0.17.0" }
 
 [dev-dependencies]
 wiggle-test = { path = "../wasmtime/crates/wiggle/test-helpers" }

--- a/lucet-wiggle/generate/Cargo.toml
+++ b/lucet-wiggle/generate/Cargo.toml
@@ -9,7 +9,7 @@ authors = ["Lucet team <lucet@fastly.com>"]
 edition = "2018"
 
 [dependencies]
-wiggle-generate = { path = "../../wasmtime/crates/wiggle/generate", version = "0.16.0" }
+wiggle-generate = { path = "../../wasmtime/crates/wiggle/generate", version = "0.17.0" }
 lucet-module = { path = "../../lucet-module", version = "0.7.0-dev" }
 witx = { path = "../../wasmtime/crates/wasi-common/WASI/tools/witx", version = "0.8.4" }
 quote = "1.0"

--- a/lucet-wiggle/generate/src/lib.rs
+++ b/lucet-wiggle/generate/src/lib.rs
@@ -33,6 +33,8 @@ pub fn generate(
     ctx_type: &Ident,
     ctx_constructor: &TokenStream,
     wiggle_mod_path: &TokenStream,
+    pre_hook: &TokenStream,
+    post_hook: &TokenStream,
 ) -> TokenStream {
     let names = wiggle_generate::Names::new(ctx_type, quote!(lucet_wiggle));
     let fs = doc.modules().map(|m| {
@@ -62,9 +64,12 @@ pub fn generate(
                 #[lucet_hostcall]
                 #[no_mangle]
                 pub fn #name(vmctx: &lucet_runtime::vmctx::Vmctx, #(#func_args),*) -> #rets {
+                    { #pre_hook }
                     let memory = lucet_wiggle::runtime::LucetMemory::new(vmctx);
                     let mut ctx: #ctx_type = #ctx_constructor;
-                    super::#mod_name::#method_name(&ctx, &memory, #(#call_args),*)
+                    let r = super::#mod_name::#method_name(&ctx, &memory, #(#call_args),*);
+                    { #post_hook }
+                    r
                 }
             }
         });

--- a/lucet-wiggle/macro/Cargo.toml
+++ b/lucet-wiggle/macro/Cargo.toml
@@ -13,7 +13,7 @@ proc-macro = true
 
 [dependencies]
 lucet-wiggle-generate = { path = "../generate", version = "0.7.0-dev" }
-wiggle-generate = { path = "../../wasmtime/crates/wiggle/generate", version = "0.16.0" }
+wiggle-generate = { path = "../../wasmtime/crates/wiggle/generate", version = "0.17.0" }
 witx = { path = "../../wasmtime/crates/wasi-common/WASI/tools/witx", version = "0.8.4" }
 syn = { version = "1.0", features = ["full"] }
 quote = "1.0"

--- a/lucet-wiggle/macro/src/lib.rs
+++ b/lucet-wiggle/macro/src/lib.rs
@@ -22,6 +22,8 @@ pub fn from_witx(args: TokenStream) -> TokenStream {
         &config.wiggle.ctx.name,
         &config.constructor,
         &quote!(super),
+        &config.pre_hook.unwrap_or(quote!()),
+        &config.post_hook.unwrap_or(quote!()),
     ));
     TokenStream::from(ts)
 }

--- a/lucet-wiggle/macro/src/lib.rs
+++ b/lucet-wiggle/macro/src/lib.rs
@@ -10,10 +10,12 @@ pub fn from_witx(args: TokenStream) -> TokenStream {
         std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANFIEST_DIR env var"),
     );
 
-    let doc = witx::load(&config.wiggle.witx.paths).expect("lucet loading witx");
+    let doc = config.wiggle.load_document();
 
     let names = wiggle_generate::Names::new(&config.wiggle.ctx.name, quote!(lucet_wiggle));
-    let mut ts = wiggle_generate::generate(&doc, &names);
+    let error_transform = wiggle_generate::ErrorTransform::new(&config.wiggle.errors, &doc)
+        .expect("validating error transform");
+    let mut ts = wiggle_generate::generate(&doc, &names, &error_transform);
     ts.extend(wiggle_generate::generate_metadata(&doc, &names));
     ts.extend(lucet_wiggle_generate::generate(
         &doc,

--- a/lucet-wiggle/src/lib.rs
+++ b/lucet-wiggle/src/lib.rs
@@ -1,8 +1,8 @@
 pub use lucet_wiggle_generate::bindings;
 pub use lucet_wiggle_macro::from_witx;
 pub use wiggle::{
-    witx, BorrowChecker, GuestError, GuestErrorType, GuestMemory, GuestPtr, GuestSlice, GuestStr,
-    GuestType, GuestTypeTransparent, Pointee,
+    tracing, witx, BorrowChecker, GuestError, GuestErrorType, GuestMemory, GuestPtr, GuestSlice,
+    GuestStr, GuestType, GuestTypeTransparent, Pointee,
 };
 
 pub mod generate {

--- a/lucetc/Cargo.toml
+++ b/lucetc/Cargo.toml
@@ -16,18 +16,18 @@ path = "lucetc/main.rs"
 [dependencies]
 anyhow = "1"
 bincode = "1.1.4"
-cranelift-codegen = { path = "../wasmtime/cranelift/codegen", version = "0.63.0" }
-cranelift-entity = { path = "../wasmtime/cranelift/entity", version = "0.63.0" }
-cranelift-native = { path = "../wasmtime/cranelift/native", version = "0.63.0" }
-cranelift-frontend = { path = "../wasmtime/cranelift/frontend", version = "0.63.0" }
-cranelift-module = { path = "../wasmtime/cranelift/module", version = "0.63.0" }
-cranelift-object = { path = "../wasmtime/cranelift/object", version = "0.63.0" }
-cranelift-wasm = { path = "../wasmtime/cranelift/wasm", version = "0.63.0" }
+cranelift-codegen = { path = "../wasmtime/cranelift/codegen", version = "0.64.0" }
+cranelift-entity = { path = "../wasmtime/cranelift/entity", version = "0.64.0" }
+cranelift-native = { path = "../wasmtime/cranelift/native", version = "0.64.0" }
+cranelift-frontend = { path = "../wasmtime/cranelift/frontend", version = "0.64.0" }
+cranelift-module = { path = "../wasmtime/cranelift/module", version = "0.64.0" }
+cranelift-object = { path = "../wasmtime/cranelift/object", version = "0.64.0" }
+cranelift-wasm = { path = "../wasmtime/cranelift/wasm", version = "0.64.0" }
 target-lexicon = "0.10"
 lucet-module = { path = "../lucet-module", version = "=0.7.0-dev" }
 lucet-validate = { path = "../lucet-validate", version = "=0.7.0-dev" }
 lucet-wiggle-generate = { path = "../lucet-wiggle/generate", version = "=0.7.0-dev" }
-wasmparser = "0.55.0"
+wasmparser = "0.57.0"
 clap="2.32"
 log = "0.4"
 env_logger = "0.6"

--- a/lucetc/src/function.rs
+++ b/lucetc/src/function.rs
@@ -556,7 +556,7 @@ impl<'a> FuncEnvironment for FuncInfo<'a> {
     fn translate_table_grow(
         &mut self,
         _pos: FuncCursor,
-        _table_index: u32,
+        _table_index: TableIndex,
         _delta: ir::Value,
         _init_value: ir::Value,
     ) -> WasmResult<ir::Value> {
@@ -568,7 +568,7 @@ impl<'a> FuncEnvironment for FuncInfo<'a> {
     fn translate_table_get(
         &mut self,
         _pos: FuncCursor,
-        _table_index: u32,
+        _table_index: TableIndex,
         _index: ir::Value,
     ) -> WasmResult<ir::Value> {
         Err(WasmError::Unsupported(
@@ -579,7 +579,7 @@ impl<'a> FuncEnvironment for FuncInfo<'a> {
     fn translate_table_set(
         &mut self,
         _pos: FuncCursor,
-        _table_index: u32,
+        _table_index: TableIndex,
         _value: ir::Value,
         _index: ir::Value,
     ) -> WasmResult<()> {
@@ -608,7 +608,7 @@ impl<'a> FuncEnvironment for FuncInfo<'a> {
     fn translate_table_fill(
         &mut self,
         _pos: FuncCursor,
-        _table_index: u32,
+        _table_index: TableIndex,
         _dst: ir::Value,
         _val: ir::Value,
         _len: ir::Value,

--- a/lucetc/src/runtime.rs
+++ b/lucetc/src/runtime.rs
@@ -1,6 +1,7 @@
 use cranelift_codegen::ir::{types, AbiParam, Signature};
 use cranelift_codegen::isa::TargetFrontendConfig;
 use std::collections::HashMap;
+use wasmparser::FuncType;
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, Clone)]
 pub enum RuntimeFunc {
@@ -8,8 +9,14 @@ pub enum RuntimeFunc {
     MemGrow,
 }
 
+pub struct RuntimeFuncType {
+    pub name: String,
+    pub signature: Signature,
+    pub wasm_func_type: FuncType,
+}
+
 pub struct Runtime {
-    pub functions: HashMap<RuntimeFunc, (String, Signature)>,
+    pub functions: HashMap<RuntimeFunc, RuntimeFuncType>,
 }
 
 impl Runtime {
@@ -17,27 +24,35 @@ impl Runtime {
         let mut functions = HashMap::new();
         functions.insert(
             RuntimeFunc::MemSize,
-            (
-                "lucet_vmctx_current_memory".to_owned(),
-                Signature {
+            RuntimeFuncType {
+                name: "lucet_vmctx_current_memory".to_owned(),
+                signature: Signature {
                     params: vec![],
                     returns: vec![AbiParam::new(types::I32)],
                     call_conv: target.default_call_conv,
                 },
-            ),
+                wasm_func_type: FuncType {
+                    params: vec![].into_boxed_slice(),
+                    returns: vec![wasmparser::Type::I32].into_boxed_slice(),
+                },
+            },
         );
         functions.insert(
             RuntimeFunc::MemGrow,
-            (
-                "lucet_vmctx_grow_memory".to_owned(),
-                Signature {
+            RuntimeFuncType {
+                name: "lucet_vmctx_grow_memory".to_owned(),
+                signature: Signature {
                     params: vec![
                         AbiParam::new(types::I32), // wasm pages to grow
                     ],
                     returns: vec![AbiParam::new(types::I32)],
                     call_conv: target.default_call_conv,
                 },
-            ),
+                wasm_func_type: FuncType {
+                    params: vec![wasmparser::Type::I32].into_boxed_slice(),
+                    returns: vec![wasmparser::Type::I32].into_boxed_slice(),
+                },
+            },
         );
         Self { functions }
     }

--- a/lucetc/src/stack_probe.rs
+++ b/lucetc/src/stack_probe.rs
@@ -16,6 +16,7 @@ use cranelift_codegen::{
     isa::CallConv,
 };
 use cranelift_module::{Backend as ClifBackend, Linkage, Module as ClifModule, TrapSite};
+use wasmparser::FuncType;
 
 /// Stack probe symbol name
 pub const STACK_PROBE_SYM: &str = "lucet_probestack";
@@ -61,6 +62,10 @@ pub fn declare<'a, B: ClifBackend>(
             clif_module,
             STACK_PROBE_SYM.to_string(),
             Linkage::Local,
+            &FuncType {
+                params: vec![].into_boxed_slice(),
+                returns: vec![wasmparser::Type::I32].into_boxed_slice(),
+            },
             Signature {
                 params: vec![],
                 returns: vec![AbiParam::new(types::I32)],

--- a/lucetc/src/types.rs
+++ b/lucetc/src/types.rs
@@ -1,8 +1,8 @@
-use cranelift_codegen::ir;
 use lucet_module::Signature;
 use lucet_module::ValueType;
 use std::fmt::{self, Display};
 use thiserror::Error;
+use wasmparser::FuncType;
 
 #[derive(Debug)]
 pub enum ValueError {
@@ -10,40 +10,20 @@ pub enum ValueError {
     InvalidVMContext,
 }
 
-fn to_lucet_value(value: &ir::AbiParam) -> Result<ValueType, ValueError> {
-    match value {
-        ir::AbiParam {
-            value_type: cranelift_ty,
-            purpose: ir::ArgumentPurpose::Normal,
-            extension: ir::ArgumentExtension::None,
-            location: ir::ArgumentLoc::Unassigned,
-        } => {
-            let size = cranelift_ty.bits();
-
-            if cranelift_ty.is_int() {
-                match size {
-                    32 => Ok(ValueType::I32),
-                    64 => Ok(ValueType::I64),
-                    _ => Err(ValueError::Unrepresentable),
-                }
-            } else if cranelift_ty.is_float() {
-                match size {
-                    32 => Ok(ValueType::F32),
-                    64 => Ok(ValueType::F64),
-                    _ => Err(ValueError::Unrepresentable),
-                }
-            } else {
-                Err(ValueError::Unrepresentable)
-            }
-        }
+fn to_lucet_valuetype(ty: &wasmparser::Type) -> Result<ValueType, ValueError> {
+    match ty {
+        wasmparser::Type::I32 => Ok(ValueType::I32),
+        wasmparser::Type::I64 => Ok(ValueType::I64),
+        wasmparser::Type::F32 => Ok(ValueType::F32),
+        wasmparser::Type::F64 => Ok(ValueType::F64),
         _ => Err(ValueError::Unrepresentable),
     }
 }
 
 #[derive(Debug, Error)]
 pub enum SignatureError {
-    BadElement(ir::AbiParam, ValueError),
-    BadSignature,
+    Type(wasmparser::Type, ValueError),
+    Multivalue,
 }
 
 impl Display for SignatureError {
@@ -52,58 +32,25 @@ impl Display for SignatureError {
     }
 }
 
-pub fn to_lucet_signature(value: &ir::Signature) -> Result<Signature, SignatureError> {
-    let mut params: Vec<ValueType> = Vec::new();
+pub fn to_lucet_signature(func_type: &FuncType) -> Result<Signature, SignatureError> {
+    let params = func_type
+        .params
+        .iter()
+        .map(|paramtype| {
+            to_lucet_valuetype(paramtype).map_err(|e| SignatureError::Type(paramtype.clone(), e))
+        })
+        .collect::<Result<Vec<ValueType>, SignatureError>>()?;
 
-    let mut param_iter = value.params.iter();
-
-    // Enforce that the first parameter is VMContext, as Signature assumes.
-    // Even functions declared no-arg take VMContext in reality.
-    if let Some(param) = param_iter.next() {
-        match &param {
-            ir::AbiParam {
-                value_type: value,
-                purpose: ir::ArgumentPurpose::VMContext,
-                extension: ir::ArgumentExtension::None,
-                location: ir::ArgumentLoc::Unassigned,
-            } => {
-                if value.is_int() && value.bits() == 64 {
-                    // this is VMContext, so we can move on.
-                } else {
-                    return Err(SignatureError::BadElement(
-                        param.to_owned(),
-                        ValueError::InvalidVMContext,
-                    ));
-                }
-            }
-            _ => {
-                return Err(SignatureError::BadElement(
-                    param.to_owned(),
-                    ValueError::InvalidVMContext,
-                ));
-            }
-        }
-    } else {
-        return Err(SignatureError::BadSignature);
-    }
-
-    for param in param_iter {
-        let value_ty =
-            to_lucet_value(param).map_err(|e| SignatureError::BadElement(param.clone(), e))?;
-
-        params.push(value_ty);
-    }
-
-    let ret_ty: Option<ValueType> = match value.returns.as_slice() {
+    let ret_ty: Option<ValueType> = match &*func_type.returns {
         &[] => None,
         &[ref ret_ty] => {
-            let value_ty = to_lucet_value(ret_ty)
-                .map_err(|e| SignatureError::BadElement(ret_ty.clone(), e))?;
+            let value_ty =
+                to_lucet_valuetype(ret_ty).map_err(|e| SignatureError::Type(ret_ty.clone(), e))?;
 
             Some(value_ty)
         }
         _ => {
-            return Err(SignatureError::BadSignature);
+            return Err(SignatureError::Multivalue);
         }
     };
 


### PR DESCRIPTION
Update wasmtime dep to include improvements to wiggle to support error transformations and the switch to use `tracing`:
https://github.com/bytecodealliance/wasmtime/pull/1796

Had to pull in some cranelift changes in the process - cranelift-wasm now keeps track of both the wasm function type and the cranelift signature, ends up being a net win that gets rid of some fallible code where we had to reverse-engineer the wasm function type back out of the signature. thank you @fitzgen!
