### PR TITLE
we should test lucet-runtime!

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -15,4 +15,4 @@ runs:
       # rustup expects $HOME to be set to /root during `docker run` because thats what
       # it was set to during container creation. Actions clears $HOME so we set it here.
       # The test target of the Makefile is our standard CI.
-    - 'export HOME=/root; CRATES_NOT_TESTED="lucet-runtime lucet-spectest lucet-benchmarks lucet-runtime-example lucet-runtime-internals" make ${{ inputs.target }}'
+    - 'export HOME=/root; CRATES_NOT_TESTED="lucet-runtime-tests lucet-spectest lucet-benchmarks lucet-runtime-example lucet-runtime-internals" make ${{ inputs.target }}'


### PR DESCRIPTION
~I think I found a typo in some of our yaml programming. `CRATES_NOT_TESTED` included `lucet-runtime`, but that's where the runtime tests are instantiated and run. Instead, we should ignore `lucet-runtime-tests` for testing (though not strictly necessary - there are no tests in there anyway).~

Edit: not a typo, this is very much intended: we don't want to run tests for `UffdRegion` on github actions, because the Linux there doesn't support that kernel API.

I _think_ this is why https://github.com/bytecodealliance/lucet/pull/554 got as far as the `lucet-objdump` smoke test before failing, since from a quick eyeball the tests that are run either test details of Cranelift state, module translation state, or use mock modules. `lucet-runtime` is the only place we actually load up a real honest-to-goodness `DlModule`, which I believe should fail on #554 for to-be-determined weirdness between `lld` and `lucetc`'s choices of relocation.

Independently testing that `lucet-runtime` really was not being tested by waiting on CI for [this very cool new test I wrote](https://github.com/bytecodealliance/lucet/commit/e171b695d4cd896f4aadca25310a5b7933b1bdf6).