### PR TITLE
use witx 0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -458,7 +458,7 @@ dependencies = [
  "log",
  "smallvec",
  "thiserror",
- "wasmparser 0.73.1",
+ "wasmparser 0.75.0",
 ]
 
 [[package]]
@@ -2678,15 +2678,15 @@ checksum = "a950e6a618f62147fd514ff445b2a0b53120d382751960797f85f058c7eda9b9"
 
 [[package]]
 name = "wasmparser"
-version = "0.73.1"
+version = "0.75.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8526ab131cbc49495a483c98954913ae7b83551adacab5e294cf77992e70ee7"
+checksum = "4580b6be7329cfc3277131fc8363044990effb57b3ce93ef304ca70ad4339c64"
 
 [[package]]
 name = "wast"
-version = "22.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe1220ed7f824992b426a76125a3403d048eaf0f627918e97ade0d9b9d510d20"
+checksum = "1d04fe175c7f78214971293e7d8875673804e736092206a3a4544dbc12811c1b"
 dependencies = [
  "leb128",
 ]
@@ -2795,7 +2795,7 @@ dependencies = [
 
 [[package]]
 name = "witx"
-version = "0.8.8"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "log",

--- a/lucet-wiggle/generate/Cargo.toml
+++ b/lucet-wiggle/generate/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 [dependencies]
 wiggle-generate = { path = "../../wasmtime/crates/wiggle/generate", version = "0.23.0" }
 lucet-module = { path = "../../lucet-module", version = "0.7.0-dev" }
-witx = { path = "../../wasmtime/crates/wasi-common/WASI/tools/witx", version = "0.8.4" }
+witx = { path = "../../wasmtime/crates/wasi-common/WASI/tools/witx", version = "0.9" }
 quote = "1.0"
 proc-macro2 = "1.0"
 heck = "*"

--- a/lucet-wiggle/macro/Cargo.toml
+++ b/lucet-wiggle/macro/Cargo.toml
@@ -14,6 +14,6 @@ proc-macro = true
 [dependencies]
 lucet-wiggle-generate = { path = "../generate", version = "0.7.0-dev" }
 wiggle-generate = { path = "../../wasmtime/crates/wiggle/generate", version = "0.23.0" }
-witx = { path = "../../wasmtime/crates/wasi-common/WASI/tools/witx", version = "0.8.8" }
+witx = { path = "../../wasmtime/crates/wasi-common/WASI/tools/witx", version = "0.9" }
 syn = { version = "1.0", features = ["full"] }
 quote = "1.0"

--- a/lucetc/Cargo.toml
+++ b/lucetc/Cargo.toml
@@ -26,7 +26,7 @@ cranelift-wasm = { path = "../wasmtime/cranelift/wasm", version = "0.70.0" }
 target-lexicon = "0.11"
 lucet-module = { path = "../lucet-module", version = "=0.7.0-dev" }
 lucet-wiggle-generate = { path = "../lucet-wiggle/generate", version = "=0.7.0-dev" }
-witx = { path = "../wasmtime/crates/wasi-common/WASI/tools/witx", version = "0.8.5" }
+witx = { path = "../wasmtime/crates/wasi-common/WASI/tools/witx", version = "0.9" }
 wasmparser = "0.59.0"
 clap="2.32"
 

--- a/lucetc/tests/wasm.rs
+++ b/lucetc/tests/wasm.rs
@@ -640,7 +640,7 @@ mod validate {
         let b = stub_wasi_bindings();
 
         let witx = "
-(typename $errno (enum u8 $inval))
+(typename $errno (enum (@witx tag u8) $inval))
 (module $wasi_snapshot_preview1
   (import \"memory\" (memory))
   ;;; Read command-line argument data.
@@ -648,7 +648,7 @@ mod validate {
   (@interface func (export \"args_get\")
     (param $argv (@witx pointer (@witx pointer u8)))
     (param $argv_buf (@witx pointer u8))
-    (result $error $errno)
+    (result $error (expected (error $errno)))
   )
 )";
         let v = Validator::builder()


### PR DESCRIPTION
bumps the wasmtime submodule, which in turn pulls in witx 0.9. Fixes in lucet-wiggle and lucetc's witx validator to use the new AST.