### PR TITLE
Delete `cargo deb` packaging metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,10 @@ install-dev: build-dev
 	@helpers/install.sh --unoptimized
 
 .PHONY: test
-test: indent-check test-packages
+test: indent-check test-crates
 
-.PHONY: test-packages
-test-packages:
+.PHONY: test-crates
+test-crates:
 	cargo test --no-fail-fast --all $(CRATES_NOT_TESTED:%=--exclude %)
 
 .PHONY: test-full
@@ -43,12 +43,13 @@ test-release-executables:
 	helpers/lucet-toolchain-tests/objdump.sh release
 
 .PHONY: test-ci
-test-ci: test-packages test-objdump test-bitrot test-signature test-objdump
+test-ci: test-crates test-objdump test-bitrot test-signature test-objdump
 
 .PHONY: test-bitrot
 test-bitrot:
-	# build but do *not* run these packages to mitigate bitrot
-	cargo build -p lucet-spectest -p lucet-runtime-example
+	# build but do *not* run these crates. The tests for these crates are
+	# known to fail, but we want to make sure they still build.
+	cargo check -p lucet-spectest -p lucet-runtime-example
 
 .PHONY: test-signature
 test-signature:

--- a/lucet-objdump/Cargo.toml
+++ b/lucet-objdump/Cargo.toml
@@ -14,13 +14,3 @@ object = "0.18"
 byteorder="1.2.1"
 colored="1.8.0"
 lucet-module = { path = "../lucet-module", version = "=0.7.0-dev" }
-
-[package.metadata.deb]
-name = "fst-lucet-objdump"
-maintainer = "Lucet team <lucet@fastly.com>"
-depends = "$auto"
-priority = "optional"
-assets = [
-    ["target/release/lucet-objdump", "/opt/fst-lucet-objdump/bin/lucet-objdump", "755"],
-    ["LICENSE", "/opt/fst-lucet-objdump/share/doc/lucet-objdump/", "644"],
-]

--- a/lucet-runtime/Cargo.toml
+++ b/lucet-runtime/Cargo.toml
@@ -36,18 +36,6 @@ cc = "1.0"
 name = "lucet_runtime"
 crate-type = ["rlib", "staticlib", "cdylib"]
 
-[package.metadata.deb]
-name = "fst-lucet-runtime"
-maintainer = "Adam C. Foltzer <acfoltzer@fastly.com>"
-depends = "$auto"
-priority = "optional"
-assets = [
-    ["target/release/liblucet_runtime.a", "/opt/fst-lucet-runtime/lib/", "644"],
-    ["target/release/liblucet_runtime.rlib", "/opt/fst-lucet-runtime/lib/", "644"],
-    ["target/release/liblucet_runtime.so", "/opt/fst-lucet-runtime/lib/", "755"],
-    ["include/*.h", "/opt/fst-lucet-runtime/include/", "644"],
-]
-
 [features]
 default = ["uffd"]
 uffd = ["lucet-runtime-internals/uffd"]

--- a/lucet-validate/Cargo.toml
+++ b/lucet-validate/Cargo.toml
@@ -28,22 +28,3 @@ lucet-wasi = { path = "../lucet-wasi", version = "=0.7.0-dev" }
 lucet-wasi-sdk = { path = "../lucet-wasi-sdk", version = "=0.7.0-dev" }
 tempfile = "3.0"
 wabt = "0.9.2"
-
-[package.metadata.deb]
-name = "fst-lucet-validate"
-maintainer = "Lucet team <lucet@fastly.com>"
-depends = "$auto"
-priority = "optional"
-assets = [
-    ["target/release/lucet-validate", "/opt/fst-lucet-validate/bin/lucet-validate", "755"],
-    ["target/release/liblucet_validate.rlib", "/opt/fst-lucet-validate/lib/", "644"],
-    ["LICENSE", "/opt/fst-lucet-validate/share/doc/lucet-validate/", "644"],
-    ["../wasi/phases/old/snapshot_0/witx/typenames.witx",
-     "/opt/fst-lucet-validate/share/wasi/snapshot_0/typenames.witx", "644"],
-    ["../wasi/phases/old/snapshot_0/witx/wasi_unstable.witx",
-     "/opt/fst-lucet-validate/share/wasi/snapshot_0/wasi_unstable.witx", "644"],
-    ["../wasi/phases/snapshot/witx/typenames.witx",
-     "/opt/fst-lucet-validate/share/wasi/snapshot_1/typenames.witx", "644"],
-    ["../wasi/phases/snapshot/witx/wasi_snapshot_preview1.witx",
-     "/opt/fst-lucet-validate/share/wasi/snapshot_1/wasi_snapshot_preview1.witx", "644"],
-]

--- a/lucet-wasi/Cargo.toml
+++ b/lucet-wasi/Cargo.toml
@@ -33,18 +33,3 @@ tempfile = "3.0"
 [lib]
 name = "lucet_wasi"
 crate-type = ["rlib", "staticlib", "cdylib"]
-
-[package.metadata.deb]
-name = "fst-lucet-wasi"
-maintainer = "Adam C. Foltzer <acfoltzer@fastly.com>"
-depends = "$auto"
-priority = "optional"
-assets = [
-    ["target/release/liblucet_wasi.a", "/opt/fst-lucet-wasi/lib/", "644"],
-    ["target/release/liblucet_wasi.rlib", "/opt/fst-lucet-wasi/lib/", "644"],
-    ["target/release/liblucet_wasi.so", "/opt/fst-lucet-wasi/lib/", "755"],
-    ["include/*.h", "/opt/fst-lucet-wasi/include/", "644"],
-    ["LICENSE", "/opt/fst-lucet-wasi/share/doc/lucet-wasi/", "644"],
-    ["LICENSE.wasmtime", "/opt/fst-lucet-wasi/share/doc/lucet-wasi/", "644"],
-    ["LICENSE.cloudabi-utils", "/opt/fst-lucet-wasi/share/doc/lucet-wasi/", "644"],
-]

--- a/lucetc/Cargo.toml
+++ b/lucetc/Cargo.toml
@@ -43,22 +43,3 @@ serde = "1.0"
 serde_json = "1.0"
 thiserror = "1.0.4"
 raw-cpuid = "6.0.0"
-
-[package.metadata.deb]
-name = "fst-lucetc"
-maintainer = "Lucet team <lucet@fastly.com>"
-depends = "$auto"
-priority = "optional"
-assets = [
-    ["target/release/lucetc", "/opt/fst-lucetc/bin/lucetc", "755"],
-    ["target/release/liblucetc.rlib", "/opt/fst-lucetc/lib/", "644"],
-    ["LICENSE", "/opt/fst-lucetc/share/doc/lucetc/", "644"],
-    ["../wasi/phases/old/snapshot_0/witx/typenames.witx",
-     "/opt/fst-lucetc/share/wasi/snapshot_0/typenames.witx", "644"],
-    ["../wasi/phases/old/snapshot_0/witx/wasi_unstable.witx",
-     "/opt/fst-lucetc/share/wasi/snapshot_0/wasi_unstable.witx", "644"],
-    ["../wasi/phases/snapshot/witx/typenames.witx",
-     "/opt/fst-lucetc/share/wasi/snapshot_1/typenames.witx", "644"],
-    ["../wasi/phases/snapshot/witx/wasi_snapshot_preview1.witx",
-     "/opt/fst-lucetc/share/wasi/snapshot_1/wasi_snapshot_preview1.witx", "644"],
-]


### PR DESCRIPTION
Several of the project's `Cargo.toml` files contained `[package.metadata.deb]` sections that described how to create a deb package with `cargo-deb`. These packages were all given the Fastly-specific `fst-` prefix for their package name and installation path (e.g. `/opt/fst-lucetc/...`). We do not use them inside Fastly anymore, and I'm not aware of any external users who depend on them either.