### PR TITLE
Update wasmtime dependency to include bytecodealliance/wasmtime#2576.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2491,6 +2491,7 @@ dependencies = [
 name = "wiggle"
 version = "0.22.0"
 dependencies = [
+ "bitflags",
  "thiserror",
  "tracing",
  "wiggle-macro",


### PR DESCRIPTION
This pulls in a fix to a codegen bug with the new x64 backend.