### PR TITLE
dlmodule version checks optional, uffd configuration options expanded

### DIFF
--- a/lucet-runtime/src/c_api.rs
+++ b/lucet-runtime/src/c_api.rs
@@ -1,6 +1,6 @@
 use crate::{DlModule, Instance, Limits, MmapRegion, Module, Region};
 #[cfg(all(target_os = "linux", feature = "uffd"))]
-use crate::{UffdRegion, WasmPageSizedUffdStrategy};
+use crate::{UffdConfig, UffdRegion};
 use libc::{c_char, c_int, c_void};
 use lucet_module::TrapCode;
 use lucet_runtime_internals::c_api::*;
@@ -111,7 +111,7 @@ pub unsafe extern "C" fn lucet_uffd_region_create(
                 .as_ref()
                 .map(|l| l.into())
                 .unwrap_or(Limits::default());
-            match UffdRegion::create(instance_capacity as usize, &limits, WasmPageSizedUffdStrategy {}) {
+            match UffdRegion::create(instance_capacity as usize, &limits, UffdConfig::default()) {
                 Ok(region) => {
                     let region_thin = Arc::into_raw(Arc::new(region as Arc<dyn Region>));
                     region_out.write(region_thin as _);

--- a/lucet-runtime/src/lib.rs
+++ b/lucet-runtime/src/lib.rs
@@ -419,7 +419,7 @@ pub use lucet_runtime_internals::module::{DlModule, Module};
 pub use lucet_runtime_internals::region::mmap::MmapRegion;
 #[cfg(all(target_os = "linux", feature = "uffd"))]
 pub use lucet_runtime_internals::region::uffd::{
-    HostPageSizedUffdStrategy, UffdRegion, UffdStrategy, WasmPageSizedUffdStrategy,
+    Disposition as UffdDisposition, HeapPageSize as UffdHeapPageSize, UffdConfig, UffdRegion,
 };
 pub use lucet_runtime_internals::region::{InstanceBuilder, Region, RegionCreate};
 pub use lucet_runtime_internals::val::{UntypedRetVal, Val};

--- a/lucet-runtime/tests/memory.rs
+++ b/lucet-runtime/tests/memory.rs
@@ -15,7 +15,7 @@ cfg_if::cfg_if! {
 mod uffd_specific {
     use libc::{c_void, mincore};
     use lucet_runtime::{Limits, Region};
-    use lucet_runtime::{UffdRegion, WasmPageSizedUffdStrategy};
+    use lucet_runtime::{UffdConfig, UffdRegion};
     use lucet_runtime_tests::build::test_module_wasm;
 
     #[test]
@@ -26,7 +26,7 @@ mod uffd_specific {
     fn lazy_memory() {
         let module = test_module_wasm("memory", "uffd_memory.wat")
             .expect("compile and load uffd_memory.wasm");
-        let region = UffdRegion::create(1, &Limits::default(), WasmPageSizedUffdStrategy {})
+        let region = UffdRegion::create(1, &Limits::default(), UffdConfig::default())
             .expect("region can be created");
         let mut inst = region
             .new_instance(module)

--- a/lucet-wasi/src/main.rs
+++ b/lucet-wasi/src/main.rs
@@ -217,7 +217,7 @@ fn run(config: Config<'_>) {
             (true, None) => panic!("signature verification requires a public key"),
         };
         let module = if let Some(pk) = pk {
-            DlModule::load_and_verify(&config.lucet_module, pk)
+            DlModule::load_and_verify(&config.lucet_module, pk, true)
                 .expect("signed module can be loaded")
         } else {
             DlModule::load(&config.lucet_module).expect("module can be loaded")


### PR DESCRIPTION
Two changes, one PR:

1. lucet-runtime::DlModule load now optionally enforces version match
    This check exists to make sure that lucetc and lucet-runtime are built
against the same revision of lucet-module - the use of serde depends
on both sides defining types the same.
    This check can be overridden for cases where the user's runtime needs to
load modules built with a different lucetc. The user is responsible for
ensuring that the modules were created with the same lucet-module type
definitions.

1. lucet-runtime: change uffd configurations to have many more options.
    The user can now configure the strategy of stack initialization and heap initialization as well as the page size. also, configurations are given by a struct now instead of a trait.


