### PR TITLE
Instruction counting: handle br_table backedges.

### DIFF
--- a/lucet-runtime/tests/instruction_counting/br_table_loop.wat
+++ b/lucet-runtime/tests/instruction_counting/br_table_loop.wat
@@ -1,0 +1,19 @@
+;; Make sure br_table backedges are handled properly.
+(module
+  (func $main (export "test_function") (local i32)
+      block
+        loop
+          local.get 0
+          i32.const 1
+          i32.add
+          local.tee 0
+          i32.const 10000
+          i32.eq
+          br_table 0 1
+        end
+      end
+  )
+  (func $instruction_count (export "instruction_count") (result i64)
+    i64.const 80000
+  )
+)

--- a/lucetc/src/function.rs
+++ b/lucetc/src/function.rs
@@ -298,7 +298,8 @@ impl<'a> FuncInfo<'a> {
                     let do_check_and_save = match op {
                         Operator::Call { .. }
                         | Operator::CallIndirect { .. }
-                        | Operator::Return => true,
+                        | Operator::Return
+                        | Operator::BrTable { .. } => true,
                         Operator::Br { relative_depth } | Operator::BrIf { relative_depth } => {
                             // only if loop backedge
                             self.scope_costs[self.scope_costs.len() - 1 - *relative_depth as usize]


### PR DESCRIPTION
Previously, we did not insert instruction count flush/check sequences on
backedges if they arose from a br_table instruction. This patch ensures
that we check the instruction count in such a case.