### PR TITLE
use $GITHUB_PATH rather than ##[add-path]

### DIFF
--- a/.github/workflows/fuzz.yml.disabled
+++ b/.github/workflows/fuzz.yml.disabled
@@ -37,7 +37,7 @@ jobs:
         curl -sS -L "https://github.com/WebAssembly/binaryen/archive/version_${BINARYEN_VERSION}.tar.gz" | tar xzf -
         mkdir -p binaryen-build
         cd binaryen-build && cmake "../binaryen-version_${BINARYEN_VERSION}" && make wasm-opt wasm-reduce
-        echo "##[add-path]$PWD/binaryen-build/bin"
+        echo "$PWD/binaryen-build/bin" >> $GITHUB_PATH
       env:
         BINARYEN_VERSION: 86
 

--- a/.github/workflows/mac-ci.yml
+++ b/.github/workflows/mac-ci.yml
@@ -14,7 +14,7 @@ jobs:
       run: |
         curl https://sh.rustup.rs | sh -s -- --default-toolchain 1.46.0 -y
         rustup update
-        echo "##[add-path]$HOME/.cargo/bin"
+        echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
     - name: Install wasi-sdk (macos)
       run: |


### PR DESCRIPTION
In accordance with this advisory it's recommended we move to a
different scheme of setting env vars and updating PATH:

https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

Thank you @alexcrichton for bringing this to my attention