### PR TITLE
Fix wake in `UffdRegion` for invalid page access on Linux 5.7+.

### DIFF
--- a/lucet-runtime/lucet-runtime-internals/src/alloc/mod.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/alloc/mod.rs
@@ -130,11 +130,15 @@ pub struct Alloc {
     pub heap_memory_size_limit: usize,
     pub slot: Option<Slot>,
     pub region: Arc<dyn RegionInternal>,
+    // The uffd region needs to keep track of accesses to pages that were "invalid" (i.e. should
+    // signal SIGBUS when accessed) so that the pages can be reset back to the appropriate
+    // protection level.
+    #[cfg(all(target_os = "linux", feature = "uffd"))]
+    pub invalid_pages: Vec<(usize, usize)>,
 }
 
 impl Drop for Alloc {
     fn drop(&mut self) {
-        // eprintln!("Alloc::drop()");
         self.region.clone().drop_alloc(self);
     }
 }

--- a/lucet-runtime/lucet-runtime-internals/src/region/uffd.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/region/uffd.rs
@@ -69,7 +69,12 @@ fn wake_invalid_access(
             .map_err(|e| Error::InternalError(e.into()))?;
     }
 
-    inst.alloc_mut().invalid_pages.push((page_addr, page_size));
+    let pages = &mut inst.alloc_mut().invalid_pages;
+    pages.push((page_addr, page_size));
+
+    if pages.len() > 2 {
+        tracing::warn!("more than two invalid page faults were observed for a single instance");
+    }
 
     uffd.wake(page_addr as _, page_size)
         .map_err(|e| Error::InternalError(e.into()))?;


### PR DESCRIPTION
On Linux 5.7+, the kernel retries faults which is causing the uffd tests to
hang because the `UffdRegion` wakes invalid page accesses expecting the kernel
to signal `SIGBUS` rather than retry the fault.

This fix attempts to work around the recent kernel behavior by changing the
page protection to `NONE` for an invalid page access. The access is reset when
the `Alloc` is dropped or when the instance is reset.