### PR TITLE
lucet-wasi: set wasi-common default-features=false

### DIFF
--- a/lucet-wasi/Cargo.toml
+++ b/lucet-wasi/Cargo.toml
@@ -22,7 +22,7 @@ lucet-wiggle = { path = "../lucet-wiggle", version = "=0.7.0-dev" }
 libc = "0.2.65"
 nix = "0.17"
 rand = "0.6"
-wasi-common = { path = "../wasmtime/crates/wasi-common", version = "0.18.0", features = ["wiggle_metadata"] }
+wasi-common = { path = "../wasmtime/crates/wasi-common", version = "0.18.0", default-features = false,  features = ["wiggle_metadata"] }
 
 [dev-dependencies]
 lucet-wasi-sdk = { path = "../lucet-wasi-sdk" }


### PR DESCRIPTION
the default features in wasi-common are to set the `tracing/log` feature
flag, which directs all tracing's events to log ecosystem backends.
Lucet is all-in on the tracing ecosystem.