### PR TITLE
Minor cleanups

### DIFF
--- a/lucetc/src/lib.rs
+++ b/lucetc/src/lib.rs
@@ -261,7 +261,7 @@ impl<T: AsLucetc> LucetcOpts for T {
 }
 
 impl Lucetc {
-    pub fn new<P: AsRef<Path>>(input: P) -> Self {
+    pub fn new(input: impl AsRef<Path>) -> Self {
         let input = input.as_ref();
         Self {
             input: LucetcInput::Path(input.to_owned()),
@@ -274,7 +274,7 @@ impl Lucetc {
         }
     }
 
-    pub fn try_from_bytes<B: AsRef<[u8]>>(bytes: B) -> Result<Self, Error> {
+    pub fn try_from_bytes(bytes: impl AsRef<[u8]>) -> Result<Self, Error> {
         let input = read_bytes(bytes.as_ref().to_vec())?;
         Ok(Self {
             input: LucetcInput::Bytes(input),
@@ -302,7 +302,7 @@ impl Lucetc {
         Ok((module_binary, bindings))
     }
 
-    pub fn object_file<P: AsRef<Path>>(&self, output: P) -> Result<(), Error> {
+    pub fn object_file(&self, output: impl AsRef<Path>) -> Result<(), Error> {
         let (module_contents, bindings) = self.build()?;
         let compiler = self.builder.create(&module_contents, &bindings)?;
         let obj = compiler.object_file()?;
@@ -311,7 +311,7 @@ impl Lucetc {
         Ok(())
     }
 
-    pub fn clif_ir<P: AsRef<Path>>(&self, output: P) -> Result<(), Error> {
+    pub fn clif_ir(&self, output: impl AsRef<Path>) -> Result<(), Error> {
         let (module_contents, bindings) = self.build()?;
 
         let compiler = self.builder.create(&module_contents, &bindings)?;
@@ -321,7 +321,7 @@ impl Lucetc {
         Ok(())
     }
 
-    pub fn shared_object_file<P: AsRef<Path>>(&self, output: P) -> Result<(), Error> {
+    pub fn shared_object_file(&self, output: impl AsRef<Path>) -> Result<(), Error> {
         let dir = tempfile::Builder::new().prefix("lucetc").tempdir()?;
         let objpath = dir.path().join("tmp.o");
         self.object_file(objpath.clone())?;
@@ -338,11 +338,11 @@ impl Lucetc {
 
 const LD_DEFAULT: &str = "ld";
 
-fn link_so<P, Q>(objpath: P, target: &Triple, sopath: Q) -> Result<(), Error>
-where
-    P: AsRef<Path>,
-    Q: AsRef<Path>,
-{
+fn link_so(
+    objpath: impl AsRef<Path>,
+    target: &Triple,
+    sopath: impl AsRef<Path>,
+) -> Result<(), Error> {
     // Let `LD` be something like "clang --target=... ..." for convenience.
     let env_ld = env::var("LD").unwrap_or(LD_DEFAULT.into());
     let mut ld_iter = env_ld.split_whitespace();
@@ -373,10 +373,7 @@ where
     Ok(())
 }
 
-fn output_arg_for<P>(cmd_ld: &mut Command, target: &Triple, sopath: P)
-where
-    P: AsRef<Path>,
-{
+fn output_arg_for(cmd_ld: &mut Command, target: &Triple, sopath: impl AsRef<Path>) {
     use target_lexicon::{Environment, OperatingSystem};
 
     if target.operating_system != OperatingSystem::Windows || target.environment == Environment::Gnu

--- a/lucetc/src/load.rs
+++ b/lucetc/src/load.rs
@@ -1,22 +1,16 @@
 use crate::error::Error;
 use crate::signature::{self, PublicKey};
-use std::fs::File;
-use std::io::Read;
 use std::path::Path;
 use wabt::{wat2wasm, ErrorKind};
 
-pub fn read_module<P: AsRef<Path>>(
-    path: P,
+pub fn read_module(
+    path: impl AsRef<Path>,
     pk: &Option<PublicKey>,
     verify: bool,
 ) -> Result<Vec<u8>, Error> {
-    let signature_box = if verify {
-        Some(signature::signature_box_for_module_path(&path)?)
-    } else {
-        None
-    };
-    let contents = read_to_u8s(path)?;
-    if let Some(signature_box) = signature_box {
+    let contents = std::fs::read(&path)?;
+    if verify {
+        let signature_box = signature::signature_box_for_module_path(&path)?;
         signature::verify_source_code(
             &contents,
             &signature_box,
@@ -28,12 +22,11 @@ pub fn read_module<P: AsRef<Path>>(
 }
 
 pub fn read_bytes(bytes: Vec<u8>) -> Result<Vec<u8>, Error> {
-    let converted = if wasm_preamble(&bytes) {
-        bytes
+    if wasm_preamble(&bytes) {
+        Ok(bytes)
     } else {
         wat2wasm(bytes).map_err(|err| {
-            let mut result = String::from("wat2wasm error: ");
-            result.push_str(&format!("{}", err));
+            let mut result = format!("wat2wasm error: {}", err);
             match unsafe { std::mem::transmute::<wabt::Error, wabt::ErrorKind>(err) } {
                 ErrorKind::Parse(msg) |
                 // this shouldn't be reachable - we're going the other way
@@ -47,16 +40,8 @@ pub fn read_bytes(bytes: Vec<u8>) -> Result<Vec<u8>, Error> {
                 _ => { }
             };
             crate::error::Error::Input(result)
-        })?
-    };
-    Ok(converted)
-}
-
-pub fn read_to_u8s<P: AsRef<Path>>(path: P) -> Result<Vec<u8>, Error> {
-    let mut buf: Vec<u8> = Vec::new();
-    let mut file = File::open(path)?;
-    file.read_to_end(&mut buf)?;
-    Ok(buf)
+        })
+    }
 }
 
 pub fn wasm_preamble(buf: &[u8]) -> bool {

--- a/lucetc/src/signature.rs
+++ b/lucetc/src/signature.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 
 pub const RAW_KEY_PREFIX: &str = "raw:";
 
-fn raw_key_path<P: AsRef<Path>>(path: P) -> Option<PathBuf> {
+fn raw_key_path(path: impl AsRef<Path>) -> Option<PathBuf> {
     let path = path.as_ref();
     if let Some(path) = path.to_str() {
         if path.starts_with(RAW_KEY_PREFIX) {
@@ -17,7 +17,7 @@ fn raw_key_path<P: AsRef<Path>>(path: P) -> Option<PathBuf> {
     None
 }
 
-pub fn sk_from_file<P: AsRef<Path>>(sk_path: P) -> Result<SecretKey, Error> {
+pub fn sk_from_file(sk_path: impl AsRef<Path>) -> Result<SecretKey, Error> {
     match raw_key_path(sk_path.as_ref()) {
         None => SecretKey::from_file(sk_path, None).map_err(|e| {
             let message = format!("Unable to read the secret key: {}", e);
@@ -34,7 +34,7 @@ pub fn sk_from_file<P: AsRef<Path>>(sk_path: P) -> Result<SecretKey, Error> {
     }
 }
 
-fn signature_path<P: AsRef<Path>>(path: P) -> Result<PathBuf, Error> {
+fn signature_path(path: impl AsRef<Path>) -> Result<PathBuf, Error> {
     let path = path.as_ref().to_str().ok_or_else(|| {
         let message = format!("Invalid signature path {:?}", path.as_ref());
         Error::Input(message)
@@ -42,7 +42,7 @@ fn signature_path<P: AsRef<Path>>(path: P) -> Result<PathBuf, Error> {
     Ok(PathBuf::from(format!("{}.minisig", path)))
 }
 
-pub fn signature_box_for_module_path<P: AsRef<Path>>(path: P) -> Result<SignatureBox, Error> {
+pub fn signature_box_for_module_path(path: impl AsRef<Path>) -> Result<SignatureBox, Error> {
     let signature_path = signature_path(path)?;
     SignatureBox::from_file(&signature_path).map_err(|e| {
         let message = format!("Unable to load the signature file: {}", e);
@@ -50,7 +50,7 @@ pub fn signature_box_for_module_path<P: AsRef<Path>>(path: P) -> Result<Signatur
     })
 }
 
-pub fn keygen<P: AsRef<Path>, Q: AsRef<Path>>(pk_path: P, sk_path: Q) -> Result<KeyPair, Error> {
+pub fn keygen(pk_path: impl AsRef<Path>, sk_path: impl AsRef<Path>) -> Result<KeyPair, Error> {
     match raw_key_path(&sk_path) {
         None => {
             let pk_writer = File::create(pk_path)?;
@@ -89,6 +89,6 @@ pub fn verify_source_code(
 }
 
 // Sign the compiled code
-pub fn sign_module<P: AsRef<Path>>(path: P, sk: &SecretKey) -> Result<(), Error> {
+pub fn sign_module(path: impl AsRef<Path>, sk: &SecretKey) -> Result<(), Error> {
     ModuleSignature::sign(path, sk).map_err(|e| e.into())
 }


### PR DESCRIPTION
This PR contains a few minor cleanups made along the way while getting to know the lucetc code:

* Using `impl AsRef<Path>` and similar rather than indirecting through generics.
* Using `std::fs::read`.

These are both Rust features that likely post-date the original code.