### PR TITLE
Remove a no-longer-necessary transmute

### DIFF
--- a/lucetc/src/load.rs
+++ b/lucetc/src/load.rs
@@ -27,7 +27,7 @@ pub fn read_bytes(bytes: Vec<u8>) -> Result<Vec<u8>, Error> {
     } else {
         wat2wasm(bytes).map_err(|err| {
             let mut result = format!("wat2wasm error: {}", err);
-            match unsafe { std::mem::transmute::<wabt::Error, wabt::ErrorKind>(err) } {
+            match err.kind() {
                 ErrorKind::Parse(msg) |
                 // this shouldn't be reachable - we're going the other way
                 ErrorKind::Deserialize(msg) |


### PR DESCRIPTION
Once upon a time `wabt::Error` had no way to access the inner `wabt::ErrorKind`. In those days, I'd noticed that `Error` was a struct that contained only an `ErrorKind`, so this transmute was a hack to get the `ErrorKind` and the corresponding message so we could print that out while `wabt` was being tweaked to make this doable safely.

`wabt` long since has been tweaked to make this doable safely.