### PR TITLE
thiserror::Error derivations: #[from] implies #[source]

### DIFF
--- a/lucet-runtime/lucet-runtime-internals/src/error.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/error.rs
@@ -47,11 +47,7 @@ pub enum Error {
 
     /// Errors arising during dynamic loading with [`DlModule`](struct.DlModule.html).
     #[error("Dynamic loading error: {0}")]
-    DlError(
-        #[from]
-        #[source]
-        crate::module::DlError,
-    ),
+    DlError(#[from] crate::module::DlError),
 
     #[error("Instance not returned")]
     InstanceNotReturned,

--- a/lucet-runtime/lucet-runtime-internals/src/module/dl.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/module/dl.rs
@@ -19,17 +19,9 @@ use raw_cpuid::CpuId;
 #[derive(Debug, Error)]
 pub enum DlError {
     #[error("Loading: {0}")]
-    Loading(
-        #[from]
-        #[source]
-        libloading::Error,
-    ),
+    Loading(#[from] libloading::Error),
     #[error("IO: {0}")]
-    Io(
-        #[from]
-        #[source]
-        std::io::Error,
-    ),
+    Io(#[from] std::io::Error),
 }
 
 fn check_feature_support(module_features: &ModuleFeatures) -> Result<(), Error> {


### PR DESCRIPTION
"The #[from] attribute always implies that the same field is #[source], so you don't ever need to specify both attributes." - https://docs.rs/thiserror/1.0.20/thiserror/