### PR TITLE
Update wasmtime to latest version.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -464,7 +464,7 @@ dependencies = [
  "log",
  "smallvec",
  "thiserror",
- "wasmparser 0.65.0",
+ "wasmparser 0.67.0",
 ]
 
 [[package]]
@@ -2669,9 +2669,9 @@ checksum = "a950e6a618f62147fd514ff445b2a0b53120d382751960797f85f058c7eda9b9"
 
 [[package]]
 name = "wasmparser"
-version = "0.65.0"
+version = "0.67.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cc2fe6350834b4e528ba0901e7aa405d78b89dc1fa3145359eb4de0e323fcf"
+checksum = "9f091cf3849e5fe76a60255bff169277459f2201435bc583b6656880553f0ad0"
 
 [[package]]
 name = "wast"

--- a/lucetc/src/compiler.rs
+++ b/lucetc/src/compiler.rs
@@ -852,15 +852,6 @@ struct ObjectRelocSink {
 }
 
 impl binemit::RelocSink for ObjectRelocSink {
-    fn reloc_block(
-        &mut self,
-        _offset: binemit::CodeOffset,
-        _reloc: binemit::Reloc,
-        _block_offset: binemit::CodeOffset,
-    ) {
-        unimplemented!();
-    }
-
     fn reloc_external(
         &mut self,
         offset: binemit::CodeOffset,

--- a/lucetc/src/decls.rs
+++ b/lucetc/src/decls.rs
@@ -12,8 +12,8 @@ use cranelift_codegen::ir;
 use cranelift_codegen::isa::TargetFrontendConfig;
 use cranelift_module::{Linkage, Module as ClifModule};
 use cranelift_wasm::{
-    Global, GlobalIndex, GlobalInit, MemoryIndex, SignatureIndex, Table, TableIndex,
-    TargetEnvironment, WasmFuncType,
+    Global, GlobalIndex, GlobalInit, MemoryIndex, Table, TableIndex, TargetEnvironment, TypeIndex,
+    WasmFuncType,
 };
 use lucet_module::bindings::Bindings;
 use lucet_module::ModuleFeatures;
@@ -470,7 +470,7 @@ impl<'a> ModuleDecls<'a> {
         })
     }
 
-    pub fn get_signature(&self, signature_index: SignatureIndex) -> Result<&ir::Signature, Error> {
+    pub fn get_signature(&self, signature_index: TypeIndex) -> Result<&ir::Signature, Error> {
         self.get_signature_uid(signature_index).and_then(|uid| {
             self.info
                 .signatures
@@ -485,7 +485,7 @@ impl<'a> ModuleDecls<'a> {
 
     pub fn get_signature_uid(
         &self,
-        signature_index: SignatureIndex,
+        signature_index: TypeIndex,
     ) -> Result<UniqueSignatureIndex, Error> {
         self.info
             .signature_mapping

--- a/lucetc/src/function.rs
+++ b/lucetc/src/function.rs
@@ -12,8 +12,7 @@ use cranelift_frontend::FunctionBuilder;
 use cranelift_module::{Linkage, Module as ClifModule, ModuleError as ClifModuleError};
 use cranelift_wasm::{
     wasmparser::Operator, FuncEnvironment, FuncIndex, FuncTranslationState, GlobalIndex,
-    GlobalVariable, MemoryIndex, SignatureIndex, TableIndex, TargetEnvironment, WasmError,
-    WasmResult,
+    GlobalVariable, MemoryIndex, TableIndex, TargetEnvironment, TypeIndex, WasmError, WasmResult,
 };
 use lucet_module::InstanceRuntimeData;
 use memoffset::offset_of;
@@ -395,7 +394,7 @@ impl<'a> FuncEnvironment for FuncInfo<'a> {
         mut pos: FuncCursor<'_>,
         _table_index: TableIndex,
         table: ir::Table,
-        sig_index: SignatureIndex,
+        sig_index: TypeIndex,
         sig_ref: ir::SigRef,
         callee: ir::Value,
         call_args: &[ir::Value],
@@ -449,7 +448,7 @@ impl<'a> FuncEnvironment for FuncInfo<'a> {
     fn make_indirect_sig(
         &mut self,
         func: &mut ir::Function,
-        index: SignatureIndex,
+        index: TypeIndex,
     ) -> Result<ir::SigRef, WasmError> {
         let sig = self.module_decls.get_signature(index).unwrap().clone();
         Ok(func.import_signature(sig))

--- a/lucetc/src/table.rs
+++ b/lucetc/src/table.rs
@@ -93,7 +93,7 @@ pub fn write_table_data(
                     // Note: this is the only place we validate that the table entry points to a valid
                     // function. If this is ever removed, make sure this check happens elsewhere.
                     if let Some(func) = decls.get_func(*func_index) {
-                        // First element in row is the SignatureIndex for the function
+                        // First element in row is the TypeIndex for the function
                         putelem(&mut table_data, func.signature_index.as_u32() as u64);
 
                         // Second element in row is the pointer to the function. The Reloc is doing the work


### PR DESCRIPTION
Following up on some API changes to the environment traits in
bytecodealliance/wasmtime#2115, this PR updates the git version of the
`wasmtime` submodule and updates `lucetc` accordingly.

The changes are basically just renamings, along with a removal of a
RelocSink trait method that was previously unused.

(This is a re-creation of #609, merging from a branch in the main repo rather than my fork.)