### PR TITLE
Refactor run_async to use custom Future implementation 

### DIFF
--- a/lucet-runtime/lucet-runtime-internals/src/future.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/future.rs
@@ -18,34 +18,60 @@ pub struct AsyncContext {
 
 const DEFAULT_INST_COUNT_BOUND: u64 = i64::MAX as u64;
 
+/// A value representing that the guest instance yielded because it was blocked on a future.
+///
+/// In the future, we could provide a value from the guest that can be accessed before resuming the future,
+/// such as if we wanted to do something from the host context.
 struct AsyncYielded;
+
+/// Providing the private `AsyncResume` as a resume value certifies that
+/// RunAsync upheld the invarriants necessary to safely resume the instance.
 struct AsyncResume;
+
+/// An error representing a failure of `try_block_on`
+#[doc(hidden)]
+pub enum BlockOnError {
+    NeedsAsyncContext,
+}
+
+impl From<BlockOnError> for TerminationDetails {
+    fn from(err: BlockOnError) -> Self {
+        match err {
+            BlockOnError::NeedsAsyncContext => TerminationDetails::BlockOnNeedsAsync,
+        }
+    }
+}
 
 impl Vmctx {
     /// Block on the result of an `async` computation from an instance run by `Instance::run_async`.
     ///
-    /// Lucet hostcalls are synchronous `extern "C" fn` functions called from WebAssembly. In that
-    /// context, we cannot use `.await` directly because the hostcall is not `async`. While we could
-    /// block on an executor using `futures::executor::block_on` or
-    /// `tokio::runtime::Runtime::block_on`, that has two drawbacks:
+    /// While this method is supported and part of the public API, it's easiest to define the hostcall
+    /// function itself as async. The `#[lucet_hostcall]` macro simply calls this function.
     ///
-    /// - If the Lucet instance was originally invoked from an async context, trying to block on the
-    ///   same runtime will fail if the executor cannot be nested (all executors we know of have this
-    ///   restriction).
-    ///
-    /// - The current OS thread would be blocked on the result of the computation, rather than being
-    ///   able to run other async tasks while awaiting. This means an application will need more
-    ///   threads than otherwise would be necessary.
-    ///
-    /// Instead, this block_on operator is designed to work only when called within an invocation
-    /// of [`Instance::run_async`]. When a future needs to be polled, the instance will yield and
-    /// RunAsync will return control to the async executor. When the future is ready to be polled/make progress,
-    /// it will be polled from within the guest context.
+    /// There's no performance penalty for doing so: futures that are immediately ready without waiting
+    /// don't require a context switch, just like using `.await`.
     ///
     /// Note:
     /// - This method may only be used if `Instance::run_async` was used to run the VM,
     ///   otherwise it will terminate the instance with `TerminationDetails::BlockOnNeedsAsync`.
-    pub fn block_on<R>(&self, mut f: impl Future<Output = R>) -> R {
+    #[doc(hidden)]
+    #[inline(always)]
+    pub fn block_on<R>(&self, f: impl Future<Output = R>) -> R {
+        match self.try_block_on(f) {
+            Ok(res) => res,
+            Err(err) => panic!(TerminationDetails::from(err)),
+        }
+    }
+
+    /// Block on the result of an `async` computation from an instance run by `Instance::run_async`.
+    ///
+    /// The primary reason you may want to use `try_block_on` manually is to provide a fallback
+    /// implementation for if your hostcall is called from outside of an asynchronous context.
+    ///
+    /// If `Instance::run_async` is not being used to run the VM, this function will return
+    /// `Err(BlockOnError::NeedsAsyncContext)`.
+    #[doc(hidden)]
+    pub fn try_block_on<R>(&self, mut f: impl Future<Output = R>) -> Result<R, BlockOnError> {
         // We pin the future to the stack (a requirement for being able to poll the future).
         // By pinning to the stack instead of using `Box::pin`, we avoid heap allocations for immediately-ready futures.
         //
@@ -61,9 +87,7 @@ impl Vmctx {
                 } => cx,
                 State::Running {
                     async_context: None,
-                } => {
-                    panic!(TerminationDetails::BlockOnNeedsAsync)
-                }
+                } => return Err(BlockOnError::NeedsAsyncContext),
                 _ => unreachable!("Access to vmctx implies instance is Running"),
             };
 
@@ -71,11 +95,16 @@ impl Vmctx {
             let mut cx = Context::from_waker(&cx.waker);
 
             match f.as_mut().poll(&mut cx) {
-                Poll::Ready(ret) => return ret,
+                Poll::Ready(ret) => return Ok(ret),
                 Poll::Pending => {
                     // The future is pending, so we need to yield to the async executor
                     self.yield_impl::<AsyncYielded, AsyncResume>(AsyncYielded, false, false);
 
+                    // Providing the private `AsyncResume` as a resume value certifies that
+                    // RunAsync upheld the invarriants necessary for us to avoid a borrow check.
+                    //
+                    // If we resume with any other value, the instance may have been modified, and it is
+                    // unsound to resume the instance.
                     let AsyncResume = self.take_resumed_val::<AsyncResume>();
                 }
             }
@@ -86,21 +115,36 @@ impl Vmctx {
 impl InstanceHandle {
     /// Run a WebAssembly function with arguments in the guest context at the given entrypoint.
     ///
-    /// This method is similar to `Instance::run()`, but allows the Wasm program to invoke hostcalls
-    /// that use `Vmctx::block_on` and provides the trampoline that `.await`s those futures on
-    /// behalf of the guest.
+    /// This method is similar to `Instance::run()`, but allows the Wasm program to invoke async hostcalls
+    /// and provides the trampoline that `.await`s those futures on behalf of the guest.
+    ///
+    /// To define an async hostcall, simply add an `async` modifier to your hostcall:
+    ///
+    /// ```ignore
+    /// #[lucet_hostcall]
+    /// #[no_mangle]
+    /// pub async fn hostcall_async(vmctx: &Vmctx) {
+    ///    foobar().await
+    /// }
+    /// ```
+    ///
+    /// See `[RunAsync]` for details.
     ///
     /// If `runtime_bound` is provided, it will also pause the Wasm execution and yield a future
     /// that resumes it after (approximately) that many Wasm opcodes have executed.
     ///
     /// # `Vmctx` Restrictions
     ///
-    /// This method permits the use of `Vmctx::block_on`, but disallows all other uses of `Vmctx::
+    /// This method permits the use of async hostcalls, but disallows all other uses of `Vmctx::
     /// yield_val_expecting_val` and family (`Vmctx::yield_`, `Vmctx::yield_expecting_val`,
     /// `Vmctx::yield_val`).
     pub fn run_async<'a>(&'a mut self, entrypoint: &'a str, args: &'a [Val]) -> RunAsync<'a> {
         let func = self.module.get_export_func(entrypoint);
-        self.run_async_internal(func, args)
+
+        match func {
+            Ok(func) => self.run_async_internal(func, args),
+            Err(err) => self.run_async_failed(err),
+        }
     }
 
     /// Run the module's [start function][start], if one exists.
@@ -117,41 +161,80 @@ impl InstanceHandle {
     /// runtime between async future yields (invocations of `.poll()` on the
     /// underlying generated future) if `runtime_bound` is provided. This
     /// behaves the same way as `Instance::run_async()`.
+    ///
+    /// Just like `Instance::run_start()`, hostcalls, including async hostcalls,
+    /// cannot be called from the instance start function.
+    ///
+    /// The result of the `RunAsync` future is unspecified, and should not be relied on.
     pub fn run_async_start<'a>(&'a mut self) -> RunAsync<'a> {
-        let func = if self.is_not_started() {
-            self.module
-                .get_start_func()
-                // Invariant: can only be in NotStarted state if a start function exists
-                .map(|start| start.expect("NotStarted, but no start function"))
-        } else {
-            Err(Error::StartAlreadyRun)
+        if !self.is_not_started() {
+            return self.run_async_failed(Error::StartAlreadyRun);
+        }
+
+        let func = match self.module.get_start_func() {
+            Ok(start) => start.expect("NotStarted, but no start function"), // can only be in NotStarted state if a start function exists,
+            Err(err) => return self.run_async_failed(err),
         };
 
         self.run_async_internal(func, &[])
     }
 
-    fn run_async_internal<'a>(
-        &'a mut self,
-        func: Result<FunctionHandle, Error>,
-        args: &'a [Val],
-    ) -> RunAsync<'a> {
-        let state = match func {
-            Ok(func) => RunAsyncState::Start(func, args),
-            Err(err) => RunAsyncState::Failed(Some(err)),
-        };
-
+    /// Returns a `RunAsync` that will asynchronously execute the guest instnace.
+    fn run_async_internal<'a>(&'a mut self, func: FunctionHandle, args: &'a [Val]) -> RunAsync<'a> {
         RunAsync {
             inst: self,
             inst_count_bound: DEFAULT_INST_COUNT_BOUND,
-            state,
+            state: RunAsyncState::Start(func, args),
+        }
+    }
+
+    /// Returns a `RunAsync` that will immediately fail with the given error, without executing the guest instance.
+    fn run_async_failed<'a>(&'a mut self, err: Error) -> RunAsync<'a> {
+        RunAsync {
+            inst: self,
+            inst_count_bound: DEFAULT_INST_COUNT_BOUND,
+            state: RunAsyncState::Failed(err),
         }
     }
 }
 
+/// A future implementation that enables running a guest instance which can call async hostcalls.
+///
+/// Lucet hostcalls are synchronous `extern "C" fn` functions called from WebAssembly. In that
+/// context, we cannot use `.await` directly because the hostcall is not `async`. While we could
+/// block on an executor such as `futures::executor::block_on`, that would block the OS thread,
+/// preventing us from running other async tasks while awaiting. This means an application will need more
+/// threads than otherwise would be necessary.
+///
+/// `RunAsync` allows the guest to call async hostcalls just as if the guest had called the async function
+/// and immediately `.await`ed it.
+///
+/// To define a async hostcall, simply add the async modifier to a hostcall definition:
+///
+/// ```ignore
+/// #[lucet_hostcall]
+/// #[no_mangle]
+/// pub async fn hostcall_async(vmctx: &Vmctx) {
+///    foobar().await
+/// }
+/// ```
+///
+/// Note: Async hostcalls may only be used if `Instance::run_async` was used to run the VM,
+/// otherwise it will terminate the instance with `TerminationDetails::BlockOnNeedsAsync`.
+///
+/// Behind the scenes, lucet polls the future from within the guest execution context. If the future is not immediately ready,
+/// the instance will yield and return control to the async executor. Later, when the future is ready to make progress,
+/// the async executor will return to the guest context, where lucet will poll the future to completion.
+///
+/// Just like `.await`, there is no overhead for futures that are immediately ready (such as `async { 5 }`).
+///
+/// For async hostcalls that may yield to the async executor many times, it's recommended that you use `tokio::spawn`,
+/// or the equivalent from your async executor, which will spawn the task to be run from the host execution context.
+/// This avoids the overhead of context switching into the guest execution context every time the future needs to make progress.
 pub struct RunAsync<'a> {
     inst: &'a mut InstanceHandle,
     state: RunAsyncState<'a>,
-    /// The instance count bound. Can be changed at any time, taking effect on the next guest entry
+    /// The instance count bound. Can be changed at any time, taking effect on the next entry to the guest execution context
     pub inst_count_bound: u64,
 }
 
@@ -165,9 +248,15 @@ impl<'a> RunAsync<'a> {
 
 enum RunAsyncState<'a> {
     Start(FunctionHandle, &'a [Val]),
-    Blocked,
-    Yielded,
-    Failed(Option<Error>),
+    /// The instance is currently blocked on a future.
+    ///
+    /// We keep the async yielded around - although the value of AsyncYielded isn't used for
+    /// anything, there's not much additional overhead in keeping it around, and it gives us
+    /// the option to pass data from the yield and potentially add other types of execution
+    /// in the future (such as bringing back host-context future execution).
+    BlockedOnFuture(Box<AsyncYielded>),
+    BoundExpired,
+    Failed(Error),
 }
 
 impl<'a> Future for RunAsync<'a> {
@@ -176,60 +265,59 @@ impl<'a> Future for RunAsync<'a> {
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let inst_count_bound = self.inst_count_bound;
 
-        let run_result = match self.state {
-            RunAsyncState::Failed(ref mut err) => {
-                return Poll::Ready(Err(err.take().expect("failed future polled twice")))
-            }
-            RunAsyncState::Start(func, args) => {
-                let cx = AsyncContext {
-                    waker: cx.waker().clone(),
-                };
+        let waker = cx.waker();
+        let cx = AsyncContext {
+            waker: waker.clone(),
+        };
 
+        let state = std::mem::replace(
+            &mut self.state,
+            RunAsyncState::Failed(Error::InvalidArgument("Polled an invalid future")),
+        );
+        let run_result = match state {
+            RunAsyncState::Start(func, args) => {
                 // This is the first iteration, call the entrypoint:
                 self.inst
                     .run_func(func, args, Some(cx), Some(inst_count_bound))
             }
-            RunAsyncState::Blocked => {
-                let cx = AsyncContext {
-                    waker: cx.waker().clone(),
-                };
-
-                // Resume the instance now that the future is ready
+            RunAsyncState::BlockedOnFuture(_) => {
+                // Resume the instance and poll the future
                 self.inst
                     .resume_with_val_impl(AsyncResume, Some(cx), Some(inst_count_bound))
             }
-            RunAsyncState::Yielded => self.inst.resume_bounded(inst_count_bound),
+            RunAsyncState::BoundExpired => self.inst.resume_bounded(cx, inst_count_bound),
+            RunAsyncState::Failed(err) => Err(err),
         };
 
-        match run_result {
-            Ok(InternalRunResult::Normal(RunResult::Returned(rval))) => {
-                // Finished running, return UntypedReturnValue
-                return Poll::Ready(Ok(rval));
-            }
+        let res = match run_result {
+            Ok(InternalRunResult::Normal(RunResult::Returned(rval))) => Ok(rval),
             Ok(InternalRunResult::Normal(RunResult::Yielded(yval))) => {
                 match yval.downcast::<AsyncYielded>() {
-                    Ok(_) => {
-                        self.state = RunAsyncState::Blocked;
+                    Ok(ye) => {
+                        self.state = RunAsyncState::BlockedOnFuture(ye);
+                        return Poll::Pending;
                     }
                     Err(_) => {
                         // Any other yielded value is not supported - die with an error.
-                        return Poll::Ready(Err(Error::Unsupported(
+                        Err(Error::Unsupported(
                             "cannot yield anything besides a future in Instance::run_async"
                                 .to_owned(),
-                        )));
+                        ))
                     }
                 }
             }
             Ok(InternalRunResult::BoundExpired) => {
-                self.state = RunAsyncState::Yielded;
-
-                // Yield, giving control back to the async executor
-                cx.waker().wake_by_ref();
+                // The instruction count bound expired. Yield to the async exeuctor and immediately wake.
+                //
+                // By immediately waking, the future will be scheduled to run later (similar to tokio's yield_now())
+                self.state = RunAsyncState::BoundExpired;
+                waker.wake_by_ref();
+                return Poll::Pending;
             }
-            Err(err) => return Poll::Ready(Err(err)),
-        }
+            Err(err) => Err(err),
+        };
 
-        return Poll::Pending;
+        Poll::Ready(res)
     }
 }
 

--- a/lucet-runtime/lucet-runtime-internals/src/future.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/future.rs
@@ -1,13 +1,14 @@
-use crate::error::Error;
 use crate::instance::{InstanceHandle, InternalRunResult, RunResult, State, TerminationDetails};
 use crate::module::FunctionHandle;
-use crate::val::{UntypedRetVal, Val};
+use crate::val::Val;
 use crate::vmctx::{Vmctx, VmctxInternal};
-use std::future::Future;
+use crate::{error::Error, instance::EmptyYieldVal};
 use std::pin::Pin;
+use std::sync::Arc;
 use std::task::Context;
 use std::task::Poll;
 use std::task::Waker;
+use std::{any::Any, future::Future};
 
 /// a representation of AsyncContext which can be freely cloned
 #[doc(hidden)]
@@ -19,9 +20,6 @@ pub struct AsyncContext {
 const DEFAULT_INST_COUNT_BOUND: u64 = i64::MAX as u64;
 
 /// A value representing that the guest instance yielded because it was blocked on a future.
-///
-/// In the future, we could provide a value from the guest that can be accessed before resuming the future,
-/// such as if we wanted to do something from the host context.
 struct AsyncYielded;
 
 /// Providing the private `AsyncResume` as a resume value certifies that
@@ -81,10 +79,10 @@ impl Vmctx {
 
         loop {
             // Get the AsyncContext, or die if we aren't async
-            let cx = match &self.instance().state {
+            let arc_cx = match &self.instance().state {
                 State::Running {
                     async_context: Some(cx),
-                } => cx,
+                } => cx.clone(),
                 State::Running {
                     async_context: None,
                 } => return Err(BlockOnError::NeedsAsyncContext),
@@ -92,13 +90,29 @@ impl Vmctx {
             };
 
             // build an std::task::Context
-            let mut cx = Context::from_waker(&cx.waker);
+            let mut cx = Context::from_waker(&arc_cx.waker);
 
             match f.as_mut().poll(&mut cx) {
                 Poll::Ready(ret) => return Ok(ret),
                 Poll::Pending => {
                     // The future is pending, so we need to yield to the async executor
                     self.yield_impl::<AsyncYielded, AsyncResume>(AsyncYielded, false, false);
+
+                    // Check that the async context hasn't changed (this could happen if the instance yielded)
+                    match &self.instance().state {
+                        State::Running { async_context: Some(new_cx) } => {
+                            let same_waker = Arc::ptr_eq(&arc_cx, &new_cx) || arc_cx.waker.will_wake(&new_cx.waker);
+
+                            if !same_waker {
+                                // The AsyncContext changed on us. This is because the instance is running from a new RunAsync.
+                                // This probably happened because the instance yielded and was resumed up by `resume_async`.
+                                //
+                                // Poll the future again before yielding to the executor in order to register the new waker.
+                                continue;
+                            }
+                        },
+                        _ => panic!("Lucet instance blocked on a future, but no longer running in async context. Make sure to use resume_async when resuming an async guest.")
+                    }
 
                     // Providing the private `AsyncResume` as a resume value certifies that
                     // RunAsync upheld the invarriants necessary for us to avoid a borrow check.
@@ -132,12 +146,6 @@ impl InstanceHandle {
     ///
     /// If `runtime_bound` is provided, it will also pause the Wasm execution and yield a future
     /// that resumes it after (approximately) that many Wasm opcodes have executed.
-    ///
-    /// # `Vmctx` Restrictions
-    ///
-    /// This method permits the use of async hostcalls, but disallows all other uses of `Vmctx::
-    /// yield_val_expecting_val` and family (`Vmctx::yield_`, `Vmctx::yield_expecting_val`,
-    /// `Vmctx::yield_val`).
     pub fn run_async<'a>(&'a mut self, entrypoint: &'a str, args: &'a [Val]) -> RunAsync<'a> {
         let func = self.module.get_export_func(entrypoint);
 
@@ -177,6 +185,38 @@ impl InstanceHandle {
         };
 
         self.run_async_internal(func, &[])
+    }
+
+    /// Resume async execution of an instance that has yielded, providing a value to the guest.
+    ///
+    /// If an async execution context yields from within a future, resuming with [`Instance::resume()`],
+    /// [`Instance::resume_with_val()`], may panic if the instance needs to block on an async function.
+    /// Use this function instead, which will resume the instance within an async context.
+    ///
+    /// The provided value will be dynamically typechecked against the type the guest expects to
+    /// receive, and if that check fails, this call will fail with `Error::InvalidArgument`.
+    ///
+    /// See [`Instance::resume()`], [`Instance::resume_with_val()`], and [`Instance::run_async()`].
+    ///
+    /// # Safety
+    ///
+    /// The foreign code safety caveat of [`Instance::run()`](struct.Instance.html#method.run)
+    /// applies.
+    pub fn resume_async_with_val<'a>(&'a mut self, val: impl Any + 'static + Send) -> RunAsync<'a> {
+        let val = Box::new(val) as Box<dyn Any + 'static + Send>;
+
+        RunAsync {
+            inst: self,
+            inst_count_bound: DEFAULT_INST_COUNT_BOUND,
+            state: RunAsyncState::ResumeYielded(val),
+        }
+    }
+
+    /// Resume execution of an instance that has yielded without providing a value to the guest.
+    ///
+    /// See [`Instance::resume_async_with_val()`]
+    pub fn resume_async<'a>(&'a mut self) -> RunAsync<'a> {
+        self.resume_async_with_val(EmptyYieldVal)
     }
 
     /// Returns a `RunAsync` that will asynchronously execute the guest instnace.
@@ -248,19 +288,13 @@ impl<'a> RunAsync<'a> {
 
 enum RunAsyncState<'a> {
     Start(FunctionHandle, &'a [Val]),
-    /// The instance is currently blocked on a future.
-    ///
-    /// We keep the async yielded around - although the value of AsyncYielded isn't used for
-    /// anything, there's not much additional overhead in keeping it around, and it gives us
-    /// the option to pass data from the yield and potentially add other types of execution
-    /// in the future (such as bringing back host-context future execution).
-    BlockedOnFuture(Box<AsyncYielded>),
+    ResumeYielded(Box<dyn Any + 'static + Send>),
     BoundExpired,
     Failed(Error),
 }
 
 impl<'a> Future for RunAsync<'a> {
-    type Output = Result<UntypedRetVal, Error>;
+    type Output = Result<RunResult, Error>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let inst_count_bound = self.inst_count_bound;
@@ -280,30 +314,24 @@ impl<'a> Future for RunAsync<'a> {
                 self.inst
                     .run_func(func, args, Some(cx), Some(inst_count_bound))
             }
-            RunAsyncState::BlockedOnFuture(_) => {
-                // Resume the instance and poll the future
+            RunAsyncState::ResumeYielded(val) => {
                 self.inst
-                    .resume_with_val_impl(AsyncResume, Some(cx), Some(inst_count_bound))
+                    .resume_with_val_impl(val, Some(cx), Some(inst_count_bound))
             }
             RunAsyncState::BoundExpired => self.inst.resume_bounded(cx, inst_count_bound),
             RunAsyncState::Failed(err) => Err(err),
         };
 
         let res = match run_result {
-            Ok(InternalRunResult::Normal(RunResult::Returned(rval))) => Ok(rval),
+            Ok(InternalRunResult::Normal(r @ RunResult::Returned(_))) => Ok(r),
             Ok(InternalRunResult::Normal(RunResult::Yielded(yval))) => {
                 match yval.downcast::<AsyncYielded>() {
-                    Ok(ye) => {
-                        self.state = RunAsyncState::BlockedOnFuture(ye);
+                    Ok(_) => {
+                        // When this future is polled next, we'll resume the guest instance using `AsyncResume`
+                        self.state = RunAsyncState::ResumeYielded(Box::new(AsyncResume));
                         return Poll::Pending;
                     }
-                    Err(_) => {
-                        // Any other yielded value is not supported - die with an error.
-                        Err(Error::Unsupported(
-                            "cannot yield anything besides a future in Instance::run_async"
-                                .to_owned(),
-                        ))
-                    }
+                    Err(yval) => Ok(RunResult::Yielded(yval)),
                 }
             }
             Ok(InternalRunResult::BoundExpired) => {

--- a/lucet-runtime/lucet-runtime-internals/src/instance.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/instance.rs
@@ -603,7 +603,7 @@ impl Instance {
     pub(crate) fn resume_bounded(
         &mut self,
         async_context: AsyncContext,
-        max_insn_count: u64
+        max_insn_count: u64,
     ) -> Result<InternalRunResult, Error> {
         if !self.state.is_bound_expired() {
             return Err(Error::InvalidArgument(

--- a/lucet-runtime/lucet-runtime-internals/src/instance/state.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/instance/state.rs
@@ -1,10 +1,9 @@
-use crate::instance::siginfo_ext::SiginfoExt;
 use crate::instance::{FaultDetails, TerminationDetails, YieldedVal};
 use crate::sysdeps::UContext;
+use crate::{future::AsyncContext, instance::siginfo_ext::SiginfoExt};
 use libc::{SIGBUS, SIGSEGV};
+use std::any::Any;
 use std::ffi::{CStr, CString};
-use std::task;
-use std::{any::Any, cell::RefCell};
 
 /// The representation of a Lucet instance's state machine.
 pub enum State {
@@ -26,10 +25,7 @@ pub enum State {
     Running {
         /// Indicates whether the instance is running in an async context (`Instance::run_async`)
         /// or not. Needed by `Vmctx::block_on`.
-        ///
-        /// Safety: the context must be valid for as long as the instance remains in the running state
-        /// The logic in swap_and_return guarantees this.
-        async_context: Option<RefCell<&'static mut task::Context<'static>>>,
+        async_context: Option<AsyncContext>,
     },
 
     /// The instance has faulted, potentially fatally.

--- a/lucet-runtime/lucet-runtime-internals/src/vmctx.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/vmctx.rs
@@ -13,10 +13,9 @@ use crate::instance::{
     CURRENT_INSTANCE, HOST_CTX,
 };
 use lucet_module::{FunctionHandle, GlobalValue};
-use std::any::Any;
+use std::any::{Any, TypeId};
 use std::borrow::{Borrow, BorrowMut};
 use std::cell::{Ref, RefCell, RefMut};
-use std::marker::PhantomData;
 
 /// An opaque handle to a running instance's context.
 #[derive(Debug)]
@@ -436,10 +435,9 @@ impl Vmctx {
         if is_bound_expiration {
             inst.state = State::BoundExpired;
         } else {
-            let expecting: Box<PhantomData<R>> = Box::new(PhantomData);
             inst.state = State::Yielding {
                 val: YieldedVal::new(val),
-                expecting: expecting as Box<dyn Any>,
+                expecting: TypeId::of::<R>(),
             };
         }
 

--- a/lucet-runtime/lucet-runtime-tests/guests/async_hostcall/bindings.json
+++ b/lucet-runtime/lucet-runtime-tests/guests/async_hostcall/bindings.json
@@ -2,6 +2,7 @@
     "env": {
         "hostcall_containing_block_on": "hostcall_containing_block_on",
         "hostcall_containing_yielding_block_on": "hostcall_containing_yielding_block_on",
-        "hostcall_async_containing_yielding_block_on": "hostcall_async_containing_yielding_block_on"
+        "hostcall_async_containing_yielding_block_on": "hostcall_async_containing_yielding_block_on",
+        "await_manual_future": "await_manual_future"
     }
 }

--- a/lucet-runtime/lucet-runtime-tests/guests/async_hostcall/bindings.json
+++ b/lucet-runtime/lucet-runtime-tests/guests/async_hostcall/bindings.json
@@ -1,6 +1,7 @@
 {
     "env": {
         "hostcall_containing_block_on": "hostcall_containing_block_on",
-        "hostcall_containing_yielding_block_on": "hostcall_containing_yielding_block_on"
+        "hostcall_containing_yielding_block_on": "hostcall_containing_yielding_block_on",
+        "hostcall_async_containing_yielding_block_on": "hostcall_async_containing_yielding_block_on"
     }
 }

--- a/lucet-runtime/lucet-runtime-tests/guests/async_hostcall/bindings.json
+++ b/lucet-runtime/lucet-runtime-tests/guests/async_hostcall/bindings.json
@@ -1,5 +1,6 @@
 {
     "env": {
-        "hostcall_containing_block_on": "hostcall_containing_block_on"
+        "hostcall_containing_block_on": "hostcall_containing_block_on",
+        "hostcall_containing_yielding_block_on": "hostcall_containing_yielding_block_on"
     }
 }

--- a/lucet-runtime/lucet-runtime-tests/guests/async_hostcall/hostcall_block_on.c
+++ b/lucet-runtime/lucet-runtime-tests/guests/async_hostcall/hostcall_block_on.c
@@ -22,3 +22,9 @@ int yielding()
 
     return 0;
 }
+
+int manual_future()
+{
+    await_manual_future();
+    return 0;
+}

--- a/lucet-runtime/lucet-runtime-tests/guests/async_hostcall/hostcall_block_on.c
+++ b/lucet-runtime/lucet-runtime-tests/guests/async_hostcall/hostcall_block_on.c
@@ -1,9 +1,20 @@
 #include <stddef.h>
 
 extern void hostcall_containing_block_on(int);
+extern void hostcall_containing_yielding_block_on(int);
+
 
 int main(void)
 {
     hostcall_containing_block_on(1312);
+    return 0;
+}
+
+int yielding()
+{
+    hostcall_containing_yielding_block_on(0);
+    hostcall_containing_yielding_block_on(1);
+    hostcall_containing_yielding_block_on(2);
+    hostcall_containing_yielding_block_on(3);
     return 0;
 }

--- a/lucet-runtime/lucet-runtime-tests/guests/async_hostcall/hostcall_block_on.c
+++ b/lucet-runtime/lucet-runtime-tests/guests/async_hostcall/hostcall_block_on.c
@@ -2,7 +2,7 @@
 
 extern void hostcall_containing_block_on(int);
 extern void hostcall_containing_yielding_block_on(int);
-
+extern int hostcall_async_containing_yielding_block_on(int, int);
 
 int main(void)
 {
@@ -16,5 +16,9 @@ int yielding()
     hostcall_containing_yielding_block_on(1);
     hostcall_containing_yielding_block_on(2);
     hostcall_containing_yielding_block_on(3);
+
+    int six = hostcall_async_containing_yielding_block_on(3, 6);
+    hostcall_async_containing_yielding_block_on(3, six);
+
     return 0;
 }

--- a/lucet-runtime/lucet-runtime-tests/src/async_hostcall.rs
+++ b/lucet-runtime/lucet-runtime-tests/src/async_hostcall.rs
@@ -1,25 +1,25 @@
-
-
 use std::future::Future;
-use std::task::{Waker, Context, Poll};
 use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll, Waker};
 
 enum StubFutureInner {
     NeverPolled,
     Polled(Waker),
-    Ready
+    Ready,
 }
 #[derive(Clone)]
 pub struct StubFuture(Arc<Mutex<StubFutureInner>>);
 impl StubFuture {
-    pub fn new() -> Self { StubFuture(Arc::new(Mutex::new(StubFutureInner::NeverPolled))) }
+    pub fn new() -> Self {
+        StubFuture(Arc::new(Mutex::new(StubFutureInner::NeverPolled)))
+    }
     pub fn make_ready(&self) {
         let mut inner = self.0.lock().unwrap();
         match std::mem::replace(&mut *inner, StubFutureInner::Ready) {
             StubFutureInner::Polled(waker) => {
                 waker.wake();
             }
-            _ => panic!("never polled")
+            _ => panic!("never polled"),
         }
     }
 }
@@ -39,7 +39,6 @@ impl Future for StubFuture {
         }
     }
 }
-
 
 #[macro_export]
 macro_rules! async_hostcall_tests {
@@ -232,8 +231,8 @@ macro_rules! async_hostcall_tests {
                                 "manual_future",
                                 &[]
                             ));
-                    
-                    if let Ok(RunResult::Yielded(_)) = run_res { /* expected */ } else { panic!("did not yield"); } 
+
+                    if let Ok(RunResult::Yielded(_)) = run_res { /* expected */ } else { panic!("did not yield"); }
 
                     // The loop within try_block_on polled the future returned by await_manual_future,
                     // and the waker that will be passed to poll `manuall_future` is from the old
@@ -249,8 +248,8 @@ macro_rules! async_hostcall_tests {
                     });
 
                     let run_res = futures_executor::block_on(inst.resume_async());
-                    
-                    if let Ok(RunResult::Returned(_)) = run_res { /* expected */ } else { panic!("did not return"); } 
+
+                    if let Ok(RunResult::Returned(_)) = run_res { /* expected */ } else { panic!("did not return"); }
                 }
             }
         )*

--- a/lucet-runtime/src/lib.rs
+++ b/lucet-runtime/src/lib.rs
@@ -406,6 +406,7 @@ pub mod c_api;
 pub use lucet_module::{PublicKey, TrapCode};
 pub use lucet_runtime_internals::alloc::{AllocStrategy, Limits, DEFAULT_SIGNAL_STACK_SIZE};
 pub use lucet_runtime_internals::error::Error;
+pub use lucet_runtime_internals::future::RunAsync;
 pub use lucet_runtime_internals::instance::signals::{
     install_lucet_signal_handler, remove_lucet_signal_handler,
 };

--- a/lucet-runtime/tests/instruction_counting.rs
+++ b/lucet-runtime/tests/instruction_counting.rs
@@ -187,10 +187,12 @@ fn check_instruction_count_with_periodic_yields_internal(want_start_function: bo
         }
 
         let yields = if want_start_function {
-            let future = Box::pin(inst.run_async_start(Some(1000)));
+            let mut future = Box::pin(inst.run_async_start());
+            future.bound_inst_count(1000);
             future_loop(future)
         } else {
-            let future = Box::pin(inst.run_async("test_function", &[], Some(1000)));
+            let mut future = Box::pin(inst.run_async("test_function", &[]));
+            future.bound_inst_count(1000);
             future_loop(future)
         };
 


### PR DESCRIPTION
This PR replaces the `async fn run_async_internal()` with a custom implementation of Future.

Advantages:

- Significantly less unsafe code than the original implementation of run_async (just one line, used for pinning the future)
a much sounder execution model: the future is executed from within the guest! When host execution is desired tokio::spawn or similar works from within block_on
- Support for defining async fn hostcalls without ever manually calling block_on
- Near-zero overhead for polling an immediately-ready future (only the cost of an Arc.clone()). For example, a future like `async { 5 }` would immediately resolve to 5, without requiring a yield to the host.
- Support for regular yielding from an async execution, even from within block_on
- A defined type for the future returned by `run_async`, which makes it easier for embedders to manage the execution, such as by changing the execution bound between polls.

Semantically, guests behave _exactly_ as normal async functions would, where block_on is equivalent to calling await.

It's now possible to declare an async hostcall like an async function:

```rust
#[lucet_hostcall]
#[no_mangle]
pub async fn hostcall_async(vmctx: &Vmctx) -> u32 {
    for i in 0..6 {
        YieldingFuture { times: 2 }.await
    }

    return 0;
}
```

I also a added new `try_block_on` method, which allows an embedded to define fallback behavior for when an instance is not run from within an async execution context.

Additionally, I removed the inst_count_bound argument in `run_async` and `run_async_start` (added in #612, API change is not released) and replaced it with a method and field on the RunAsync future. This is more flexible for users that need the ability to configure a CPU bound (it lets a user change the CPU bound in-between any poll) while being less verbose (and backward compatible with the old api) for users without that need.