### PR TITLE
Add `wrap_blocking` argument to `run_async`; rename `run_await`

### DIFF
--- a/lucet-runtime/lucet-runtime-internals/src/future.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/future.rs
@@ -99,7 +99,8 @@ impl Instance {
     /// another closure so that the types are compatible. For example:
     ///
     /// ```no_run
-    /// # let instance: InstanceHandle = unimplemented!();
+    /// # async fn f() {
+    /// # let instance: lucet_runtime_internals::instance::InstanceHandle = unimplemented!();
     /// fn block_in_place<F, R>(f: F) -> R
     /// where
     ///     F: FnOnce() -> R,
@@ -108,7 +109,8 @@ impl Instance {
     ///     # f()
     /// }
     ///
-    /// instance.run_async("entrypoint", &[], |f| block_in_place(f)).unwrap();
+    /// instance.run_async("entrypoint", &[], |f| block_in_place(f)).await.unwrap();
+    /// # }
     /// ```
     ///
     /// [tokio]: https://docs.rs/tokio/0.2.21/tokio/task/fn.block_in_place.html

--- a/lucet-runtime/lucet-runtime-internals/src/instance.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/instance.rs
@@ -523,10 +523,10 @@ impl Instance {
     /// The foreign code safety caveat of [`Instance::run()`](struct.Instance.html#method.run)
     /// applies.
     pub fn resume_with_val<A: Any + 'static>(&mut self, val: A) -> Result<RunResult, Error> {
-        self._resume_with_val(val, false)
+        self.resume_with_val_impl(val, false)
     }
 
-    pub(crate) fn _resume_with_val<A: Any + 'static>(
+    pub(crate) fn resume_with_val_impl<A: Any + 'static>(
         &mut self,
         val: A,
         async_context: bool,
@@ -1286,7 +1286,7 @@ pub enum TerminationDetails {
     Provided(Box<dyn Any + 'static>),
     /// The instance was terminated by its `KillSwitch`.
     Remote,
-    /// The instance was terminated by `Vmctx::run_await` being called from an instance
+    /// The instance was terminated by `Vmctx::block_on` being called from an instance
     /// that isnt running in an async context
     AwaitNeedsAsync,
 }


### PR DESCRIPTION
This godawful type signature enables callers to make sure Wasm execution happens on a blocking thread, for example by passing `|f| tokio::task::spawn_blocking(f)` as the `wrap_blocking` argument.

Renamed `run_await` to `block_on` for consistency with other async libraries.