### PR TITLE
upgrade to wasi-sdk-11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,7 +181,7 @@ commands:
           condition: << parameters.cache_target >>
           steps:
             - save_cache:
-                key: target_dir-macos-{{ .Branch }}-{{ checksum "Cargo.lock" }}
+                key: target_dir-macos-{{ .Branch }}-{{ checksum "Cargo.lock" }}-{{ .Environment.CACHE_VERSION }}
                 paths:
                   - "target"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,10 +166,10 @@ commands:
           name: "Install wasi-sdk"
           command: |
             set -x
-            curl -sS -L -O https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-10/wasi-sdk-10.0-macos.tar.gz
-            tar xf wasi-sdk-10.0-macos.tar.gz
+            curl -sS -L -O https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-11/wasi-sdk-11.0-macos.tar.gz
+            tar xf wasi-sdk-11.0-macos.tar.gz
             sudo mkdir -p /opt/wasi-sdk
-            sudo mv wasi-sdk-10.0/* /opt/wasi-sdk/
+            sudo mv wasi-sdk-11.0/* /opt/wasi-sdk/
       - run:
           name: "Make target: test-ci"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,9 +144,9 @@ commands:
                   # The hope is that even if some of the dependencies change between branches and
                   # revisions, that enough of the slow-changing dependencies will remain static that
                   # Cargo won't have to rebuild them.
-                  - target_dir-macos-{{ .Branch }}-{{ checksum "Cargo.lock" }}
-                  - target_dir-macos-{{ .Branch }}-
-                  - target_dir-macos-
+                  - target_dir-macos-{{ .Branch }}-{{ checksum "Cargo.lock" }}-{{ .Environment.CACHE_VERSION }}
+                  - target_dir-macos-{{ .Branch }}-{{ .Environment.CACHE_VERSION }}
+                  - target_dir-macos-{{ .Environment.CACHE_VERSION }}
       - run:
           name: "Install Homebrew dependencies"
           command: |

--- a/.github/workflows/mac-ci.yml
+++ b/.github/workflows/mac-ci.yml
@@ -18,10 +18,10 @@ jobs:
 
     - name: Install wasi-sdk (macos)
       run: |
-        curl -sS -L -O https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-10/wasi-sdk-10.0-macos.tar.gz
-        tar xf wasi-sdk-10.0-macos.tar.gz
+        curl -sS -L -O https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-11/wasi-sdk-11.0-macos.tar.gz
+        tar xf wasi-sdk-11.0-macos.tar.gz
         sudo mkdir -p /opt/wasi-sdk
-        sudo mv wasi-sdk-10.0/* /opt/wasi-sdk/
+        sudo mv wasi-sdk-11.0/* /opt/wasi-sdk/
 
     - name: Test Lucet
       run: make test-ci

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,8 +43,9 @@ RUN rustup target add wasm32-wasi
 # Optional additional Rust programs
 RUN cargo install --debug rsign2 cargo-audit mdbook
 
-RUN curl -sSLO https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-10/wasi-sdk_10.0_amd64.deb \
-	&& dpkg -i wasi-sdk_10.0_amd64.deb && rm -f wasi-sdk_10.0_amd64.deb
+RUN curl -sSLO https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-11/wasi-sdk_11.0_amd64_ubuntu20.04.deb \
+    && dpkg -i wasi-sdk_11.0_amd64_ubuntu20.04.deb \
+    && rm -f wasi-sdk_11.0_amd64_ubuntu20.04.deb
 
 ENV WASI_SDK=/opt/wasi-sdk
 

--- a/lucet-module/src/signature.rs
+++ b/lucet-module/src/signature.rs
@@ -6,7 +6,7 @@ use byteorder::{ByteOrder, LittleEndian};
 use memoffset::offset_of;
 pub use minisign::{PublicKey, SecretKey};
 use minisign::{SignatureBones, SignatureBox};
-use object::{read::ObjectSection, NativeFile as ObjectFile, Object, SymbolKind};
+use object::{NativeFile as ObjectFile, Object, SymbolKind};
 use std::fs::{File, OpenOptions};
 use std::io::{self, Cursor, Read, Seek, SeekFrom, Write};
 use std::path::Path;
@@ -146,6 +146,8 @@ impl RawModuleAndData {
         symbol_name: &str,
         _mangle: bool,
     ) -> Result<Option<SymbolData>, io::Error> {
+        use object::read::ObjectSection;
+
         let obj = ObjectFile::parse(obj_bin)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
         let symbol_map = obj.symbol_map();


### PR DESCRIPTION
Upgrade to wasi-sdk-11 in the CI scripts.

Also, add a CACHE_VERSION environment variable to the circle ci macos cache key, because the cache has gotten too big to successfully restore and circle-ci's honest answer to that glaring flaw in their product is "just roll your own cache invalidation system on the spot, itll be fine" which is pretty cool