### PR TITLE
💢 Package unknown hostcall panics into termination details

### DIFF
--- a/lucet-runtime/include/lucet_types.h
+++ b/lucet-runtime/include/lucet_types.h
@@ -50,6 +50,7 @@ enum lucet_terminated_reason {
     lucet_terminated_reason_borrow_error,
     lucet_terminated_reason_provided,
     lucet_terminated_reason_remote,
+    lucet_terminated_reason_other_panic,
 };
 
 enum lucet_trapcode {

--- a/lucet-runtime/lucet-runtime-macros/src/lib.rs
+++ b/lucet-runtime/lucet-runtime-macros/src/lib.rs
@@ -111,12 +111,11 @@ pub fn lucet_hostcall(_attr: TokenStream, item: TokenStream) -> TokenStream {
                 match res {
                     Ok(res) => res,
                     Err(e) => {
-                        match e.downcast::<#termination_details>() {
-                            Ok(details) => {
-                                #vmctx_mod::Vmctx::from_raw(vmctx_raw).terminate_no_unwind(*details)
-                            },
-                            Err(e) => std::panic::resume_unwind(e),
-                        }
+                        let details = match e.downcast::<#termination_details>() {
+                            Ok(details) => *details,
+                            Err(e) => #termination_details::OtherPanic(e),
+                        };
+                        #vmctx_mod::Vmctx::from_raw(vmctx_raw).terminate_no_unwind(details)
                     }
                 }
             })


### PR DESCRIPTION
This prevents panics that aren't intentionally initiated by the Lucet runtime from attempting to unwind across Wasm stack frames. When #254 lands, this will no longer be necessary, but until then this allows us to safely transport the unknown panic payload across the FFI boundary so that panicking can resume on the other side.