### PR TITLE
Don't enable the Cranelift verifier in release mode

### DIFF
--- a/lucetc/src/compiler.rs
+++ b/lucetc/src/compiler.rs
@@ -489,7 +489,14 @@ impl<'a> Compiler<'a> {
     ) -> Result<Box<dyn TargetIsa>, Error> {
         let mut flags_builder = settings::builder();
         let isa_builder = cpu_features.isa_builder(target)?;
-        flags_builder.enable("enable_verifier").unwrap();
+        let enable_verifier = if cfg!(debug_assertions) {
+            "true"
+        } else {
+            "false"
+        };
+        flags_builder
+            .set("enable_verifier", enable_verifier)
+            .unwrap();
         flags_builder.enable("is_pic").unwrap();
         flags_builder.set("opt_level", opt_level.to_flag()).unwrap();
         if canonicalize_nans {


### PR DESCRIPTION
The verifier can end up taking a significant chunk of time. On a local
test case this change decreases the CPU time used by lucetc from 30s to
6.5s.

This is take 2 of https://github.com/bytecodealliance/lucet/pull/603 as a PR from this repo's branch to see if CI triggers well.