### PR TITLE
Don't use non-constant string as panic!()'s first argument

### DIFF
--- a/lucet-runtime/lucet-runtime-internals/src/future.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/future.rs
@@ -55,7 +55,7 @@ impl Vmctx {
     pub fn block_on<R>(&self, f: impl Future<Output = R>) -> R {
         match self.try_block_on(f) {
             Ok(res) => res,
-            Err(err) => panic!(TerminationDetails::from(err)),
+            Err(err) => panic!("{:?}", TerminationDetails::from(err)),
         }
     }
 

--- a/lucet-runtime/lucet-runtime-internals/src/hostcall_macros.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/hostcall_macros.rs
@@ -67,7 +67,7 @@ macro_rules! lucet_hostcall_terminate {
         lucet_hostcall_terminate!("lucet_hostcall_terminate")
     };
     ( $payload:expr ) => {
-        panic!($crate::instance::TerminationDetails::provide($payload))
+        panic!("{:?}", $crate::instance::TerminationDetails::provide($payload))
     };
     ( $payload:expr, ) => {
         lucet_hostcall_terminate!($payload)

--- a/lucet-runtime/lucet-runtime-internals/src/instance.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/instance.rs
@@ -1044,7 +1044,7 @@ impl Instance {
     pub fn grow_memory_from_hostcall(&mut self, additional_pages: u32) -> Result<u32, Error> {
         let res = self.grow_memory(additional_pages);
         if self.terminate_on_heap_oom() && res.is_err() {
-            panic!(TerminationDetails::HeapOutOfMemory)
+            panic!("{:?}", TerminationDetails::HeapOutOfMemory)
         } else {
             res
         }

--- a/lucet-runtime/lucet-runtime-internals/src/vmctx.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/vmctx.rs
@@ -171,7 +171,7 @@ impl Vmctx {
         let r = self
             .heap_view
             .try_borrow()
-            .unwrap_or_else(|_| panic!(TerminationDetails::BorrowError("heap")));
+            .unwrap_or_else(|_| panic!("{:?}", TerminationDetails::BorrowError("heap")));
         Ref::map(r, |b| b.borrow())
     }
 
@@ -186,7 +186,7 @@ impl Vmctx {
         let r = self
             .heap_view
             .try_borrow_mut()
-            .unwrap_or_else(|_| panic!(TerminationDetails::BorrowError("heap_mut")));
+            .unwrap_or_else(|_| panic!("{:?}", TerminationDetails::BorrowError("heap_mut")));
         RefMut::map(r, |b| b.borrow_mut())
     }
 
@@ -235,8 +235,8 @@ impl Vmctx {
     pub fn get_embed_ctx<T: Any>(&self) -> Ref<'_, T> {
         match self.instance().embed_ctx.try_get::<T>() {
             Some(Ok(t)) => t,
-            Some(Err(_)) => panic!(TerminationDetails::BorrowError("get_embed_ctx")),
-            None => panic!(TerminationDetails::CtxNotFound),
+            Some(Err(_)) => panic!("{:?}", TerminationDetails::BorrowError("get_embed_ctx")),
+            None => panic!("{:?}", TerminationDetails::CtxNotFound),
         }
     }
 
@@ -250,8 +250,8 @@ impl Vmctx {
     pub fn get_embed_ctx_mut<T: Any>(&self) -> RefMut<'_, T> {
         match unsafe { self.instance_mut().embed_ctx.try_get_mut::<T>() } {
             Some(Ok(t)) => t,
-            Some(Err(_)) => panic!(TerminationDetails::BorrowError("get_embed_ctx_mut")),
-            None => panic!(TerminationDetails::CtxNotFound),
+            Some(Err(_)) => panic!("{:?}", TerminationDetails::BorrowError("get_embed_ctx_mut")),
+            None => panic!("{:?}", TerminationDetails::CtxNotFound),
         }
     }
 
@@ -286,7 +286,7 @@ impl Vmctx {
         let r = self
             .globals_view
             .try_borrow()
-            .unwrap_or_else(|_| panic!(TerminationDetails::BorrowError("globals")));
+            .unwrap_or_else(|_| panic!("{:?}", TerminationDetails::BorrowError("globals")));
         Ref::map(r, |b| b.borrow())
     }
 
@@ -298,7 +298,7 @@ impl Vmctx {
         let r = self
             .globals_view
             .try_borrow_mut()
-            .unwrap_or_else(|_| panic!(TerminationDetails::BorrowError("globals_mut")));
+            .unwrap_or_else(|_| panic!("{:?}", TerminationDetails::BorrowError("globals_mut")));
         RefMut::map(r, |b| b.borrow_mut())
     }
 
@@ -451,7 +451,7 @@ impl Vmctx {
     /// `crate::future`.
     pub(crate) fn take_resumed_val<R: Any + 'static>(&self) -> R {
         self.try_take_resumed_val()
-            .unwrap_or_else(|| panic!(TerminationDetails::YieldTypeMismatch))
+            .unwrap_or_else(|| panic!("{:?}", TerminationDetails::YieldTypeMismatch))
     }
 
     /// Ensure there are no outstanding borrows to the contents of the `Vmctx`.
@@ -464,10 +464,10 @@ impl Vmctx {
     fn ensure_no_borrows(&self) {
         self.ensure_no_heap_borrows();
         if self.globals_view.try_borrow_mut().is_err() {
-            panic!(TerminationDetails::BorrowError("globals"));
+            panic!("{:?}", TerminationDetails::BorrowError("globals"));
         }
         if self.instance().embed_ctx.is_any_value_borrowed() {
-            panic!(TerminationDetails::BorrowError("embed_ctx"));
+            panic!("{:?}", TerminationDetails::BorrowError("embed_ctx"));
         }
     }
 
@@ -476,7 +476,7 @@ impl Vmctx {
     /// Terminates the instance with a `TerminationDetails::BorrowError` if a borrow exists.
     fn ensure_no_heap_borrows(&self) {
         if self.heap_view.try_borrow_mut().is_err() {
-            panic!(TerminationDetails::BorrowError("heap"));
+            panic!("{:?}", TerminationDetails::BorrowError("heap"));
         }
     }
 }

--- a/lucet-runtime/lucet-runtime-tests/src/guest_fault.rs
+++ b/lucet-runtime/lucet-runtime-tests/src/guest_fault.rs
@@ -33,7 +33,7 @@ macro_rules! guest_fault_common_defs {
             #[lucet_hostcall]
             #[no_mangle]
             pub fn raise_other_panic(_vmctx: &Vmctx) {
-                panic!(OtherPanicPayload);
+                panic!("{:?}", OtherPanicPayload);
             }
 
             pub static mut RECOVERABLE_PTR: *mut libc::c_char = std::ptr::null_mut();

--- a/lucetc/src/function.rs
+++ b/lucetc/src/function.rs
@@ -209,7 +209,7 @@ impl<'a> FuncInfo<'a> {
             let new_instr_count = builder.ins().iadd(cur_instr_count, update_const);
             builder.def_var(environ.instr_count_var, new_instr_count);
             environ.scope_costs.last_mut().unwrap().cost = 0;
-        };
+        }
 
         fn do_check(environ: &mut FuncInfo<'_>, builder: &mut FunctionBuilder<'_>) {
             let yield_block = builder.create_block();


### PR DESCRIPTION
This is no longer accepted in Rust 2021.

Also remove a column sign after a function definition (how come that did even compile?)