### PR TITLE
lucetc: add command line option to disable wat translation

### DIFF
--- a/lucetc/lucetc/main.rs
+++ b/lucetc/lucetc/main.rs
@@ -143,6 +143,8 @@ pub fn run(opts: &Options) -> Result<(), Error> {
         c.count_instructions(true);
     }
 
+    c.translate_wat(opts.translate_wat);
+
     match opts.codegen {
         CodegenOutput::Obj => c.object_file(&opts.output)?,
         CodegenOutput::SharedObj => c.shared_object_file(&opts.output)?,

--- a/lucetc/lucetc/options.rs
+++ b/lucetc/lucetc/options.rs
@@ -122,6 +122,7 @@ pub struct Options {
     pub count_instructions: bool,
     pub error_style: ErrorStyle,
     pub target: Triple,
+    pub translate_wat: bool,
 }
 
 impl Options {
@@ -211,6 +212,7 @@ impl Options {
         let sk_path = m.value_of("sk_path").map(PathBuf::from);
         let pk_path = m.value_of("pk_path").map(PathBuf::from);
         let count_instructions = m.is_present("count_instructions");
+        let translate_wat = !m.is_present("no_translate_wat");
 
         let error_style = match m.value_of("error_style") {
             None => ErrorStyle::default(),
@@ -241,6 +243,7 @@ impl Options {
             count_instructions,
             error_style,
             target,
+            translate_wat,
         })
     }
     pub fn get() -> Result<Self, Error> {
@@ -458,6 +461,12 @@ SSE3 but not AVX:
                     .takes_value(true)
                     .possible_values(&["human", "json"])
                     .help("Style of error reporting (default: human)"),
+            )
+            .arg(
+                Arg::with_name("no_translate_wat")
+                    .long("--no-translate-wat")
+                    .takes_value(false)
+                    .help("Disable translating wat input files to wasm")
             )
             .get_matches();
 

--- a/lucetc/src/error.rs
+++ b/lucetc/src/error.rs
@@ -20,6 +20,8 @@ pub enum Error {
     IOError(#[from] std::io::Error),
     #[error("Converting to Wasm signature: {0}")]
     SignatureConversion(#[from] SignatureError),
+    #[error("Input does not have Wasm preamble")]
+    MissingWasmPreamble,
     #[error("Wasm validation: {0}")]
     WasmValidation(#[from] wasmparser::BinaryReaderError),
     #[error("Wat input: {0}")]


### PR DESCRIPTION
wat translation is a potential attack vector, since it happens in the C++ `wabt` library, so we want a way to turn it off if required.

```sh
[lucet]% cargo run -p lucetc -- lucetc/tests/wasm/globals_export.wat --no-translate-wat
    Finished dev [unoptimized + debuginfo] target(s) in 0.06s
     Running `target/debug/lucetc lucetc/tests/wasm/globals_export.wat --no-translate-wat`
Error: Input does not have Wasm preamble
```
