### PR TITLE
🈵 Add an option to terminate the runtime when `memory.grow` fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 - Added the field `hostcall_reservation` to `Limits` to specify an amount of stack space Lucet will ensure is available when making a hostcall. `hostcall_reservation` defaults to 32KiB. If there is less than the configured amount of stack space when making a hostcall, the instance will fault in the same way as any other guest-code stack overflow.
 
+- Added `terminate_on_heap_oom` as an option for instances. This causes instances to terminate with an OOM-specific termination value rather than returning `-1` when a `memory.grow` instruction fails.
+
 [start-function]: https://webassembly.github.io/spec/core/syntax/modules.html#syntax-start
 
 ### 0.6.1 (2020-02-18)

--- a/lucet-runtime/include/lucet_types.h
+++ b/lucet-runtime/include/lucet_types.h
@@ -51,6 +51,7 @@ enum lucet_terminated_reason {
     lucet_terminated_reason_provided,
     lucet_terminated_reason_remote,
     lucet_terminated_reason_block_on_needs_async,
+    lucet_terminated_reason_heap_out_of_memory,
     lucet_terminated_reason_other_panic,
 };
 

--- a/lucet-runtime/lucet-runtime-internals/src/c_api.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/c_api.rs
@@ -328,6 +328,10 @@ pub mod lucet_result {
                                 reason: lucet_terminated_reason::BlockOnNeedsAsync,
                                 provided: std::ptr::null_mut(),
                             },
+                            TerminationDetails::HeapOutOfMemory => lucet_terminated {
+                                reason: lucet_terminated_reason::HeapOutOfMemory,
+                                provided: std::ptr::null_mut(),
+                            },
                         },
                     },
                 },
@@ -384,6 +388,7 @@ pub mod lucet_result {
         Remote,
         OtherPanic,
         BlockOnNeedsAsync,
+        HeapOutOfMemory,
     }
 
     #[repr(C)]

--- a/lucet-runtime/lucet-runtime-internals/src/instance.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/instance.rs
@@ -264,6 +264,17 @@ pub struct Instance {
     /// The value passed back to the guest when resuming a yielded instance.
     pub(crate) resumed_val: Option<Box<dyn Any + 'static>>,
 
+    /// Whether to terminate the guest when `memory.grow` fails, rather than returning `-1`;
+    /// disabled by default.
+    ///
+    /// This behavior deviates from the WebAssembly spec, but is useful in practice for determining
+    /// when guest programs fail due to an exhausted heap.
+    ///
+    /// Most languages will compile to code that includes an `unreachable` instruction if allocation
+    /// fails, but this same instruction might also appear when other types of assertions fail,
+    /// `panic!()` is called, etc. Terminating allows the error to be more directly identifiable.
+    terminate_on_heap_oom: bool,
+
     /// `_padding` must be the last member of the structure.
     /// This marks where the padding starts to make the structure exactly 4096 bytes long.
     /// It is also used to compute the size of the structure up to that point, i.e. without padding.
@@ -884,6 +895,16 @@ impl Instance {
         // meet some guest stack pointer early.
         self.get_instance_implicits_mut().stack_limit = slot.stack as u64 + reservation as u64;
     }
+
+    #[inline]
+    pub fn terminate_on_heap_oom(&self) -> bool {
+        self.terminate_on_heap_oom
+    }
+
+    #[inline]
+    pub fn set_terminate_on_heap_oom(&mut self, terminate_on_heap_oom: bool) {
+        self.terminate_on_heap_oom = terminate_on_heap_oom;
+    }
 }
 
 // Private API
@@ -916,6 +937,7 @@ impl Instance {
             ensure_sigstack_installed: true,
             entrypoint: None,
             resumed_val: None,
+            terminate_on_heap_oom: false,
             _padding: (),
         };
         inst.set_globals_ptr(globals_ptr);
@@ -927,6 +949,20 @@ impl Instance {
         let unpadded_size = offset_of!(Instance, _padding);
         assert!(unpadded_size <= HOST_PAGE_SIZE_EXPECTED - mem::size_of::<*mut i64>());
         inst
+    }
+
+    /// Like `Instance::grow_memory()`, but terminates on out-of-memory if `terminate_on_heap_oom`
+    /// is set.
+    ///
+    /// This is exported only to support the implementation of the builtin `lucet_vmctx_grow_memory`
+    /// function, and should not be called by users.
+    pub fn grow_memory_from_hostcall(&mut self, additional_pages: u32) -> Result<u32, Error> {
+        let res = self.grow_memory(additional_pages);
+        if self.terminate_on_heap_oom() && res.is_err() {
+            panic!(TerminationDetails::HeapOutOfMemory)
+        } else {
+            res
+        }
     }
 
     // The globals pointer must be stored right before the end of the structure, padded to the page size,
@@ -1327,6 +1363,11 @@ pub enum TerminationDetails {
     /// The instance was terminated by `Vmctx::block_on` being called from an instance
     /// that isnt running in an async context
     BlockOnNeedsAsync,
+    /// A `memory.grow` instruction failed, and the `terminate_on_heap_oom` option was `true`.
+    ///
+    /// If `terminate_on_heap_oom` is `false`, this variant should never appear; `memory.grow` will
+    /// instead evaluate to `-1` within the Wasm guest.
+    HeapOutOfMemory,
 }
 
 impl TerminationDetails {
@@ -1380,6 +1421,7 @@ impl std::fmt::Debug for TerminationDetails {
             TerminationDetails::Remote => write!(f, "Remote"),
             TerminationDetails::OtherPanic(_) => write!(f, "OtherPanic(Any)"),
             TerminationDetails::BlockOnNeedsAsync => write!(f, "BlockOnNeedsAsync"),
+            TerminationDetails::HeapOutOfMemory => write!(f, "HeapOutOfMemory"),
         }
     }
 }

--- a/lucet-runtime/lucet-runtime-internals/src/region/mmap.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/region/mmap.rs
@@ -1,5 +1,5 @@
-use crate::alloc::{instance_heap_offset, Alloc, AllocStrategy, Limits, Slot};
-use crate::embed_ctx::CtxMap;
+use super::NewInstanceArgs;
+use crate::alloc::{instance_heap_offset, Alloc, Limits, Slot};
 use crate::error::Error;
 use crate::instance::{new_instance_handle, Instance, InstanceHandle};
 use crate::module::Module;
@@ -77,10 +77,14 @@ impl Region for MmapRegion {
 impl RegionInternal for MmapRegion {
     fn new_instance_with(
         &self,
-        module: Arc<dyn Module>,
-        embed_ctx: CtxMap,
-        heap_memory_size_limit: usize,
-        mut alloc_strategy: AllocStrategy,
+        NewInstanceArgs {
+            module,
+            embed_ctx,
+            heap_memory_size_limit,
+            mut alloc_strategy,
+            terminate_on_heap_oom,
+            ..
+        }: NewInstanceArgs,
     ) -> Result<InstanceHandle, Error> {
         let limits = self.get_limits();
 
@@ -140,7 +144,8 @@ impl RegionInternal for MmapRegion {
 
         // Though this is a potential early return from the function, the Drop impl
         // on the Alloc will put the slot back on the freelist.
-        let inst = new_instance_handle(inst_ptr, module, alloc, embed_ctx)?;
+        let mut inst = new_instance_handle(inst_ptr, module, alloc, embed_ctx)?;
+        inst.set_terminate_on_heap_oom(terminate_on_heap_oom);
 
         Ok(inst)
     }

--- a/lucet-runtime/lucet-runtime-internals/src/vmctx.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/vmctx.rs
@@ -249,7 +249,10 @@ impl Vmctx {
     /// the instance with `TerminationDetails::BorrowError`.
     pub fn grow_memory(&self, additional_pages: u32) -> Result<u32, Error> {
         self.ensure_no_heap_borrows();
-        unsafe { self.instance_mut().grow_memory(additional_pages) }
+        unsafe {
+            self.instance_mut()
+                .grow_memory_from_hostcall(additional_pages)
+        }
     }
 
     /// Return the WebAssembly globals as a slice of `i64`s.

--- a/lucet-runtime/src/c_api.rs
+++ b/lucet-runtime/src/c_api.rs
@@ -444,7 +444,10 @@ pub unsafe extern "C" fn lucet_vmctx_current_memory(vmctx: &Vmctx) -> u32 {
 ///
 /// On success, returns the number of pages that existed before the call. On failure, returns `-1`.
 pub unsafe extern "C" fn lucet_vmctx_grow_memory(vmctx: &Vmctx, additional_pages: u32) -> i32 {
-    if let Ok(old_pages) = vmctx.instance_mut().grow_memory(additional_pages) {
+    if let Ok(old_pages) = vmctx
+        .instance_mut()
+        .grow_memory_from_hostcall(additional_pages)
+    {
         old_pages as i32
     } else {
         -1


### PR DESCRIPTION
This new option determines whether to terminate the guest with a new `TerminationDetails::HeapOutOfMemory` variant when `memory.grow` fails, rather than returning `-1`. It is disabled by default, but can be set via `InstanceBuilder` or directly on the `Instance`.

This behavior deviates from the WebAssembly spec, but is useful in practice for determining when guest programs fail due to an exhausted heap.

Most languages will compile to code that includes an `unreachable` instruction if allocation fails, but this same instruction might also appear when other types of assertions fail, `panic!()` is called, etc. Terminating allows the error to be more directly identifiable.