### PR TITLE
Use draft new wasi-common virtual pipe interface

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,2 @@
-[build]
+[target.'cfg(not(target_arch = "wasm32"))']
 rustflags = ["-C", "link-args=-rdynamic"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1068,6 +1068,7 @@ dependencies = [
  "structopt",
  "tempfile",
  "wait-timeout",
+ "wasi-common",
 ]
 
 [[package]]

--- a/lucet-wasi-fuzz/Cargo.toml
+++ b/lucet-wasi-fuzz/Cargo.toml
@@ -27,3 +27,4 @@ rayon = "1.0"
 structopt = "0.3.3"
 tempfile = "3.0"
 wait-timeout = "0.2"
+wasi-common = { path = "../wasmtime/crates/wasi-common" }

--- a/lucet-wasi/tests/tests.rs
+++ b/lucet-wasi/tests/tests.rs
@@ -114,18 +114,11 @@ fn getentropy() {
 
 #[test]
 fn stdin() {
-    use std::io::Write;
-    use std::os::unix::io::FromRawFd;
-
-    let (pipe_out, pipe_in) = nix::unistd::pipe().expect("can create pipe");
-
-    let mut stdin_file = unsafe { File::from_raw_fd(pipe_in) };
-    write!(stdin_file, "hello from stdin!").expect("pipe write succeeds");
-    drop(stdin_file);
+    let stdin = wasi_common::virtfs::pipe::ReadPipe::from("hello from stdin!");
 
     let mut ctx = WasiCtxBuilder::new();
     ctx.args(["stdin"].iter());
-    ctx.stdin(unsafe { File::from_raw_fd(pipe_out) });
+    ctx.stdin(stdin);
 
     let (exitcode, stdout) = run_with_stdout("stdin.c", &mut ctx).unwrap();
 


### PR DESCRIPTION
This uses a branch on wasmtime that's based on the wasmtime revision in this branch. I will be doing a PR with the same contents into wasmtime main once I write some docs for it.