### PR TITLE
Refer to BA security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,11 +1,3 @@
-## Report a security issue
+# Security Policy
 
-The Lucet project team welcomes security reports and is committed to providing prompt attention to security issues. Security issues should be reported privately via [Fastly’s security issue reporting process](https://www.fastly.com/security/report-security-issue). 
-
-See the [Lucet security overview](docs/src/Security.md) for more information Lucet's security model.
-
-## Security advisories
-
-Remediation of security vulnerabilities is prioritized. The project teams endeavors to coordinate remediation with third-party stakeholders, and is committed to transparency in the disclosure process. The Lucet team announces security issues via release notes as well as the [RustSec advisory database](https://github.com/RustSec/advisory-db) (i.e. `cargo-audit`) on a best-effort basis.
-
-Note that communications related to security issues in Fastly-maintained OSS as described here are distinct from [Fastly Security Advisories](https://www.fastly.com/security-advisories).
+Please refer to the [Bytecode Alliance security policy](https://bytecodealliance.org/security) for details on how to report security issues in Lucet, our disclosure policy, and how to receive notifications about security issues.


### PR DESCRIPTION
At a meeting last week, the Bytecode Alliance board resolved to introduce a BA security policy, and apply it to some core projects to begin with, including Lucet.