### PR TITLE
pull in latest wasmtime 0.19.1 / cranelift 0.66

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,6 +40,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85bb70cc08ec97ca5450e6eba421deeea5f172c0fc61f78b5357b2a8e8be195f"
 
 [[package]]
+name = "arrayref"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+
+[[package]]
+name = "arrayvec"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -74,6 +86,12 @@ dependencies = [
  "object 0.19.0",
  "rustc-demangle",
 ]
+
+[[package]]
+name = "base64"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
 name = "bencher"
@@ -145,6 +163,17 @@ name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+
+[[package]]
+name = "blake2b_simd"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "constant_time_eq",
+]
 
 [[package]]
 name = "block-buffer"
@@ -283,6 +312,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
 name = "core_affinity"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -306,14 +341,14 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "byteorder",
  "cranelift-bforest",
@@ -330,7 +365,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "cranelift-codegen-shared",
  "cranelift-entity",
@@ -338,15 +373,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.65.0"
+version = "0.66.0"
 
 [[package]]
 name = "cranelift-entity"
-version = "0.65.0"
+version = "0.66.0"
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -356,7 +391,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -367,7 +402,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "cranelift-codegen",
  "raw-cpuid 7.0.3",
@@ -376,25 +411,25 @@ dependencies = [
 
 [[package]]
 name = "cranelift-object"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
  "cranelift-module",
- "object 0.20.0",
+ "object 0.21.1",
  "target-lexicon",
 ]
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
  "cranelift-frontend",
  "log",
  "thiserror",
- "wasmparser 0.58.0",
+ "wasmparser 0.59.0",
 ]
 
 [[package]]
@@ -547,6 +582,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "dirs"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
+dependencies = [
+ "cfg-if",
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -1182,7 +1238,7 @@ dependencies = [
  "lucet-wiggle-generate",
  "memoffset",
  "minisign",
- "object 0.20.0",
+ "object 0.21.1",
  "raw-cpuid 6.1.0",
  "serde",
  "serde_json",
@@ -1190,7 +1246,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "wabt",
- "wasmparser 0.58.0",
+ "wasmparser 0.59.0",
  "witx",
 ]
 
@@ -1332,10 +1388,18 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ab52be62400ca80aa00285d25253d7f7c437b7375c4de678f5405d3afe82ca5"
 dependencies = [
- "crc32fast",
  "flate2",
- "indexmap",
  "wasmparser 0.57.0",
+]
+
+[[package]]
+name = "object"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37fd5004feb2ce328a52b0b3d01dbf4ffff72583493900ed15f22d4111c51693"
+dependencies = [
+ "crc32fast",
+ "indexmap",
 ]
 
 [[package]]
@@ -1751,10 +1815,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 
 [[package]]
-name = "regalloc"
-version = "0.0.26"
+name = "redox_users"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c03092d79e0fd610932d89ed53895a38c0dd3bcd317a0046e69940de32f1d95"
+checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+ "rust-argon2",
+]
+
+[[package]]
+name = "regalloc"
+version = "0.0.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2041c2d34f6ff346d6f428974f03d8bf12679b0c816bb640dc5eb1d48848d8d1"
 dependencies = [
  "log",
  "rustc-hash",
@@ -1805,6 +1880,18 @@ checksum = "99371657d3c8e4d816fb6221db98fa408242b0b53bac08f8676a41f8554fe99f"
 dependencies = [
  "libc",
  "winapi 0.3.8",
+]
+
+[[package]]
+name = "rust-argon2"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dab61250775933275e84053ac235621dfb739556d5c54a2f2e9313b7cf43a19"
+dependencies = [
+ "base64",
+ "blake2b_simd",
+ "constant_time_eq",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1961,6 +2048,15 @@ dependencies = [
  "digest",
  "fake-simd",
  "opaque-debug",
+]
+
+[[package]]
+name = "shellexpand"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2b22262a9aaf9464d356f656fea420634f78c881c5eebd5ef5e66d8b9bc603"
+dependencies = [
+ "dirs",
 ]
 
 [[package]]
@@ -2340,7 +2436,7 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi-common"
-version = "0.18.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -2349,8 +2445,8 @@ dependencies = [
  "getrandom",
  "lazy_static",
  "libc",
- "log",
  "thiserror",
+ "tracing",
  "wig",
  "wiggle",
  "winapi 0.3.8",
@@ -2420,15 +2516,15 @@ checksum = "32fddd575d477c6e9702484139cf9f23dcd554b06d185ed0f56c857dd3a47aa6"
 
 [[package]]
 name = "wasmparser"
-version = "0.58.0"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721a8d79483738d7aef6397edcf8f04cd862640b1ad5973adf5bb50fc10e86db"
+checksum = "a950e6a618f62147fd514ff445b2a0b53120d382751960797f85f058c7eda9b9"
 
 [[package]]
 name = "wast"
-version = "11.0.0"
+version = "22.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df4d67ba9266f4fcaf2e8a1afadc5e2a959e51aecc07b1ecbdf85a6ddaf08bde"
+checksum = "fe1220ed7f824992b426a76125a3403d048eaf0f627918e97ade0d9b9d510d20"
 dependencies = [
  "leb128",
 ]
@@ -2445,7 +2541,7 @@ dependencies = [
 
 [[package]]
 name = "wig"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "heck",
  "proc-macro2 1.0.13",
@@ -2455,7 +2551,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "thiserror",
  "tracing",
@@ -2465,19 +2561,20 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "heck",
  "proc-macro2 1.0.13",
  "quote 1.0.6",
+ "shellexpand",
  "syn 1.0.22",
  "witx",
 ]
 
 [[package]]
 name = "wiggle-macro"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "quote 1.0.6",
  "syn 1.0.22",
@@ -2487,7 +2584,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-test"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "proptest",
  "wiggle",
@@ -2538,7 +2635,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winx"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "bitflags 1.2.1",
  "cvt",
@@ -2547,7 +2644,7 @@ dependencies = [
 
 [[package]]
 name = "witx"
-version = "0.8.5"
+version = "0.8.7"
 dependencies = [
  "anyhow",
  "log",
@@ -2563,11 +2660,11 @@ checksum = "da90eac47bf1d7871b75004b9b631d107df15f37669383b23f0b5297bc7516b6"
 
 [[package]]
 name = "yanix"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "bitflags 1.2.1",
  "cfg-if",
  "filetime",
  "libc",
- "log",
+ "tracing",
 ]

--- a/lucet-module/Cargo.toml
+++ b/lucet-module/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
-cranelift-entity = { path = "../wasmtime/cranelift/entity", version = "0.65.0" }
+cranelift-entity = { path = "../wasmtime/cranelift/entity", version = "0.66.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bincode = "1.1.4"

--- a/lucet-module/src/traps.rs
+++ b/lucet-module/src/traps.rs
@@ -13,6 +13,7 @@ pub enum TrapCode {
     Interrupt,
     TableOutOfBounds,
     Unreachable,
+    HeapMisaligned,
 }
 
 /// Trap information for an address in a compiled function

--- a/lucet-runtime/include/lucet_types.h
+++ b/lucet-runtime/include/lucet_types.h
@@ -65,6 +65,7 @@ enum lucet_trapcode {
     lucet_trapcode_interrupt,
     lucet_trapcode_table_out_of_bounds,
     lucet_trapcode_user,
+    lucet_trapcode_heap_misaligned,
     lucet_trapcode_unknown,
 };
 

--- a/lucet-runtime/lucet-runtime-internals/src/c_api.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/c_api.rs
@@ -414,6 +414,7 @@ pub mod lucet_result {
         Interrupt,
         TableOutOfBounds,
         Unreachable,
+        HeapMisaligned,
         Unknown,
     }
 
@@ -437,6 +438,7 @@ pub mod lucet_result {
                     TrapCode::Interrupt => lucet_trapcode::Interrupt,
                     TrapCode::TableOutOfBounds => lucet_trapcode::TableOutOfBounds,
                     TrapCode::Unreachable => lucet_trapcode::Unreachable,
+                    TrapCode::HeapMisaligned => lucet_trapcode::HeapMisaligned,
                 }
             } else {
                 lucet_trapcode::Unknown

--- a/lucet-wasi/Cargo.toml
+++ b/lucet-wasi/Cargo.toml
@@ -22,7 +22,7 @@ lucet-wiggle = { path = "../lucet-wiggle", version = "=0.7.0-dev" }
 libc = "0.2.65"
 nix = "0.17"
 rand = "0.6"
-wasi-common = { path = "../wasmtime/crates/wasi-common", version = "0.18.0", default-features = false,  features = ["wiggle_metadata"] }
+wasi-common = { path = "../wasmtime/crates/wasi-common", version = "0.19.0", default-features = false,  features = ["wiggle_metadata"] }
 
 [dev-dependencies]
 lucet-wasi-sdk = { path = "../lucet-wasi-sdk" }

--- a/lucet-wasi/generate/Cargo.toml
+++ b/lucet-wasi/generate/Cargo.toml
@@ -13,8 +13,8 @@ proc-macro = true
 
 [dependencies]
 lucet-wiggle = { path = "../../lucet-wiggle", version = "0.7.0-dev" }
-wasi-common = { path = "../../wasmtime/crates/wasi-common",  version = "0.18.0", features = ["wiggle_metadata"] }
-wiggle-generate = { path = "../../wasmtime/crates/wiggle/generate",  version = "0.18.0" }
+wasi-common = { path = "../../wasmtime/crates/wasi-common",  version = "0.19.0", features = ["wiggle_metadata"] }
+wiggle-generate = { path = "../../wasmtime/crates/wiggle/generate",  version = "0.19.0" }
 syn = { version = "1.0", features = ["full"] }
 quote = "1.0"
 proc-macro2 = "1.0"

--- a/lucet-wiggle/Cargo.toml
+++ b/lucet-wiggle/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 lucet-wiggle-macro = { path = "./macro", version = "0.7.0-dev" }
 lucet-wiggle-generate = { path = "./generate", version = "0.7.0-dev" }
 lucet-runtime = { path = "../lucet-runtime", version = "0.7.0-dev" }
-wiggle =  { path = "../wasmtime/crates/wiggle", version = "0.18.0" }
+wiggle =  { path = "../wasmtime/crates/wiggle", version = "0.19.0" }
 
 [dev-dependencies]
 wiggle-test = { path = "../wasmtime/crates/wiggle/test-helpers" }

--- a/lucet-wiggle/generate/Cargo.toml
+++ b/lucet-wiggle/generate/Cargo.toml
@@ -9,7 +9,7 @@ authors = ["Lucet team <lucet@fastly.com>"]
 edition = "2018"
 
 [dependencies]
-wiggle-generate = { path = "../../wasmtime/crates/wiggle/generate", version = "0.18.0" }
+wiggle-generate = { path = "../../wasmtime/crates/wiggle/generate", version = "0.19.0" }
 lucet-module = { path = "../../lucet-module", version = "0.7.0-dev" }
 witx = { path = "../../wasmtime/crates/wasi-common/WASI/tools/witx", version = "0.8.4" }
 quote = "1.0"

--- a/lucet-wiggle/macro/Cargo.toml
+++ b/lucet-wiggle/macro/Cargo.toml
@@ -13,7 +13,7 @@ proc-macro = true
 
 [dependencies]
 lucet-wiggle-generate = { path = "../generate", version = "0.7.0-dev" }
-wiggle-generate = { path = "../../wasmtime/crates/wiggle/generate", version = "0.18.0" }
+wiggle-generate = { path = "../../wasmtime/crates/wiggle/generate", version = "0.19.0" }
 witx = { path = "../../wasmtime/crates/wasi-common/WASI/tools/witx", version = "0.8.4" }
 syn = { version = "1.0", features = ["full"] }
 quote = "1.0"

--- a/lucet-wiggle/macro/src/lib.rs
+++ b/lucet-wiggle/macro/src/lib.rs
@@ -5,10 +5,7 @@ use syn::parse_macro_input;
 
 #[proc_macro]
 pub fn from_witx(args: TokenStream) -> TokenStream {
-    let mut config = parse_macro_input!(args as lucet_wiggle_generate::Config);
-    config.wiggle.witx.make_paths_relative_to(
-        std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANFIEST_DIR env var"),
-    );
+    let config = parse_macro_input!(args as lucet_wiggle_generate::Config);
 
     let doc = config.wiggle.load_document();
 

--- a/lucet-wiggle/tests/wasi.rs
+++ b/lucet-wiggle/tests/wasi.rs
@@ -49,7 +49,7 @@ pub struct TestCtx {
 // `constructor`: Show how to construct a ctx struct.
 // `vmctx` is in scope at use sites.
 lucet_wiggle::from_witx!({
-    witx: ["../wasi/phases/snapshot/witx/wasi_snapshot_preview1.witx"],
+    witx: ["$CARGO_MANIFEST_DIR/../wasmtime/crates/wasi-common/WASI/phases/snapshot/witx/wasi_snapshot_preview1.witx"],
     ctx: LucetWasiCtx,
     constructor: { LucetWasiCtx::build(vmctx) },
 });

--- a/lucetc/Cargo.toml
+++ b/lucetc/Cargo.toml
@@ -16,22 +16,23 @@ path = "lucetc/main.rs"
 [dependencies]
 anyhow = "1"
 bincode = "1.1.4"
-cranelift-codegen = { path = "../wasmtime/cranelift/codegen", version = "0.65.0" }
-cranelift-entity = { path = "../wasmtime/cranelift/entity", version = "0.65.0" }
-cranelift-native = { path = "../wasmtime/cranelift/native", version = "0.65.0" }
-cranelift-frontend = { path = "../wasmtime/cranelift/frontend", version = "0.65.0" }
-cranelift-module = { path = "../wasmtime/cranelift/module", version = "0.65.0" }
-cranelift-object = { path = "../wasmtime/cranelift/object", version = "0.65.0" }
-cranelift-wasm = { path = "../wasmtime/cranelift/wasm", version = "0.65.0" }
+cranelift-codegen = { path = "../wasmtime/cranelift/codegen", version = "0.66.0" }
+cranelift-entity = { path = "../wasmtime/cranelift/entity", version = "0.66.0" }
+cranelift-native = { path = "../wasmtime/cranelift/native", version = "0.66.0" }
+cranelift-frontend = { path = "../wasmtime/cranelift/frontend", version = "0.66.0" }
+cranelift-module = { path = "../wasmtime/cranelift/module", version = "0.66.0" }
+cranelift-object = { path = "../wasmtime/cranelift/object", version = "0.66.0" }
+cranelift-wasm = { path = "../wasmtime/cranelift/wasm", version = "0.66.0" }
 target-lexicon = "0.10"
 lucet-module = { path = "../lucet-module", version = "=0.7.0-dev" }
 lucet-wiggle-generate = { path = "../lucet-wiggle/generate", version = "=0.7.0-dev" }
 witx = { path = "../wasmtime/crates/wasi-common/WASI/tools/witx", version = "0.8.5" }
-wasmparser = "0.58.0"
+wasmparser = "0.59.0"
 clap="2.32"
+
 log = "0.4"
 env_logger = "0.6"
-object = { version = "0.20.0", default-features = false, features = ["write"] }
+object = { version = "0.21.1", default-features = false, features = ["write"] }
 byteorder = "1.2"
 wabt = "0.9.1"
 tempfile = "3.0"

--- a/lucetc/src/compiler.rs
+++ b/lucetc/src/compiler.rs
@@ -208,7 +208,7 @@ impl<'a> Compiler<'a> {
         let frontend_config = isa.frontend_config();
         let mut module_info = ModuleInfo::new(frontend_config.clone(), validator);
 
-        wasmparser::validate(wasm_binary, None).map_err(Error::WasmValidation)?;
+        wasmparser::validate(wasm_binary).map_err(Error::WasmValidation)?;
 
         let module_translation_state =
             translate_module(wasm_binary, &mut module_info).map_err(|e| match e {

--- a/lucetc/src/decls.rs
+++ b/lucetc/src/decls.rs
@@ -12,7 +12,7 @@ use cranelift_codegen::isa::TargetFrontendConfig;
 use cranelift_module::{Backend as ClifBackend, Linkage, Module as ClifModule};
 use cranelift_wasm::{
     Global, GlobalIndex, GlobalInit, MemoryIndex, SignatureIndex, Table, TableIndex,
-    TargetEnvironment,
+    TargetEnvironment, WasmFuncType,
 };
 use lucet_module::bindings::Bindings;
 use lucet_module::ModuleFeatures;
@@ -22,7 +22,6 @@ use lucet_module::{
     ModuleData, Signature as LucetSignature, UniqueSignatureIndex,
 };
 use std::collections::HashMap;
-use wasmparser::FuncType;
 
 #[derive(Debug)]
 pub struct FunctionDecl<'a> {
@@ -202,7 +201,7 @@ impl<'a> ModuleDecls<'a> {
         clif_module: &mut ClifModule<B>,
         decl_sym: String,
         decl_linkage: Linkage,
-        wasm_func_type: &FuncType,
+        wasm_func_type: WasmFuncType,
         signature: ir::Signature,
     ) -> Result<UniqueFuncIndex, Error> {
         let (new_funcidx, _) = self.info.declare_func_with_sig(wasm_func_type, signature)?;
@@ -279,7 +278,7 @@ impl<'a> ModuleDecls<'a> {
                 clif_module,
                 functype.name.clone(),
                 Linkage::Import,
-                &functype.wasm_func_type,
+                functype.wasm_func_type.clone(),
                 functype.signature.clone(),
             )?;
 

--- a/lucetc/src/function.rs
+++ b/lucetc/src/function.rs
@@ -736,4 +736,26 @@ impl<'a> FuncEnvironment for FuncInfo<'a> {
         }
         Ok(())
     }
+
+    fn translate_atomic_wait(
+        &mut self,
+        _: FuncCursor,
+        _: MemoryIndex,
+        _: ir::Heap,
+        _: ir::Value,
+        _: ir::Value,
+        _: ir::Value,
+    ) -> WasmResult<ir::Value> {
+        unimplemented!("translate atomic wait");
+    }
+    fn translate_atomic_notify(
+        &mut self,
+        _: FuncCursor,
+        _: MemoryIndex,
+        _: ir::Heap,
+        _: ir::Value,
+        _: ir::Value,
+    ) -> WasmResult<ir::Value> {
+        unimplemented!("translate atomic verify");
+    }
 }

--- a/lucetc/src/runtime.rs
+++ b/lucetc/src/runtime.rs
@@ -1,7 +1,7 @@
 use cranelift_codegen::ir::{types, AbiParam, Signature};
 use cranelift_codegen::isa::TargetFrontendConfig;
+use cranelift_wasm::{WasmFuncType, WasmType};
 use std::collections::HashMap;
-use wasmparser::FuncType;
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, Clone)]
 pub enum RuntimeFunc {
@@ -12,7 +12,7 @@ pub enum RuntimeFunc {
 pub struct RuntimeFuncType {
     pub name: String,
     pub signature: Signature,
-    pub wasm_func_type: FuncType,
+    pub wasm_func_type: WasmFuncType,
 }
 
 pub struct Runtime {
@@ -31,9 +31,9 @@ impl Runtime {
                     returns: vec![AbiParam::new(types::I32)],
                     call_conv: target.default_call_conv,
                 },
-                wasm_func_type: FuncType {
+                wasm_func_type: WasmFuncType {
                     params: vec![].into_boxed_slice(),
-                    returns: vec![wasmparser::Type::I32].into_boxed_slice(),
+                    returns: vec![WasmType::I32].into_boxed_slice(),
                 },
             },
         );
@@ -48,9 +48,9 @@ impl Runtime {
                     returns: vec![AbiParam::new(types::I32)],
                     call_conv: target.default_call_conv,
                 },
-                wasm_func_type: FuncType {
-                    params: vec![wasmparser::Type::I32].into_boxed_slice(),
-                    returns: vec![wasmparser::Type::I32].into_boxed_slice(),
+                wasm_func_type: WasmFuncType {
+                    params: vec![WasmType::I32].into_boxed_slice(),
+                    returns: vec![WasmType::I32].into_boxed_slice(),
                 },
             },
         );

--- a/lucetc/src/stack_probe.rs
+++ b/lucetc/src/stack_probe.rs
@@ -16,7 +16,7 @@ use cranelift_codegen::{
     isa::CallConv,
 };
 use cranelift_module::{Backend as ClifBackend, Linkage, Module as ClifModule, TrapSite};
-use wasmparser::FuncType;
+use cranelift_wasm::{WasmFuncType, WasmType};
 
 /// Stack probe symbol name
 pub const STACK_PROBE_SYM: &str = "lucet_probestack";
@@ -62,9 +62,9 @@ pub fn declare<'a, B: ClifBackend>(
             clif_module,
             STACK_PROBE_SYM.to_string(),
             Linkage::Local,
-            &FuncType {
+            WasmFuncType {
                 params: vec![].into_boxed_slice(),
-                returns: vec![wasmparser::Type::I32].into_boxed_slice(),
+                returns: vec![WasmType::I32].into_boxed_slice(),
             },
             Signature {
                 params: vec![],

--- a/lucetc/src/traps.rs
+++ b/lucetc/src/traps.rs
@@ -23,6 +23,7 @@ pub(crate) fn translate_trapcode(code: ir::TrapCode) -> lucet_module::TrapCode {
         ir::TrapCode::Interrupt => lucet_module::TrapCode::Interrupt,
         ir::TrapCode::TableOutOfBounds => lucet_module::TrapCode::TableOutOfBounds,
         ir::TrapCode::UnreachableCodeReached => lucet_module::TrapCode::Unreachable,
+        ir::TrapCode::HeapMisaligned => lucet_module::TrapCode::HeapMisaligned,
         ir::TrapCode::User(_) => panic!("we should never emit a user trapcode"),
     }
 }

--- a/lucetc/src/types.rs
+++ b/lucetc/src/types.rs
@@ -1,7 +1,7 @@
+use cranelift_wasm::{WasmFuncType, WasmType};
 use lucet_module::{Signature, ValueType};
 use std::fmt::{self, Display};
 use thiserror::Error;
-use wasmparser::FuncType;
 
 #[derive(Debug)]
 pub enum ValueError {
@@ -9,19 +9,19 @@ pub enum ValueError {
     InvalidVMContext,
 }
 
-fn to_lucet_valuetype(ty: &wasmparser::Type) -> Result<ValueType, ValueError> {
+fn to_lucet_valuetype(ty: &WasmType) -> Result<ValueType, ValueError> {
     match ty {
-        wasmparser::Type::I32 => Ok(ValueType::I32),
-        wasmparser::Type::I64 => Ok(ValueType::I64),
-        wasmparser::Type::F32 => Ok(ValueType::F32),
-        wasmparser::Type::F64 => Ok(ValueType::F64),
+        WasmType::I32 => Ok(ValueType::I32),
+        WasmType::I64 => Ok(ValueType::I64),
+        WasmType::F32 => Ok(ValueType::F32),
+        WasmType::F64 => Ok(ValueType::F64),
         _ => Err(ValueError::Unrepresentable),
     }
 }
 
 #[derive(Debug, Error)]
 pub enum SignatureError {
-    Type(wasmparser::Type, ValueError),
+    Type(WasmType, ValueError),
     Multivalue,
 }
 
@@ -31,7 +31,7 @@ impl Display for SignatureError {
     }
 }
 
-pub fn to_lucet_signature(func_type: &FuncType) -> Result<Signature, SignatureError> {
+pub fn to_lucet_signature(func_type: &WasmFuncType) -> Result<Signature, SignatureError> {
     let params = func_type
         .params
         .iter()

--- a/lucetc/tests/wasm.rs
+++ b/lucetc/tests/wasm.rs
@@ -708,7 +708,7 @@ mod validate {
                     },
                     ValidationError::MissingRequiredExport {
                         field: "_start".to_owned(),
-                        type_: wasmparser::FuncType {
+                        type_: cranelift_wasm::WasmFuncType {
                             params: vec![].into_boxed_slice(),
                             returns: vec![].into_boxed_slice()
                         }


### PR DESCRIPTION
* Lots of version bumps
* new cranelift trapcode
* some types are now provided by cranelift-wasm instead of wasmparser
* wiggle macro path resolution works differently now.