### PR TITLE
Add new x64 backend as lucetc option, and add to CI runs.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,14 +56,14 @@ jobs:
     steps:
       - full_ci:
           cache_target: true
-          lucetc_features: new-x64-backend
+          new_cranelift_backend: true
 
   new_backend_ci_main:
     executor: linux
     steps:
       - full_ci:
           cache_target: false
-          lucetc_features: new-x64-backend
+          new_cranelift_backend: true
 
 workflows:
   build:
@@ -110,12 +110,20 @@ commands:
       cache_target:
         type: boolean
         description: "If `true`, the target/ directory will be cached between builds"
-      lucetc_features:
-        type: string
-        description: "Non-default features with which to build Lucetc"
-        default: ""
+      new_cranelift_backend:
+        type: boolean
+        description: "If `true`, edit `lucetc/Cargo.toml` to select the new Cranelift x86-64 backend"
+        default: false
     steps:
       - checkout_recursively
+      - when:
+          condition: << parameters.new_cranelift_backend >>
+          steps:
+            - run:
+                name: "Switch lucetc to new Cranelift backend"
+                command: |
+                  set -x
+                  sed -i -e 's/default = \[\]/default = \["new-x64-backend"\]/' lucetc/Cargo.toml
       - when:
           condition: << parameters.cache_target >>
           steps:
@@ -140,7 +148,6 @@ commands:
       - build_container
       - make_in_container:
           target: test-full
-          make_vars: "LUCETC_FEATURES=<<parameters.lucetc_features>>"
       - make_in_container:
           target: test-release test-release-executables
       - ensure_sources_unchanged
@@ -250,15 +257,12 @@ commands:
     parameters:
       target:
         type: string
-      make_vars:
-        type: string
-        default: ""
     steps:
       - run:
           name: "Run Make target in Docker: << parameters.target >>"
           command: |
             set -x
-            docker run --privileged -v `pwd`:/lucet -it lucet /bin/bash -c "make -C /lucet << parameters.make_vars >> << parameters.target >>"
+            docker run --privileged -v `pwd`:/lucet -it lucet /bin/bash -c "make -C /lucet << parameters.target >>"
 
   ensure_sources_unchanged:
     description: "Make sure that previous steps did not change the source files from git"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,7 +150,12 @@ commands:
           target: test-full
       - make_in_container:
           target: test-release test-release-executables
-      - ensure_sources_unchanged
+      - when:
+          condition:
+            not:
+              << parameters.new_cranelift_backend >>
+          steps:
+            - ensure_sources_unchanged
       - when:
           condition: << parameters.cache_target >>
           steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,23 @@ jobs:
       - mac_ci:
           cache_target: false
 
+  ###################################################
+  # Linux `make test-ci` targets on new x64 backend #
+  ###################################################
+  new_backend_ci_branch:
+    executor: linux
+    steps:
+      - full_ci:
+          cache_target: true
+          lucetc_features: new-x64-backend
+
+  new_backend_ci_main:
+    executor: linux
+    steps:
+      - full_ci:
+          cache_target: false
+          lucetc_features: new-x64-backend
+
 workflows:
   build:
     jobs:
@@ -81,6 +98,10 @@ commands:
       cache_target:
         type: boolean
         description: "If `true`, the target/ directory will be cached between builds"
+      lucetc_features:
+        type: string
+        description: "Non-default features with which to build Lucetc"
+        default: ""
     steps:
       - checkout_recursively
       - when:
@@ -107,6 +128,7 @@ commands:
       - build_container
       - make_in_container:
           target: test-full
+          make_vars: "LUCETC_FEATURES=<<parameters.lucetc_features>>"
       - make_in_container:
           target: test-release test-release-executables
       - ensure_sources_unchanged
@@ -216,12 +238,15 @@ commands:
     parameters:
       target:
         type: string
+      make_vars:
+        type: string
+        default: ""
     steps:
       - run:
           name: "Run Make target in Docker: << parameters.target >>"
           command: |
             set -x
-            docker run --privileged -v `pwd`:/lucet -it lucet /bin/bash -c "make -C /lucet << parameters.target >>"
+            docker run --privileged -v `pwd`:/lucet -it lucet /bin/bash -c "make -C /lucet << parameters.make_vars >> << parameters.target >>"
 
   ensure_sources_unchanged:
     description: "Make sure that previous steps did not change the source files from git"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,6 +91,18 @@ workflows:
             branches:
               only: main
 
+      ###################################################
+      # Linux `make test-ci` targets on new x64 backend #
+      ###################################################
+      - new_backend_ci_branch:
+          filters:
+            branches:
+              ignore: main
+      - new_backend_ci_main:
+          filters:
+            branches:
+              only: main
+
 commands:
   full_ci:
     description: "Run the full CI for Lucet"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -464,7 +464,7 @@ dependencies = [
  "log",
  "smallvec",
  "thiserror",
- "wasmparser 0.68.0",
+ "wasmparser 0.69.2",
 ]
 
 [[package]]
@@ -2670,9 +2670,9 @@ checksum = "a950e6a618f62147fd514ff445b2a0b53120d382751960797f85f058c7eda9b9"
 
 [[package]]
 name = "wasmparser"
-version = "0.68.0"
+version = "0.69.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29a00e14eed9c2ecbbdbdd4fb284f49d21b6808965de24769a6379a13ec47d4c"
+checksum = "fd2dd6dadf3a723971297bcc0ec103e0aa8118bf68e23f49cb575e21621894a8"
 
 [[package]]
 name = "wast"

--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,7 @@ test-release:
 
 .PHONY: test-release-executables
 test-release-executables:
-	(cd lucetc; cargo build --release --features "$(LUCETC_FEATURES)")
-	cargo build --release -p lucet-wasi -p lucet-objdump
+	cargo build --release -p lucetc -p lucet-wasi -p lucet-objdump
 	helpers/lucet-toolchain-tests/signature.sh release
 	helpers/lucet-toolchain-tests/objdump.sh release
 

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,8 @@ test-release:
 
 .PHONY: test-release-executables
 test-release-executables:
-	cargo build --release -p lucetc -p lucet-wasi -p lucet-objdump
+	(cd lucetc; cargo build --release --features "$(LUCETC_FEATURES)")
+	cargo build --release -p lucet-wasi -p lucet-objdump
 	helpers/lucet-toolchain-tests/signature.sh release
 	helpers/lucet-toolchain-tests/objdump.sh release
 

--- a/lucet-runtime/lucet-runtime-tests/src/guest_fault.rs
+++ b/lucet-runtime/lucet-runtime-tests/src/guest_fault.rs
@@ -203,7 +203,7 @@ macro_rules! guest_fault_common_defs {
                 let native_build = Lucetc::try_from_bytes($crate::stack::generate_test_wat(
                     num_locals,
                     &["onetwothree"],
-                    Some("      (i32.add (i32.wrap_i64 (call $onetwothree)))\n"),
+                    Some("      (i64.add (call $onetwothree))\n"),
                 ))?
                 .with_bindings(Bindings::from_str(
                     r#"
@@ -586,6 +586,7 @@ macro_rules! guest_fault_tests {
                         .new_instance(module)
                         .expect("instance can be created");
 
+                    let recursion_depth = recursion_depth as i64;
                     inst.run("localpalooza", &[recursion_depth.into()])
                         .and_then(|rr| rr.returned())
                 }
@@ -619,11 +620,11 @@ macro_rules! guest_fault_tests {
                 #[test]
                 // Exhausting most stack space with the default hostcall reservation will fail,
                 // we've used far more than the limit in the guest.
-                fn expect_hostcall_reservation_stack_overflow_locals64_441() {
+                fn expect_hostcall_reservation_stack_overflow_locals64_481() {
                     expect_stack_overflow(
                         &Limits::default(),
                         stack_testcase(64 - 4).expect("generate stack_testcase 64"),
-                        461,
+                        481,
                         true,
                     );
                 }

--- a/lucet-runtime/lucet-runtime-tests/src/stack.rs
+++ b/lucet-runtime/lucet-runtime-tests/src/stack.rs
@@ -26,10 +26,17 @@ pub fn stack_testcase(num_locals: usize) -> Result<Arc<DlModule>, Error> {
 // `recursive_body` must be a wasm body taking `i32` and returning an `i32`. Empty string is
 // permissible, but `None` is allowed for caller-clarity.
 pub fn generate_test_wat(
-    num_locals: usize,
+    num_i32_locals: usize,
     hostcalls: &[&str],
     recursive_body: Option<&str>,
 ) -> String {
+    // N.B.: because the new backend stack-aligns all local slots to 8 bytes on
+    // a 64-bit platform while the old does not, and because we want this test
+    // to work for both old and new backends when making specific assertions
+    // about stack usage, we use only `i64` locals here. Tests were historically
+    // written and tuned using `i32` local counts, so we adjust here while
+    // keeping the caller's unit the same.
+    let num_locals = num_i32_locals / 2;
     assert!(num_locals > 2);
 
     let mut module = "(module\n".to_string();
@@ -41,19 +48,19 @@ pub fn generate_test_wat(
             hostcall, hostcall
         ));
     }
-    module.push_str("  (func $localpalooza (export \"localpalooza\") (param i32) (result i32)\n");
+    module.push_str("  (func $localpalooza (export \"localpalooza\") (param i64) (result i64)\n");
 
     // Declare locals:
     module.push_str("(local ");
     for _ in 0..num_locals {
-        module.push_str("i32 ");
+        module.push_str("i64 ");
     }
     module.push_str(")\n");
 
     // Use each local for the first time:
     for i in 1..num_locals {
         module.push_str(&format!(
-            "(set_local {} (i32.add (get_local {}) (i32.xor (get_local {}) (i32.const {}))))\n",
+            "(set_local {} (i64.add (get_local {}) (i64.xor (get_local {}) (i64.const {}))))\n",
             i,
             i - 1,
             i,
@@ -64,7 +71,7 @@ pub fn generate_test_wat(
     // Use each local for a second time, so they get pushed to the stack between uses:
     for i in 2..(num_locals - 1) {
         module.push_str(&format!(
-            "(set_local {} (i32.add (get_local {}) (i32.and (get_local {}) (i32.const {}))))\n",
+            "(set_local {} (i64.add (get_local {}) (i64.and (get_local {}) (i64.const {}))))\n",
             i,
             i - 1,
             i,
@@ -74,18 +81,18 @@ pub fn generate_test_wat(
 
     // Keep locals alive across a recursive call. Make as many recursive calls as the first
     // argument to the func:
-    module.push_str("(if (get_local 0)\n");
+    module.push_str("(if (i32.wrap_i64 (get_local 0))\n");
     module.push_str(&format!(
-        "  (then (set_local {} (i32.add (get_local {})\n",
+        "  (then (set_local {} (i64.add (get_local {})\n",
         num_locals - 1,
         num_locals - 2
     ));
     if let Some(body) = recursive_body {
         module.push_str(body);
     }
-    module.push_str("      (call $localpalooza (i32.sub (get_local 0) (i32.const 1))))))\n");
+    module.push_str("      (call $localpalooza (i64.sub (get_local 0) (i64.const 1))))))\n");
     module.push_str(&format!(
-        "  (else (set_local {} (i32.add (get_local {}) (get_local {})))))\n",
+        "  (else (set_local {} (i64.add (get_local {}) (get_local {})))))\n",
         num_locals - 1,
         num_locals - 2,
         num_locals - 3
@@ -114,6 +121,7 @@ macro_rules! stack_tests {
                         .new_instance(module)
                         .expect("instance can be created");
 
+                    let recursion_depth = recursion_depth as i64;
                     inst.run("localpalooza", &[recursion_depth.into()])
                         .and_then(|rr| rr.returned())
                 }
@@ -150,13 +158,13 @@ macro_rules! stack_tests {
                 }
 
                 #[test]
-                fn expect_ok_locals3_1() {
-                    expect_ok(stack_testcase(3).expect("generate stack_testcase 3"), 1);
+                fn expect_ok_locals6_1() {
+                    expect_ok(stack_testcase(6).expect("generate stack_testcase 6"), 1);
                 }
 
-                // The test with 64 locals should cause a stack overflow on the 481st recursion.  The trap
-                // table knows about all of the instructions in the function that manipulate the stack, so
-                // the catch mechanism for this is the usual one.
+                // The test with 64 locals should cause a stack overflow on the 481st recursion
+                // with the old backend. The trap table knows about all of the instructions in the function
+                // that manipulate the stack, so the catch mechanism for this is the usual one.
 
                 #[test]
                 fn expect_ok_locals64_1() {
@@ -169,7 +177,7 @@ macro_rules! stack_tests {
                 }
 
                 #[test]
-                fn expect_ok_locals64_481() {
+                fn expect_ok_locals64_480() {
                     // We use 64 local variables, but cranelift optimizes many of them into registers
                     // rather than stack space. Four of those are callee-saved, for n > 18 local
                     // variables, we actually use n + 4 stack spaces. So we use 64 spaces at 64 - 4 = 60
@@ -185,13 +193,17 @@ macro_rules! stack_tests {
                     expect_stack_overflow(
                         // Same note as `expect_ok_locals64_481`
                         stack_testcase(64 - 4).expect("generate stack_testcase 64"),
-                        481,
+                        1000,
                         true,
                     );
                 }
 
                 // 1050 locals is about 1 page (4k) on the stack - just enough for Cranelift to use probestack to grow
                 // the stack. The 31st recursion should cause a stack overflow.
+                //
+                // With the new backend, all local stackslots are 8-byte aligned, so the stack
+                // usage is roughly twice as high here. So 31 recursions will cause an overflow in
+                // all cases, but we don't assert that 30 is OK; rather, we test at 14.
 
                 #[test]
                 fn expect_ok_locals_1page_1() {
@@ -210,10 +222,10 @@ macro_rules! stack_tests {
                 }
 
                 #[test]
-                fn expect_ok_locals_1page_30() {
+                fn expect_ok_locals_1page_14() {
                     expect_ok(
                         stack_testcase(1050).expect("generate stack_testcase 1050"),
-                        30,
+                        14,
                     );
                 }
 

--- a/lucetc/Cargo.toml
+++ b/lucetc/Cargo.toml
@@ -45,3 +45,6 @@ serde_json = "1.0"
 thiserror = "1.0.4"
 raw-cpuid = "6.0.0"
 rayon = "1.5.0"
+
+[features]
+new-x64-backend = ["cranelift-codegen/x64"]

--- a/lucetc/Cargo.toml
+++ b/lucetc/Cargo.toml
@@ -47,4 +47,5 @@ raw-cpuid = "6.0.0"
 rayon = "1.5.0"
 
 [features]
+default = []
 new-x64-backend = ["cranelift-codegen/x64"]


### PR DESCRIPTION
The new x86-64 backend in Cranelift is now able to run all Lucet tests,
and has shown better performance (compile-time and run-time) than the
current backend. This PR adds a Cargo feature to lucetc to build with
the new backend, and modifies the Makefile and CircleCI config to run
tests with the new backend as well, in order to ensure that it continues
to work.