### PR TITLE
Don't try to install packages we don't include any more

### DIFF
--- a/helpers/install.sh
+++ b/helpers/install.sh
@@ -38,9 +38,9 @@ else
     DYLIB_SUFFIX="so"
 fi
 
-BINS="lucet-objdump lucet-validate lucet-wasi lucetc sightglass spec-test wasmonkey"
+BINS="lucet-objdump lucet-validate lucet-wasi lucetc spec-test"
 LIBS="liblucet_runtime.${DYLIB_SUFFIX}"
-DOCS="sightglass/README.md"
+DOCS=""
 BUNDLE_DOCS="README.md"
 
 if test -t 0; then


### PR DESCRIPTION
`sightglass` and `wasmonkey` are now maintained independently, so don't try to install them.