### PR TITLE
Add install llvm to ubuntu compile instructions

### DIFF
--- a/docs/src/Compiling-on-Linux.md
+++ b/docs/src/Compiling-on-Linux.md
@@ -11,7 +11,7 @@ The following instructions only work on Ubuntu. They install a recent version of
 First, the `curl` and `cmake` packages must be installed:
 
 ```sh
-apt install curl ca-certificates cmake
+apt install curl ca-certificates cmake llvm
 ```
 
 You will need to install `wasi-sdk` as well. Note that you may need to run `dpkg` with elevated

--- a/docs/src/Compiling-on-Linux.md
+++ b/docs/src/Compiling-on-Linux.md
@@ -11,7 +11,7 @@ The following instructions only work on Ubuntu. They install a recent version of
 First, the `curl` and `cmake` packages must be installed:
 
 ```sh
-apt install curl ca-certificates cmake llvm
+apt install curl ca-certificates cmake llvm libclang
 ```
 
 You will need to install `wasi-sdk` as well. Note that you may need to run `dpkg` with elevated


### PR DESCRIPTION
Without LLVM installed compilation will fail like so:

```
Compiling csv v1.1.5
The following warnings were emitted during compilation:

warning: couldn't execute `llvm-config --prefix` (error: No such file or directory (os error 2))
warning: set the LLVM_CONFIG_PATH environment variable to a valid `llvm-config` executable

error: failed to run custom build command for `userfaultfd-sys v0.2.1`

Caused by:
  process didn't exit successfully: `/root/lucet/target/release/build/userfaultfd-sys-f24d6ed52ac9011b/build-script-build` (exit code: 101)
  --- stdout
  cargo:warning=couldn't execute `llvm-config --prefix` (error: No such file or directory (os error 2))
  cargo:warning=set the LLVM_CONFIG_PATH environment variable to a valid `llvm-config` executable

  --- stderr
  thread 'main' panicked at 'Unable to find libclang: "couldn\'t find any valid shared libraries matching: [\'libclang.so\', \'libclang-*.so\', \'libclang.so.*\'], set the `LIBCLANG_PATH` environment variable to a path where one of these files can be found (invalid: [])"', /root/.cargo/registry/src/github.com-1ecc6299db9ec823/bindgen-0.51.1/src/lib.rs:1731:31
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...
error: build failed
make: *** [Makefile:13: build] Error 101
```