### PR TITLE
☢️ Remove UB from `extern "C"` ABI on annotated hostcalls

### DIFF
--- a/benchmarks/lucet-benchmarks/src/modules.rs
+++ b/benchmarks/lucet-benchmarks/src/modules.rs
@@ -210,7 +210,7 @@ pub fn hostcalls_mock() -> Arc<dyn Module> {
     #[lucet_hostcall]
     #[inline(never)]
     #[no_mangle]
-    pub unsafe extern "C" fn hostcall_wrapped(
+    pub unsafe fn hostcall_wrapped(
         vmctx: &Vmctx,
         x1: u64,
         x2: u64,

--- a/lucet-runtime/lucet-runtime-internals/src/vmctx.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/vmctx.rs
@@ -301,7 +301,7 @@ impl Vmctx {
     ///
     /// #[lucet_hostcall]
     /// #[no_mangle]
-    /// pub unsafe extern "C" fn hostcall_call_binop(
+    /// pub unsafe fn hostcall_call_binop(
     ///     vmctx: &Vmctx,
     ///     binop_table_idx: u32,
     ///     binop_func_idx: u32,

--- a/lucet-runtime/lucet-runtime-macros/src/lib.rs
+++ b/lucet-runtime/lucet-runtime-macros/src/lib.rs
@@ -1,6 +1,6 @@
 extern crate proc_macro;
 use proc_macro::TokenStream;
-use quote::quote;
+use quote::{quote, quote_spanned};
 use syn::spanned::Spanned;
 
 /// This attribute generates a Lucet hostcall from a standalone Rust function that takes a `&mut
@@ -39,6 +39,12 @@ pub fn lucet_hostcall(_attr: TokenStream, item: TokenStream) -> TokenStream {
     };
 
     let mut hostcall = syn::parse_macro_input!(item as syn::ItemFn);
+    if let Some(abi) = &hostcall.sig.abi {
+        let err = quote_spanned! {abi.span()=>
+            compile_error!("Functions annotated with `#[lucet_hostcall]` may not have an `extern` ABI");
+        };
+        return err.into();
+    }
     let hostcall_ident = hostcall.sig.ident.clone();
 
     // use the same attributes and visibility as the impl hostcall

--- a/lucet-runtime/lucet-runtime-tests/src/entrypoint.rs
+++ b/lucet-runtime/lucet-runtime-tests/src/entrypoint.rs
@@ -203,7 +203,7 @@ macro_rules! entrypoint_tests {
 
         #[lucet_hostcall]
         #[no_mangle]
-        pub unsafe extern "C" fn callback_hostcall(vmctx: &Vmctx, cb_idx: u32, x: u64) -> u64 {
+        pub unsafe fn callback_hostcall(vmctx: &Vmctx, cb_idx: u32, x: u64) -> u64 {
             let func = vmctx
                 .get_func_from_idx(0, cb_idx)
                 .expect("can get function by index");
@@ -215,7 +215,7 @@ macro_rules! entrypoint_tests {
 
         #[lucet_hostcall]
         #[no_mangle]
-        pub unsafe extern "C" fn add_4_hostcall(
+        pub unsafe fn add_4_hostcall(
             vmctx: &Vmctx,
             x: u64,
             y: u64,

--- a/lucet-runtime/src/c_api.rs
+++ b/lucet-runtime/src/c_api.rs
@@ -421,20 +421,20 @@ pub fn ensure_linked() {
 
 #[lucet_hostcall]
 #[no_mangle]
-pub unsafe extern "C" fn lucet_vmctx_get_heap(vmctx: &Vmctx) -> *mut u8 {
+pub unsafe fn lucet_vmctx_get_heap(vmctx: &Vmctx) -> *mut u8 {
     vmctx.instance().alloc().slot().heap as *mut u8
 }
 
 #[lucet_hostcall]
 #[no_mangle]
-pub unsafe extern "C" fn lucet_vmctx_get_globals(vmctx: &Vmctx) -> *mut i64 {
+pub unsafe fn lucet_vmctx_get_globals(vmctx: &Vmctx) -> *mut i64 {
     vmctx.instance().alloc().slot().globals as *mut i64
 }
 
 #[lucet_hostcall]
 #[no_mangle]
 /// Get the number of WebAssembly pages currently in the heap.
-pub unsafe extern "C" fn lucet_vmctx_current_memory(vmctx: &Vmctx) -> u32 {
+pub unsafe fn lucet_vmctx_current_memory(vmctx: &Vmctx) -> u32 {
     vmctx.instance().alloc().heap_len() as u32 / WASM_PAGE_SIZE
 }
 
@@ -443,7 +443,7 @@ pub unsafe extern "C" fn lucet_vmctx_current_memory(vmctx: &Vmctx) -> u32 {
 /// Grows the guest heap by the given number of WebAssembly pages.
 ///
 /// On success, returns the number of pages that existed before the call. On failure, returns `-1`.
-pub unsafe extern "C" fn lucet_vmctx_grow_memory(vmctx: &Vmctx, additional_pages: u32) -> i32 {
+pub unsafe fn lucet_vmctx_grow_memory(vmctx: &Vmctx, additional_pages: u32) -> i32 {
     if let Ok(old_pages) = vmctx.instance_mut().grow_memory(additional_pages) {
         old_pages as i32
     } else {
@@ -454,17 +454,13 @@ pub unsafe extern "C" fn lucet_vmctx_grow_memory(vmctx: &Vmctx, additional_pages
 #[lucet_hostcall]
 #[no_mangle]
 /// Check if a memory region is inside the instance heap.
-pub unsafe extern "C" fn lucet_vmctx_check_heap(
-    vmctx: &Vmctx,
-    ptr: *mut c_void,
-    len: libc::size_t,
-) -> bool {
+pub unsafe fn lucet_vmctx_check_heap(vmctx: &Vmctx, ptr: *mut c_void, len: libc::size_t) -> bool {
     vmctx.instance().check_heap(ptr, len)
 }
 
 #[lucet_hostcall]
 #[no_mangle]
-pub unsafe extern "C" fn lucet_vmctx_get_func_from_idx(
+pub unsafe fn lucet_vmctx_get_func_from_idx(
     vmctx: &Vmctx,
     table_idx: u32,
     func_idx: u32,
@@ -479,7 +475,7 @@ pub unsafe extern "C" fn lucet_vmctx_get_func_from_idx(
 
 #[lucet_hostcall]
 #[no_mangle]
-pub unsafe extern "C" fn lucet_vmctx_terminate(_vmctx: &Vmctx, details: *mut c_void) {
+pub unsafe fn lucet_vmctx_terminate(_vmctx: &Vmctx, details: *mut c_void) {
     lucet_hostcall_terminate!(CTerminationDetails { details });
 }
 
@@ -490,7 +486,7 @@ pub unsafe extern "C" fn lucet_vmctx_terminate(_vmctx: &Vmctx, details: *mut c_v
 /// TODO: rename
 ///
 /// TODO: C implementations of hostcalls are highly questionable
-pub unsafe extern "C" fn lucet_vmctx_get_delegate(vmctx: &Vmctx) -> *mut c_void {
+pub unsafe fn lucet_vmctx_get_delegate(vmctx: &Vmctx) -> *mut c_void {
     vmctx
         .instance()
         .get_embed_ctx::<*mut c_void>()
@@ -501,7 +497,7 @@ pub unsafe extern "C" fn lucet_vmctx_get_delegate(vmctx: &Vmctx) -> *mut c_void 
 /// TODO: C implementations of hostcalls are highly questionable
 #[lucet_hostcall]
 #[no_mangle]
-pub unsafe extern "C" fn lucet_vmctx_yield(vmctx: &Vmctx, val: *mut c_void) -> *mut c_void {
+pub unsafe fn lucet_vmctx_yield(vmctx: &Vmctx, val: *mut c_void) -> *mut c_void {
     vmctx
         .yield_val_try_val(CYieldedVal { val })
         .map(|CYieldedVal { val }| val)


### PR DESCRIPTION
This was a programming error introduced in the transition between the `lucet_hostcalls!` macro and the `#[lucet_hostcall]` attribute.

The expansion of the code in the attribute called the annotated function from within a `catch_unwind` without modifying its ABI. Since it is UB to unwind from a non-Rust ABI function, release mode optimizations would elide the code which would otherwise handle an unwind from the function. This caused the process to abort if the function ever _did_ unwind, since the system unwinding runtime would reach the end of the guest stack without finding any frames willing to handle the exception.

I believe this behavior was very difficult, if not impossible, to observe in practice with the current state of the Lucet codebase. The only unwinding that these functions could directly induce are the assertions in `vmctx::instance_from_vmctx` that should never be violated except in the case of a Lucet programming error, or a dynamic linking problem.

However, in #583 we are adding an option to instances that would cause `lucet_vmctx_grow_memory` to potentially terminate the instance via the `lucet_hostcall_terminate!()` mechanism that is implemented via unwinding. We discovered this problem during testing on that branch, and so we need to land this fix before it can proceed.

This patch contains a fix to the immediate problem by removing the erroneous `extern "C"` specifiers. It also prevents the problem recurring in the future by generating a compile-time error from `#[lucet_hostcall]` if there is an ABI specifier present on the function it annotates.