### PR TITLE
Add a "bounded runtime" mode to guest execution.

### DIFF
--- a/lucet-module/src/runtime.rs
+++ b/lucet-module/src/runtime.rs
@@ -11,16 +11,10 @@ pub struct InstanceRuntimeData {
     /// `instruction_count_adj` set to some negative value and
     /// `instruction_count_bound` adjusted upward in compensation.
     /// `instruction_count_adj` is incremented as execution proceeds; on each
-    /// increment, the Wasm code checks the carry flag. If the value crosses
-    /// zero (becomes positive), then we have exceeded the bound and we must
-    /// yield. At any point, the `adj` value can be adjusted downward by
-    /// transferring the count to the `bound`.
-    ///
-    /// Note that the bound-yield is only triggered if the `adj` value
-    /// transitions from negative to non-negative; in other words, it is
-    /// edge-triggered, not level-triggered. So entering code that has been
-    /// instrumented for instruction counting with `adj` >= 0 will result in no
-    /// bound ever triggered (until 2^64 instructions execute).
+    /// increment, the Wasm code checks the sign. If the value is greater than
+    /// zero, then we have exceeded the bound and we must yield. At any point,
+    /// the `adj` value can be adjusted downward by transferring the count to
+    /// the `bound`.
     pub instruction_count_adj: i64,
     pub instruction_count_bound: i64,
     pub stack_limit: u64,

--- a/lucet-module/src/runtime.rs
+++ b/lucet-module/src/runtime.rs
@@ -4,6 +4,24 @@
 #[repr(align(8))]
 pub struct InstanceRuntimeData {
     pub globals_ptr: *mut i64,
-    pub instruction_count: u64,
+    /// `instruction_count_bound + instruction_count_adj` gives the total
+    /// instructions executed. We deconstruct the count into a signed adjustment
+    /// and a "bound" because we want to be able to set a runtime bound beyond
+    /// which we yield to the caller. We do this by beginning execution with
+    /// `instruction_count_adj` set to some negative value and
+    /// `instruction_count_bound` adjusted upward in compensation.
+    /// `instruction_count_adj` is incremented as execution proceeds; on each
+    /// increment, the Wasm code checks the carry flag. If the value crosses
+    /// zero (becomes positive), then we have exceeded the bound and we must
+    /// yield. At any point, the `adj` value can be adjusted downward by
+    /// transferring the count to the `bound`.
+    ///
+    /// Note that the bound-yield is only triggered if the `adj` value
+    /// transitions from negative to non-negative; in other words, it is
+    /// edge-triggered, not level-triggered. So entering code that has been
+    /// instrumented for instruction counting with `adj` >= 0 will result in no
+    /// bound ever triggered (until 2^64 instructions execute).
+    pub instruction_count_adj: i64,
+    pub instruction_count_bound: i64,
     pub stack_limit: u64,
 }

--- a/lucet-runtime/include/lucet_vmctx.h
+++ b/lucet-runtime/include/lucet_vmctx.h
@@ -42,4 +42,10 @@ void *lucet_vmctx_get_func_from_idx(struct lucet_vmctx const *ctx, uint32_t tabl
 // Mostly for tests - this conversion is builtin to lucetc
 int64_t *lucet_vmctx_get_globals(struct lucet_vmctx const *ctx);
 
+// Yield that is meant to be inserted by compiler instrumentation, transparent
+// to Wasm code execution. It is intended to be invoked periodically (e.g.,
+// every N instructions) to bound runtime of any particular execution slice of
+// Wasm code.
+void lucet_vmctx_yield_at_bound_expiration(struct lucet_vmctx const *ctx);
+
 #endif // LUCET_VMCTX_H

--- a/lucet-runtime/lucet-runtime-internals/src/future.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/future.rs
@@ -1,10 +1,11 @@
 use crate::error::Error;
-use crate::instance::{InstanceHandle, RunResult, State, TerminationDetails};
+use crate::instance::{InstanceHandle, InternalRunResult, RunResult, State, TerminationDetails};
 use crate::val::{UntypedRetVal, Val};
 use crate::vmctx::{Vmctx, VmctxInternal};
 use std::any::Any;
 use std::future::Future;
 use std::pin::Pin;
+use std::task::{Context, Poll};
 
 /// This is the same type defined by the `futures` library, but we don't need the rest of the
 /// library for this purpose.
@@ -75,7 +76,7 @@ impl Vmctx {
         // Wrap the computation in `YieldedFuture` so that
         // `Instance::run_async` can catch and run it.  We will get the
         // `ResumeVal` we applied to `f` above.
-        self.yield_impl::<YieldedFuture, ResumeVal>(YieldedFuture(f), false);
+        self.yield_impl::<YieldedFuture, ResumeVal>(YieldedFuture(f), false, false);
         let ResumeVal(v) = self.take_resumed_val();
         // We may now downcast and unbox the returned Box<dyn Any> into an `R`
         // again.
@@ -83,15 +84,30 @@ impl Vmctx {
     }
 }
 
-/// This struct needs to be exposed publicly in order for the signature of a
-/// "block_in_place" function to be writable, a concession we must make because
-/// Rust does not have rank 2 types. To prevent the user from inspecting or
-/// constructing the inside of this type, it is completely opaque.
-pub struct Bounce<'a>(BounceInner<'a>);
+/// A simple future that yields once. We use this to yield when a runtime bound is reached.
+///
+/// Inspired by Tokio's `yield_now()`.
+struct YieldNow {
+    yielded: bool,
+}
 
-enum BounceInner<'a> {
-    Done(UntypedRetVal),
-    More(BoxFuture<'a, ResumeVal>),
+impl YieldNow {
+    fn new() -> Self {
+        Self { yielded: false }
+    }
+}
+
+impl Future for YieldNow {
+    type Output = ();
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+        if self.yielded {
+            Poll::Ready(())
+        } else {
+            self.yielded = true;
+            cx.waker().wake_by_ref();
+            Poll::Pending
+        }
+    }
 }
 
 impl InstanceHandle {
@@ -101,51 +117,20 @@ impl InstanceHandle {
     /// that use `Vmctx::block_on` and provides the trampoline that `.await`s those futures on
     /// behalf of the guest.
     ///
+    /// If `runtime_bound` is provided, it will also pause the Wasm execution and yield a future
+    /// that resumes it after (approximately) that many Wasm opcodes have executed.
+    ///
     /// # `Vmctx` Restrictions
     ///
     /// This method permits the use of `Vmctx::block_on`, but disallows all other uses of `Vmctx::
     /// yield_val_expecting_val` and family (`Vmctx::yield_`, `Vmctx::yield_expecting_val`,
     /// `Vmctx::yield_val`).
-    ///
-    /// # Blocking thread
-    ///
-    /// The `wrap_blocking` argument is a function that is called with a closure that runs the Wasm
-    /// program. Since Wasm may execute for an arbitrarily long time without `await`ing, we need to
-    /// make sure that it runs on a thread that is allowed to block.
-    ///
-    /// This argument is designed with [`tokio::task::block_in_place`][tokio] in mind. The odd type
-    /// is a concession to the fact that we don't have rank 2 types in Rust, and so must fall back
-    /// to trait objects in order to be able to take an argument that is itself a function that
-    /// takes a closure.
-    ///
-    /// In order to provide an appropriate function, you may have to wrap the library function in
-    /// another closure so that the types are compatible. For example:
-    ///
-    /// ```no_run
-    /// # async fn f() {
-    /// # let instance: lucet_runtime_internals::instance::InstanceHandle = unimplemented!();
-    /// fn block_in_place<F, R>(f: F) -> R
-    /// where
-    ///     F: FnOnce() -> R,
-    /// {
-    ///     // ...
-    ///     # f()
-    /// }
-    ///
-    /// instance.run_async("entrypoint", &[], |f| block_in_place(f)).await.unwrap();
-    /// # }
-    /// ```
-    ///
-    /// [tokio]: https://docs.rs/tokio/0.2.21/tokio/task/fn.block_in_place.html
-    pub async fn run_async<'a, F>(
+    pub async fn run_async<'a>(
         &'a mut self,
         entrypoint: &'a str,
         args: &'a [Val],
-        wrap_blocking: F,
-    ) -> Result<UntypedRetVal, Error>
-    where
-        F: for<'b> Fn(&mut (dyn FnMut() -> Result<Bounce<'b>, Error>)) -> Result<Bounce<'b>, Error>,
-    {
+        runtime_bound: Option<u64>,
+    ) -> Result<UntypedRetVal, Error> {
         if self.is_yielded() {
             return Err(Error::Unsupported(
                 "cannot run_async a yielded instance".to_owned(),
@@ -156,55 +141,56 @@ impl InstanceHandle {
         let mut resume_val: Option<ResumeVal> = None;
         loop {
             // Run the WebAssembly program
-            let bounce = wrap_blocking(&mut || {
-                let run_result = if self.is_yielded() {
-                    // A previous iteration of the loop stored the ResumeVal in
-                    // `resume_val`, send it back to the guest ctx and continue
-                    // running:
-                    self.resume_with_val_impl(
-                        resume_val
-                            .take()
-                            .expect("is_yielded implies resume_value is some"),
-                        true,
-                    )
-                } else {
-                    // This is the first iteration, call the entrypoint:
-                    let func = self.module.get_export_func(entrypoint)?;
-                    self.run_func(func, args, true)
-                };
-                match run_result? {
-                    RunResult::Returned(rval) => {
-                        // Finished running, return UntypedReturnValue
-                        return Ok(Bounce(BounceInner::Done(rval)));
-                    }
-                    RunResult::Yielded(yval) => {
-                        // Check if the yield came from Vmctx::block_on:
-                        if yval.is::<YieldedFuture>() {
-                            let YieldedFuture(future) = *yval.downcast::<YieldedFuture>().unwrap();
-                            // Rehydrate the lifetime from `'static` to `'a`, which
-                            // is morally the same lifetime as was passed into
-                            // `Vmctx::block_on`.
-                            Ok(Bounce(BounceInner::More(
-                                future as BoxFuture<'a, ResumeVal>,
-                            )))
-                        } else {
-                            // Any other yielded value is not supported - die with an error.
-                            Err(Error::Unsupported(
-                                "cannot yield anything besides a future in Instance::run_async"
-                                    .to_owned(),
-                            ))
-                        }
-                    }
+            let run_result = if self.is_yielded() {
+                // A previous iteration of the loop stored the ResumeVal in
+                // `resume_val`, send it back to the guest ctx and continue
+                // running:
+                self.resume_with_val_impl(
+                    resume_val
+                        .take()
+                        .expect("is_yielded implies resume_value is some"),
+                    true,
+                    runtime_bound,
+                )
+            } else if self.is_bound_expired() {
+                self.resume_bounded(
+                    runtime_bound.expect("should have bound if guest had expired bound"),
+                )
+            } else {
+                // This is the first iteration, call the entrypoint:
+                let func = self.module.get_export_func(entrypoint)?;
+                self.run_func(func, args, true, runtime_bound)
+            };
+            match run_result? {
+                InternalRunResult::Normal(RunResult::Returned(rval)) => {
+                    // Finished running, return UntypedReturnValue
+                    return Ok(rval);
                 }
-            })?;
-            match bounce {
-                Bounce(BounceInner::Done(rval)) => return Ok(rval),
-                Bounce(BounceInner::More(fut)) => {
-                    // await on the computation. Store its result in
-                    // `resume_val`.
-                    resume_val = Some(fut.await);
+                InternalRunResult::Normal(RunResult::Yielded(yval)) => {
+                    // Check if the yield came from Vmctx::block_on:
+                    if yval.is::<YieldedFuture>() {
+                        let YieldedFuture(future) = *yval.downcast::<YieldedFuture>().unwrap();
+                        // Rehydrate the lifetime from `'static` to `'a`, which
+                        // is morally the same lifetime as was passed into
+                        // `Vmctx::block_on`.
+                        let future = future as BoxFuture<'a, ResumeVal>;
+
+                        // await on the computation. Store its result in
+                        // `resume_val`.
+                        resume_val = Some(future.await);
                     // Now we want to `Instance::resume_with_val` and start
                     // this cycle over.
+                    } else {
+                        // Any other yielded value is not supported - die with an error.
+                        return Err(Error::Unsupported(
+                            "cannot yield anything besides a future in Instance::run_async"
+                                .to_owned(),
+                        ));
+                    }
+                }
+                InternalRunResult::BoundExpired => {
+                    // Await on a simple future that yields once then is ready.
+                    YieldNow::new().await
                 }
             }
         }

--- a/lucet-runtime/src/c_api.rs
+++ b/lucet-runtime/src/c_api.rs
@@ -507,6 +507,12 @@ pub unsafe fn lucet_vmctx_yield(vmctx: &Vmctx, val: *mut c_void) -> *mut c_void 
         .unwrap_or(std::ptr::null_mut())
 }
 
+#[lucet_hostcall]
+#[no_mangle]
+pub unsafe fn lucet_vmctx_yield_at_bound_expiration(vmctx: &Vmctx) {
+    vmctx.yield_at_bound_expiration();
+}
+
 #[cfg(test)]
 mod tests {
     use super::lucet_dl_module;

--- a/lucet-runtime/tests/instruction_counting.rs
+++ b/lucet-runtime/tests/instruction_counting.rs
@@ -3,8 +3,10 @@ use lucet_runtime::{DlModule, Limits, MmapRegion, Region, RunResult};
 use lucetc::{Lucetc, LucetcOpts};
 use rayon::prelude::*;
 use std::fs::DirEntry;
+use std::future::Future;
 use std::path::Path;
 use std::sync::Arc;
+use std::task::{Context, Poll, Waker};
 use tempfile::TempDir;
 
 pub fn wasm_test<P: AsRef<Path>>(
@@ -105,6 +107,105 @@ pub fn check_instruction_count() {
                 }
             },
             "instruction count for test case {} is incorrect",
+            wasm_path.display()
+        );
+    });
+}
+
+/// Create a fake `Waker` for testing a `Future`.
+///
+/// Borrowed from:
+/// https://stackoverflow.com/questions/63263880/testing-futures-and-streams-how-do-i-create-a-fake-context
+fn dummy_waker() -> Waker {
+    use std::task::{RawWaker, RawWakerVTable};
+
+    static DUMMY_VTABLE: RawWakerVTable =
+        RawWakerVTable::new(dummy_clone, dummy_wake, dummy_wake_by_ref, dummy_drop);
+
+    unsafe fn dummy_clone(ptr: *const ()) -> RawWaker {
+        RawWaker::new(ptr, &DUMMY_VTABLE)
+    }
+    unsafe fn dummy_wake(_ptr: *const ()) {}
+
+    unsafe fn dummy_wake_by_ref(_ptr: *const ()) {}
+
+    unsafe fn dummy_drop(_ptr: *const ()) {}
+
+    unsafe { Waker::from_raw(RawWaker::new(&(), &DUMMY_VTABLE)) }
+}
+
+#[test]
+pub fn check_instruction_count_with_periodic_yields() {
+    let files: Vec<DirEntry> = get_instruction_count_test_files();
+
+    assert!(
+        !files.is_empty(),
+        "there are no test cases in the `instruction_counting` directory"
+    );
+
+    files.par_iter().for_each(|ent| {
+        let wasm_path = ent.path();
+        let do_instrument = true;
+        let module = wasm_test(&wasm_path, do_instrument).expect("can load instrumented module");
+
+        let region = MmapRegion::create(1, &Limits::default()).expect("region can be created");
+
+        let mut inst = region
+            .new_instance(module)
+            .expect("instance can be created");
+
+        let yields = {
+            let mut yields = 0;
+            let mut future = Box::pin(inst.run_async("test_function", &[], Some(1000)));
+            let waker = dummy_waker();
+            let mut context = Context::from_waker(&waker);
+            loop {
+                match future.as_mut().poll(&mut context) {
+                    Poll::Ready(val) => {
+                        val.expect("instance runs");
+                        break;
+                    }
+                    Poll::Pending => {
+                        yields += 1;
+                        if yields > 1000 {
+                            panic!("Instruction-counting test ran for too long");
+                        }
+                    }
+                }
+            }
+            yields
+        };
+
+        let instruction_count = inst
+            .get_instruction_count()
+            .expect("instruction count expected from instance");
+
+        assert_eq!(
+            instruction_count,
+            match inst
+                .run("instruction_count", &[])
+                .expect("instance still runs")
+            {
+                RunResult::Returned(value) => value.as_i64() as u64,
+                RunResult::Yielded(_) => {
+                    panic!("instruction counting test runner doesn't support yielding");
+                }
+            },
+            "instruction count for test case {} is incorrect",
+            wasm_path.display()
+        );
+
+        // There is some variance to this in the real world, because yields happen only at the ends
+        // of basic blocks, and there may be an off-by-one; so allow a small range.
+        let expected_yields = instruction_count / 1000;
+        let diff = if expected_yields > yields {
+            expected_yields - yields
+        } else {
+            yields - expected_yields
+        };
+        assert!(
+            diff <= 1,
+            "periodic yield count for test case {} is incorrect",
             wasm_path.display()
         );
     });

--- a/lucet-runtime/tests/instruction_counting/long_loop.wat
+++ b/lucet-runtime/tests/instruction_counting/long_loop.wat
@@ -1,0 +1,16 @@
+(module
+  (func $main (export "test_function") (local i32)
+      loop
+        local.get 0
+        i32.const 1
+	i32.add
+	local.tee 0
+	i32.const 10000
+	i32.ne
+	br_if 0
+      end
+  )
+  (func $instruction_count (export "instruction_count") (result i64)
+    i64.const 70000
+  )
+)

--- a/lucet-runtime/tests/instruction_counting/long_loop_start.wat
+++ b/lucet-runtime/tests/instruction_counting/long_loop_start.wat
@@ -1,0 +1,17 @@
+(module
+  (start $start)
+  (func $start (export "_start") (local i32)
+      loop
+        local.get 0
+        i32.const 1
+	i32.add
+	local.tee 0
+	i32.const 10000
+	i32.ne
+	br_if 0
+      end
+  )
+  (func $instruction_count (export "instruction_count") (result i64)
+    i64.const 70000
+  )
+)

--- a/lucetc/src/error.rs
+++ b/lucetc/src/error.rs
@@ -1,6 +1,7 @@
 use crate::types::SignatureError;
 use crate::validate::Error as ValidationError;
 use cranelift_module::ModuleError as ClifModuleError;
+use cranelift_wasm::wasmparser::BinaryReaderError as ClifWasmReaderError;
 use cranelift_wasm::WasmError as ClifWasmError;
 use lucet_module::error::Error as LucetModuleError;
 use object;
@@ -27,6 +28,8 @@ pub enum Error {
     MissingWasmPreamble,
     #[error("Wasm validation: {0}")]
     WasmValidation(#[from] wasmparser::BinaryReaderError),
+    #[error("Wasm validation: {0}")]
+    ClifWasmValidation(#[from] ClifWasmReaderError),
     #[error("Wat input: {0}")]
     WatInput(#[from] wabt::Error),
     #[error("Object artifact: {1}. {0:?}")]

--- a/lucetc/src/function.rs
+++ b/lucetc/src/function.rs
@@ -8,7 +8,7 @@ use cranelift_codegen::cursor::FuncCursor;
 use cranelift_codegen::entity::EntityRef;
 use cranelift_codegen::ir::{self, condcodes::IntCC, InstBuilder};
 use cranelift_codegen::isa::TargetFrontendConfig;
-use cranelift_frontend::FunctionBuilder;
+use cranelift_frontend::{FunctionBuilder, Variable};
 use cranelift_module::{Linkage, Module as ClifModule, ModuleError as ClifModuleError};
 use cranelift_wasm::{
     wasmparser::Operator, FuncEnvironment, FuncIndex, FuncTranslationState, GlobalIndex,
@@ -22,10 +22,16 @@ pub struct FuncInfo<'a> {
     module_decls: &'a ModuleDecls<'a>,
     codegen_context: &'a CodegenContext,
     count_instructions: bool,
-    scope_costs: Vec<u32>,
+    scope_costs: Vec<ScopeInfo>,
     vmctx_value: Option<ir::GlobalValue>,
     global_base_value: Option<ir::GlobalValue>,
     runtime_funcs: HashMap<RuntimeFunc, ir::FuncRef>,
+    instr_count_var: Variable,
+}
+
+struct ScopeInfo {
+    cost: u32,
+    is_loop: bool,
 }
 
 impl<'a> FuncInfo<'a> {
@@ -33,15 +39,24 @@ impl<'a> FuncInfo<'a> {
         module_decls: &'a ModuleDecls<'a>,
         codegen_context: &'a CodegenContext,
         count_instructions: bool,
+        arg_count: u32,
+        local_count: u32,
     ) -> Self {
         Self {
             module_decls,
             codegen_context,
             count_instructions,
-            scope_costs: vec![0],
+            scope_costs: vec![ScopeInfo {
+                cost: 0,
+                is_loop: false,
+            }],
             vmctx_value: None,
             global_base_value: None,
             runtime_funcs: HashMap::new(),
+            // variable indices correspond to Wasm bytecode's index space,
+            // so we designate a new one after all the Wasm locals to hold
+            // the instruction count.
+            instr_count_var: Variable::with_u32(arg_count + local_count),
         }
     }
 
@@ -89,7 +104,51 @@ impl<'a> FuncInfo<'a> {
         })
     }
 
-    fn update_instruction_count_instrumentation(
+    fn get_instr_count_addr_offset(
+        &mut self,
+        builder: &mut FunctionBuilder<'_>,
+    ) -> (ir::Value, ir::immediates::Offset32) {
+        let instr_count_offset: ir::immediates::Offset32 =
+            (-(std::mem::size_of::<InstanceRuntimeData>() as i32)
+                + offset_of!(InstanceRuntimeData, instruction_count_adj) as i32)
+                .into();
+        let vmctx_gv = self.get_vmctx(builder.func);
+        let addr = builder.ins().global_value(self.pointer_type(), vmctx_gv);
+        (addr, instr_count_offset)
+    }
+
+    fn load_instr_count(&mut self, builder: &mut FunctionBuilder<'_>) {
+        let (addr, instr_count_offset) = self.get_instr_count_addr_offset(builder);
+        let trusted_mem = ir::MemFlags::trusted();
+
+        // Do the equivalent of:
+        //
+        //    let instruction_count_ptr: &mut i64 = vmctx.instruction_count;
+        //    let instruction_count: i64 = *instruction_count_ptr;
+        //    vars[instr_count] = instruction_count;
+        let cur_instr_count =
+            builder
+                .ins()
+                .load(ir::types::I64, trusted_mem, addr, instr_count_offset);
+        builder.def_var(self.instr_count_var, cur_instr_count);
+    }
+
+    fn save_instr_count(&mut self, builder: &mut FunctionBuilder<'_>) {
+        let (addr, instr_count_offset) = self.get_instr_count_addr_offset(builder);
+        let trusted_mem = ir::MemFlags::trusted();
+
+        // Do the equivalent of:
+        //
+        //    let instruction_count_ptr: &mut i64 = vmctx.instruction_count;
+        //    let instruction_count = vars[instr_count];
+        //    *instruction_count_ptr = instruction_count;
+        let new_instr_count = builder.use_var(self.instr_count_var);
+        builder
+            .ins()
+            .store(trusted_mem, new_instr_count, addr, instr_count_offset);
+    }
+
+    fn update_instruction_count_instrumentation_pre(
         &mut self,
         op: &Operator<'_>,
         builder: &mut FunctionBuilder<'_>,
@@ -121,60 +180,63 @@ impl<'a> FuncInfo<'a> {
         //     anyway (exception dispatch is much more expensive than a single wasm op)
         //   * Return corresponds to exactly one function call, so we can count it by resetting the
         //     stack to 1 at return of a function.
+        //
+        // We keep a cache of the counter in the pinned register. We load it in the prologue, save
+        // it in the epilogue, and save and reload it around calls. (We could alter our ABI to
+        // preserve the pinned reg across calls within Wasm, and save and reload it only around
+        // hostcalls, as long as we could load and save it in a trampoline wrapping the initial
+        // Wasm entry. We haven't yet done this.)
 
         /// Flush the currently-accumulated instruction count to the counter in the instance data,
         /// invoking the yield hostcall if we hit the bound.
         fn flush_counter(environ: &mut FuncInfo<'_>, builder: &mut FunctionBuilder<'_>) {
-            if environ.scope_costs.last() == Some(&0) {
-                return;
+            match environ.scope_costs.last() {
+                Some(info) if info.cost == 0 => return,
+                _ => {}
             }
-            let instr_count_offset: ir::immediates::Offset32 =
-                (-(std::mem::size_of::<InstanceRuntimeData>() as i32)
-                    + offset_of!(InstanceRuntimeData, instruction_count_adj) as i32)
-                    .into();
-            let vmctx_gv = environ.get_vmctx(builder.func);
-            let addr = builder.ins().global_value(environ.pointer_type(), vmctx_gv);
-            let trusted_mem = ir::MemFlags::trusted();
 
             //    Now insert a sequence of clif that is, functionally:
             //
-            //    let instruction_count_ptr: &mut u64 = vmctx.instruction_count;
-            //    let mut instruction_count: u64 = *instruction_count_ptr;
+            //    let mut instruction_count = vars[instr_count];
             //    instruction_count += <counter>;
-            //    *instruction_count_ptr = instruction_count;
+            //    vars[instr_count] = instruction_count;
 
-            let cur_instr_count =
-                builder
-                    .ins()
-                    .load(ir::types::I64, trusted_mem, addr, instr_count_offset);
+            let cur_instr_count = builder.use_var(environ.instr_count_var);
             let update_const = builder.ins().iconst(
                 ir::types::I64,
-                i64::from(*environ.scope_costs.last().unwrap()),
+                i64::from(environ.scope_costs.last().unwrap().cost),
             );
-            let (new_instr_count, flags) = builder.ins().iadd_ifcout(cur_instr_count, update_const);
-            builder
-                .ins()
-                .store(trusted_mem, new_instr_count, addr, instr_count_offset);
+            let new_instr_count = builder.ins().iadd(cur_instr_count, update_const);
+            builder.def_var(environ.instr_count_var, new_instr_count);
+            environ.scope_costs.last_mut().unwrap().cost = 0;
+        };
 
+        fn do_check(environ: &mut FuncInfo<'_>, builder: &mut FunctionBuilder<'_>) {
             let yield_block = builder.create_block();
             let continuation_block = builder.create_block();
+            // If `adj` is positive, branch to yield block.
+            let zero = builder.ins().iconst(ir::types::I64, 0);
+            let new_instr_count = builder.use_var(environ.instr_count_var);
+            let cmp = builder.ins().ifcmp(new_instr_count, zero);
             builder
                 .ins()
-                .brif(IntCC::UnsignedLessThan, flags, yield_block, &[]);
+                .brif(IntCC::SignedGreaterThanOrEqual, cmp, yield_block, &[]);
             builder.ins().jump(continuation_block, &[]);
             builder.seal_block(yield_block);
 
             builder.switch_to_block(yield_block);
+            environ.save_instr_count(builder);
             let yield_hostcall =
                 environ.get_runtime_func(RuntimeFunc::YieldAtBoundExpiration, &mut builder.func);
+            let vmctx_gv = environ.get_vmctx(builder.func);
+            let addr = builder.ins().global_value(environ.pointer_type(), vmctx_gv);
             builder.ins().call(yield_hostcall, &[addr]);
+            environ.load_instr_count(builder);
             builder.ins().jump(continuation_block, &[]);
             builder.seal_block(continuation_block);
 
             builder.switch_to_block(continuation_block);
-
-            *environ.scope_costs.last_mut().unwrap() = 0;
-        };
+        }
 
         // Only update or flush the counter when the scope is not sealed.
         //
@@ -216,7 +278,9 @@ impl<'a> FuncInfo<'a> {
                 // everything else, just call it one operation.
                 _ => 1,
             };
-            self.scope_costs.last_mut().map(|x| *x += op_cost);
+            self.scope_costs
+                .last_mut()
+                .map(|ref mut info| info.cost += op_cost);
 
             // apply flushing behavior if applicable
             match op {
@@ -231,7 +295,22 @@ impl<'a> FuncInfo<'a> {
                 | Operator::Br { .. }
                 | Operator::BrIf { .. }
                 | Operator::BrTable { .. } => {
+                    let do_check_and_save = match op {
+                        Operator::Call { .. }
+                        | Operator::CallIndirect { .. }
+                        | Operator::Return => true,
+                        Operator::Br { relative_depth } | Operator::BrIf { relative_depth } => {
+                            // only if loop backedge
+                            self.scope_costs[self.scope_costs.len() - 1 - *relative_depth as usize]
+                                .is_loop
+                        }
+                        _ => false,
+                    };
                     flush_counter(self, builder);
+                    if do_check_and_save {
+                        self.save_instr_count(builder);
+                        do_check(self, builder);
+                    }
                 }
                 Operator::End => {
                     // We have to be really careful here to avoid violating a cranelift invariant:
@@ -269,7 +348,7 @@ impl<'a> FuncInfo<'a> {
             // we shouldn't (because they're unreachable), or we didn't flush the counter before
             // starting to also instrument unreachable instructions (and would have tried to
             // overcount)
-            assert_eq!(*self.scope_costs.last().unwrap(), 0);
+            assert_eq!(self.scope_costs.last().unwrap().cost, 0);
         }
 
         // finally, we might have to set up a new counter for a new scope, or fix up counts a bit.
@@ -283,18 +362,63 @@ impl<'a> FuncInfo<'a> {
                 // reachable, the "called" function won't return!
                 if reachable {
                     // add 1 to count the return from the called function
-                    self.scope_costs.last_mut().map(|x| *x = 1);
+                    self.scope_costs
+                        .last_mut()
+                        .map(|ref mut info| info.cost += 1);
                 }
             }
             Operator::Block { .. } | Operator::Loop { .. } | Operator::If { .. } => {
                 // opening a scope, which starts having executed zero wasm ops
-                self.scope_costs.push(0);
+                let is_loop = match op {
+                    Operator::Loop { .. } => true,
+                    _ => false,
+                };
+                self.scope_costs.push(ScopeInfo { cost: 0, is_loop });
             }
             Operator::End => {
                 // close the top scope
                 self.scope_costs.pop();
             }
             _ => {}
+        }
+        Ok(())
+    }
+
+    fn update_instruction_count_instrumentation_post(
+        &mut self,
+        op: &Operator<'_>,
+        builder: &mut FunctionBuilder<'_>,
+        reachable: bool,
+    ) -> WasmResult<()> {
+        // Handle reloads after calls.
+        let is_call = match op {
+            Operator::Call { .. } | Operator::CallIndirect { .. } => true,
+            _ => false,
+        };
+        if reachable && is_call {
+            self.load_instr_count(builder);
+        }
+        Ok(())
+    }
+
+    fn update_instruction_count_instrumentation_before_func(
+        &mut self,
+        builder: &mut FunctionBuilder<'_>,
+    ) -> WasmResult<()> {
+        if self.count_instructions {
+            builder.declare_var(self.instr_count_var, ir::types::I64);
+            self.load_instr_count(builder);
+        }
+        Ok(())
+    }
+
+    fn update_instruction_count_instrumentation_after_func(
+        &mut self,
+        builder: &mut FunctionBuilder<'_>,
+        reachable: bool,
+    ) -> WasmResult<()> {
+        if reachable {
+            self.save_instr_count(builder);
         }
         Ok(())
     }
@@ -761,7 +885,41 @@ impl<'a> FuncEnvironment for FuncInfo<'a> {
         state: &FuncTranslationState,
     ) -> WasmResult<()> {
         if self.count_instructions {
-            self.update_instruction_count_instrumentation(op, builder, state.reachable())?;
+            self.update_instruction_count_instrumentation_pre(op, builder, state.reachable())?;
+        }
+        Ok(())
+    }
+
+    fn after_translate_operator(
+        &mut self,
+        op: &Operator<'_>,
+        builder: &mut FunctionBuilder<'_>,
+        state: &FuncTranslationState,
+    ) -> WasmResult<()> {
+        if self.count_instructions {
+            self.update_instruction_count_instrumentation_post(op, builder, state.reachable())?;
+        }
+        Ok(())
+    }
+
+    fn before_translate_function(
+        &mut self,
+        builder: &mut FunctionBuilder<'_>,
+        _state: &FuncTranslationState,
+    ) -> WasmResult<()> {
+        if self.count_instructions {
+            self.update_instruction_count_instrumentation_before_func(builder)?;
+        }
+        Ok(())
+    }
+
+    fn after_translate_function(
+        &mut self,
+        builder: &mut FunctionBuilder<'_>,
+        state: &FuncTranslationState,
+    ) -> WasmResult<()> {
+        if self.count_instructions {
+            self.update_instruction_count_instrumentation_after_func(builder, state.reachable())?;
         }
         Ok(())
     }

--- a/lucetc/src/runtime.rs
+++ b/lucetc/src/runtime.rs
@@ -7,6 +7,7 @@ use std::collections::HashMap;
 pub enum RuntimeFunc {
     MemSize,
     MemGrow,
+    YieldAtBoundExpiration,
 }
 
 pub struct RuntimeFuncType {
@@ -51,6 +52,21 @@ impl Runtime {
                 wasm_func_type: WasmFuncType {
                     params: vec![WasmType::I32].into_boxed_slice(),
                     returns: vec![WasmType::I32].into_boxed_slice(),
+                },
+            },
+        );
+        functions.insert(
+            RuntimeFunc::YieldAtBoundExpiration,
+            RuntimeFuncType {
+                name: "lucet_vmctx_yield_at_bound_expiration".to_owned(),
+                signature: Signature {
+                    params: vec![],
+                    returns: vec![],
+                    call_conv: target.default_call_conv,
+                },
+                wasm_func_type: WasmFuncType {
+                    params: vec![].into_boxed_slice(),
+                    returns: vec![].into_boxed_slice(),
                 },
             },
         );

--- a/lucetc/tests/wasm.rs
+++ b/lucetc/tests/wasm.rs
@@ -67,7 +67,7 @@ mod module_data {
 
         assert_eq!(mdata.import_functions().len(), 2);
         assert_eq!(mdata.export_functions().len(), 2);
-        assert_eq!(mdata.function_info().len(), 4);
+        assert_eq!(mdata.function_info().len(), 5);
         // This ordering is actually arbitrary. Cranelift hoists additional declaration modifiers
         // up to the function declaration. This means inc comes first, and main second, in
         // `exported_import.wat`.
@@ -86,7 +86,7 @@ mod module_data {
 
         assert_eq!(mdata.import_functions().len(), 2);
         assert_eq!(mdata.export_functions().len(), 1);
-        assert_eq!(mdata.function_info().len(), 4);
+        assert_eq!(mdata.function_info().len(), 5);
         assert_eq!(mdata.export_functions()[0].names, vec!["exported_inc"]);
     }
 
@@ -103,7 +103,7 @@ mod module_data {
 
         assert_eq!(mdata.import_functions().len(), 0);
         assert_eq!(mdata.export_functions().len(), 0);
-        assert_eq!(mdata.function_info().len(), 2);
+        assert_eq!(mdata.function_info().len(), 3);
     }
 
     #[test]
@@ -116,7 +116,7 @@ mod module_data {
         assert_eq!(mdata.globals_spec().len(), 0);
 
         assert_eq!(mdata.import_functions().len(), 0);
-        assert_eq!(mdata.function_info().len(), 3);
+        assert_eq!(mdata.function_info().len(), 4);
         assert_eq!(mdata.export_functions()[0].names, vec!["main"]);
     }
 
@@ -130,7 +130,7 @@ mod module_data {
         assert_eq!(mdata.globals_spec().len(), 0);
 
         assert_eq!(mdata.import_functions().len(), 0);
-        assert_eq!(mdata.function_info().len(), 3);
+        assert_eq!(mdata.function_info().len(), 4);
         assert_eq!(mdata.export_functions()[0].names, vec!["main"]);
     }
 
@@ -150,7 +150,7 @@ mod module_data {
         assert_eq!(mdata.import_functions()[0].name, "read");
         assert_eq!(mdata.import_functions()[1].module, "env");
         assert_eq!(mdata.import_functions()[1].name, "write");
-        assert_eq!(mdata.function_info().len(), 5);
+        assert_eq!(mdata.function_info().len(), 6);
         assert_eq!(mdata.function_info()[0].name, Some("host_read"));
         assert_eq!(mdata.function_info()[1].name, Some("host_write"));
         assert_eq!(mdata.function_info()[2].name, Some("guest_func__start"));
@@ -174,7 +174,7 @@ mod module_data {
         assert_eq!(mdata.import_functions().len(), 1);
         assert_eq!(mdata.import_functions()[0].module, "env");
         assert_eq!(mdata.import_functions()[0].name, "icalltarget");
-        assert_eq!(mdata.function_info().len(), 7);
+        assert_eq!(mdata.function_info().len(), 8);
         assert_eq!(mdata.export_functions()[0].names, vec!["launchpad"]);
         assert_eq!(mdata.globals_spec().len(), 0);
 
@@ -396,7 +396,7 @@ mod module_data {
 
         assert_eq!(mdata.import_functions().len(), 0);
         assert_eq!(mdata.export_functions().len(), 0);
-        assert_eq!(mdata.function_info().len(), 3);
+        assert_eq!(mdata.function_info().len(), 4);
         assert_eq!(
             mdata.function_info().get(0).unwrap().name,
             Some("func_name_0")


### PR DESCRIPTION
This modifies the instruction-counting mechanism to track an
instruction-count bound as well; and when a bound is set, the Wasm guest
will make a hostcall to yield back to the host context.

This is all placed under the `run_async()` function, so bounded-execution
yields manifest as futures that are immediately ready to continue execution.
This should give an executor main loop a chance to do other work at regular
intervals.