### PR TITLE
Make the new Cranelift x64 backend the default.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,21 +49,21 @@ jobs:
           cache_target: false
 
   ###################################################
-  # Linux `make test-ci` targets on new x64 backend #
+  # Linux `make test-ci` targets on old x64 backend #
   ###################################################
-  new_backend_ci_branch:
+  old_backend_ci_branch:
     executor: linux
     steps:
       - full_ci:
           cache_target: true
-          new_cranelift_backend: true
+          old_cranelift_backend: true
 
-  new_backend_ci_main:
+  old_backend_ci_main:
     executor: linux
     steps:
       - full_ci:
           cache_target: false
-          new_cranelift_backend: true
+          old_cranelift_backend: true
 
 workflows:
   build:
@@ -92,13 +92,13 @@ workflows:
               only: main
 
       ###################################################
-      # Linux `make test-ci` targets on new x64 backend #
+      # Linux `make test-ci` targets on old x64 backend #
       ###################################################
-      - new_backend_ci_branch:
+      - old_backend_ci_branch:
           filters:
             branches:
               ignore: main
-      - new_backend_ci_main:
+      - old_backend_ci_main:
           filters:
             branches:
               only: main
@@ -110,20 +110,20 @@ commands:
       cache_target:
         type: boolean
         description: "If `true`, the target/ directory will be cached between builds"
-      new_cranelift_backend:
+      old_cranelift_backend:
         type: boolean
-        description: "If `true`, edit `lucetc/Cargo.toml` to select the new Cranelift x86-64 backend"
+        description: "If `true`, edit `lucetc/Cargo.toml` to select the old Cranelift x86-64 backend"
         default: false
     steps:
       - checkout_recursively
       - when:
-          condition: << parameters.new_cranelift_backend >>
+          condition: << parameters.old_cranelift_backend >>
           steps:
             - run:
-                name: "Switch lucetc to new Cranelift backend"
+                name: "Switch lucetc to old Cranelift backend"
                 command: |
                   set -x
-                  sed -i -e 's/default = \[\]/default = \["new-x64-backend"\]/' lucetc/Cargo.toml
+                  sed -i -e 's/default = \[\]/default = \["old-x64-backend"\]/' lucetc/Cargo.toml
       - when:
           condition: << parameters.cache_target >>
           steps:
@@ -153,7 +153,7 @@ commands:
       - when:
           condition:
             not:
-              << parameters.new_cranelift_backend >>
+              << parameters.old_cranelift_backend >>
           steps:
             - ensure_sources_unchanged
       - when:

--- a/lucetc/Cargo.toml
+++ b/lucetc/Cargo.toml
@@ -48,4 +48,4 @@ rayon = "1.5.0"
 
 [features]
 default = []
-new-x64-backend = []
+old-x64-backend = []

--- a/lucetc/src/compiler.rs
+++ b/lucetc/src/compiler.rs
@@ -117,12 +117,12 @@ pub struct CompilerBuilder {
     target_version: TargetVersion,
 }
 
-#[cfg(not(feature = "new-x64-backend"))]
+#[cfg(feature = "old-x64-backend")]
 fn default_backend_variant() -> BackendVariant {
     BackendVariant::Legacy
 }
 
-#[cfg(feature = "new-x64-backend")]
+#[cfg(not(feature = "old-x64-backend"))]
 fn default_backend_variant() -> BackendVariant {
     BackendVariant::MachInst
 }


### PR DESCRIPTION
After sufficient testing, we're confident that the new x64 backend does
not have any correctness issues relative to the old backend; and because
it generates better code, we would like to switch the default. This PR
will cause `lucetc` to use the new backend by default. Building `lucetc`
with the `old-x64-backend` Cargo feature will swap the old backend in
again. This PR also removes the separate new-backend CI tests.