### PR TITLE
just pass the underlying wiggle::Trap to lucet_hostcall_terminate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 
 - Added `terminate_on_heap_oom` as an option for instances. This causes instances to terminate with an OOM-specific termination value rather than returning `-1` when a `memory.grow` instruction fails.
 
+- Lucet will no longer try to translate `wiggle::Trap` to primitives for `lucet_hostcall_terminate!`. Instead, the underlying `wiggle::Trap` is passed directly to the embedder.
+
 [start-function]: https://webassembly.github.io/spec/core/syntax/modules.html#syntax-start
 
 ### 0.6.1 (2020-02-18)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1102,6 +1102,7 @@ dependencies = [
  "thiserror",
  "tracing",
  "userfaultfd",
+ "wiggle",
 ]
 
 [[package]]

--- a/lucet-runtime/lucet-runtime-internals/Cargo.toml
+++ b/lucet-runtime/lucet-runtime-internals/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 [dependencies]
 lucet-module = { path = "../../lucet-module", version = "=0.7.0-dev" }
 lucet-runtime-macros = { path = "../lucet-runtime-macros", version = "=0.7.0-dev" }
+wiggle = { path = "../../wasmtime/crates/wiggle", version = "0.22.0" }
 
 anyhow = "1.0"
 bitflags = "1.0"

--- a/lucet-wasi/src/main.rs
+++ b/lucet-wasi/src/main.rs
@@ -268,11 +268,10 @@ fn run(config: Config<'_>) {
             )) => {
                 println!("Terminated via remote kill switch (likely a timeout)");
                 std::u32::MAX
-            },
-            Err(lucet_runtime::Error::RuntimeTerminated(details)) => {
-                details.as_exitcode()
-                .expect("termination yields an exitcode")
-            },
+            }
+            Err(lucet_runtime::Error::RuntimeTerminated(details)) => details
+                .as_exitcode()
+                .expect("termination yields an exitcode"),
             Err(e) => panic!("lucet-wasi runtime error: {}", e),
         }
     };

--- a/lucet-wasi/src/main.rs
+++ b/lucet-wasi/src/main.rs
@@ -7,7 +7,7 @@ use anyhow::{format_err, Error};
 use cap_std::fs::Dir;
 use clap::Arg;
 use lucet_runtime::{self, DlModule, Limits, MmapRegion, Module, PublicKey, Region, RunResult};
-use lucet_wasi::{self, types::Exitcode, WasiCtxBuilder};
+use lucet_wasi::{self, WasiCtxBuilder};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::thread;
@@ -264,16 +264,15 @@ fn run(config: Config<'_>) {
             // none of the WASI hostcalls use yield yet, so this shouldn't happen
             Ok(RunResult::Yielded(_)) => panic!("lucet-wasi unexpectedly yielded"),
             Err(lucet_runtime::Error::RuntimeTerminated(
-                lucet_runtime::TerminationDetails::Provided(any),
-            )) => *any
-                .downcast_ref::<Exitcode>()
-                .expect("termination yields an exitcode"),
-            Err(lucet_runtime::Error::RuntimeTerminated(
                 lucet_runtime::TerminationDetails::Remote,
             )) => {
                 println!("Terminated via remote kill switch (likely a timeout)");
                 std::u32::MAX
-            }
+            },
+            Err(lucet_runtime::Error::RuntimeTerminated(details)) => {
+                details.as_exitcode()
+                .expect("termination yields an exitcode")
+            },
             Err(e) => panic!("lucet-wasi runtime error: {}", e),
         }
     };

--- a/lucet-wasi/tests/test_helpers/mod.rs
+++ b/lucet-wasi/tests/test_helpers/mod.rs
@@ -101,10 +101,8 @@ pub fn run<P: AsRef<Path>>(path: P, ctx: WasiCtx) -> Result<Exitcode, Error> {
     match inst.run("_start", &[]) {
         // normal termination implies 0 exit code
         Ok(_) => Ok(0),
-        Err(lucet_runtime::Error::RuntimeTerminated(
-            lucet_runtime::TerminationDetails::Provided(any),
-        )) => Ok(*any
-            .downcast_ref::<Exitcode>()
+        Err(lucet_runtime::Error::RuntimeTerminated(details)) => Ok(details
+            .as_exitcode()
             .expect("termination yields an exitcode")),
         Err(e) => bail!("runtime error: {}", e),
     }

--- a/lucet-wiggle/generate/src/lib.rs
+++ b/lucet-wiggle/generate/src/lib.rs
@@ -71,17 +71,7 @@ pub fn generate(
                     { #post_hook }
                     match r {
                         Ok(r) => { r },
-                        Err(wiggle::Trap::String(s)) => { lucet_runtime::lucet_hostcall_terminate!(s); }
-                        // I apologize for this load-bearing `as u32`.
-                        // Wasi uses an u32 for the proc_exit status (`lucet_wasi::Exitcode`) in
-                        // the witx. However, wasmtime::Trap exit status is an i32, so the
-                        // wiggle::Trap::I32Exit variant mirrors Wasmtime. The value passed to
-                        // lucet_hostcall_terminate gets Any-downcast back to an
-                        // `lucet_wasi::Exitcode` when inspected in Wasi embeddings.
-                        // On the upside, one day all of this code will be deleted and these sins
-                        // will be washed away.
-                        Err(wiggle::Trap::I32Exit(e)) => {
-                            lucet_runtime::lucet_hostcall_terminate!(e as u32); }
+                        Err(trap) => { lucet_runtime::lucet_hostcall_terminate!(trap); }
                     }
                 }
             }


### PR DESCRIPTION
another small one for the day: by passing `wiggle::Trap` we can ~force~ encourage users of `lucet` to handle the types that can arrive from a `TerminationDetails::Provided` by passing `wiggle::Trap` directly. then, users can be certain that the only types that can show up are their own provided types from `lucet_hostcall_terminate`, or `wiggle::Trap` via the wiggle bindings.