### PR TITLE
update to wasmtime main with fix for CVE-2021-32629

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,16 +386,15 @@ checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.70.0"
+version = "0.74.0"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.70.0"
+version = "0.74.0"
 dependencies = [
- "byteorder",
  "cranelift-bforest",
  "cranelift-codegen-meta",
  "cranelift-codegen-shared",
@@ -404,13 +403,12 @@ dependencies = [
  "log",
  "regalloc",
  "smallvec",
- "target-lexicon",
- "thiserror",
+ "target-lexicon 0.12.0",
 ]
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.70.0"
+version = "0.74.0"
 dependencies = [
  "cranelift-codegen-shared",
  "cranelift-entity",
@@ -418,56 +416,55 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.70.0"
+version = "0.74.0"
 
 [[package]]
 name = "cranelift-entity"
-version = "0.70.0"
+version = "0.74.0"
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.70.0"
+version = "0.74.0"
 dependencies = [
  "cranelift-codegen",
  "log",
  "smallvec",
- "target-lexicon",
+ "target-lexicon 0.12.0",
 ]
 
 [[package]]
 name = "cranelift-module"
-version = "0.70.0"
+version = "0.74.0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
  "cranelift-entity",
  "log",
- "thiserror",
 ]
 
 [[package]]
 name = "cranelift-native"
-version = "0.70.0"
+version = "0.74.0"
 dependencies = [
  "cranelift-codegen",
- "target-lexicon",
+ "target-lexicon 0.12.0",
 ]
 
 [[package]]
 name = "cranelift-object"
-version = "0.70.0"
+version = "0.74.0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
  "cranelift-module",
  "log",
- "object 0.23.0",
- "target-lexicon",
+ "object 0.24.0",
+ "target-lexicon 0.12.0",
 ]
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.70.0"
+version = "0.74.0"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -476,7 +473,7 @@ dependencies = [
  "log",
  "smallvec",
  "thiserror",
- "wasmparser 0.75.0",
+ "wasmparser 0.78.2",
 ]
 
 [[package]]
@@ -821,9 +818,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
+checksum = "0e4075386626662786ddb0ec9081e7c7eeb1ba31951f447ca780ef9f5d568189"
 dependencies = [
  "indexmap",
 ]
@@ -1171,7 +1168,7 @@ dependencies = [
  "lucetc",
  "serde",
  "serde_json",
- "target-lexicon",
+ "target-lexicon 0.11.2",
  "tempfile",
  "thiserror",
  "wabt",
@@ -1239,7 +1236,7 @@ dependencies = [
  "lucet-module",
  "lucet-wasi",
  "lucetc",
- "target-lexicon",
+ "target-lexicon 0.11.2",
  "tempfile",
  "thiserror",
 ]
@@ -1305,12 +1302,12 @@ dependencies = [
  "lucet-wiggle-generate",
  "memoffset 0.5.6",
  "minisign",
- "object 0.23.0",
+ "object 0.24.0",
  "raw-cpuid",
  "rayon",
  "serde",
  "serde_json",
- "target-lexicon",
+ "target-lexicon 0.12.0",
  "tempfile",
  "thiserror",
  "wabt",
@@ -1484,9 +1481,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9a7ab5d64814df0fe4a4b5ead45ed6c5f181ee3ff04ba344313a6c80446c5d4"
+checksum = "1a5b3dd1c072ee7963717671d1ca129f1048fda25edea6b752bfc71ac8854170"
 dependencies = [
  "crc32fast",
  "indexmap",
@@ -2288,6 +2285,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "422045212ea98508ae3d28025bc5aaa2bd4a9cdaecd442a08da2ee620ee9ea95"
 
 [[package]]
+name = "target-lexicon"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ae3b39281e4b14b8123bdbaddd472b7dfe215e444181f2f9d2443c2444f834"
+
+[[package]]
 name = "task-group"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2799,9 +2802,9 @@ checksum = "a950e6a618f62147fd514ff445b2a0b53120d382751960797f85f058c7eda9b9"
 
 [[package]]
 name = "wasmparser"
-version = "0.75.0"
+version = "0.78.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4580b6be7329cfc3277131fc8363044990effb57b3ce93ef304ca70ad4339c64"
+checksum = "52144d4c78e5cf8b055ceab8e5fa22814ce4315d6002ad32cfd914f37c12fd65"
 
 [[package]]
 name = "wast"

--- a/lucet-module/Cargo.toml
+++ b/lucet-module/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
-cranelift-entity = { path = "../wasmtime/cranelift/entity", version = "0.70.0" }
+cranelift-entity = { path = "../wasmtime/cranelift/entity", version = "0.74.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bincode = "1.1.4"

--- a/lucetc/Cargo.toml
+++ b/lucetc/Cargo.toml
@@ -16,14 +16,14 @@ path = "lucetc/main.rs"
 [dependencies]
 anyhow = "1"
 bincode = "1.1.4"
-cranelift-codegen = { path = "../wasmtime/cranelift/codegen", version = "0.70.0", features = ["x86", "x64"] }
-cranelift-entity = { path = "../wasmtime/cranelift/entity", version = "0.70.0" }
-cranelift-native = { path = "../wasmtime/cranelift/native", version = "0.70.0" }
-cranelift-frontend = { path = "../wasmtime/cranelift/frontend", version = "0.70.0" }
-cranelift-module = { path = "../wasmtime/cranelift/module", version = "0.70.0" }
-cranelift-object = { path = "../wasmtime/cranelift/object", version = "0.70.0" }
-cranelift-wasm = { path = "../wasmtime/cranelift/wasm", version = "0.70.0" }
-target-lexicon = "0.11"
+cranelift-codegen = { path = "../wasmtime/cranelift/codegen", version = "0.74.0", features = ["x86" ] }
+cranelift-entity = { path = "../wasmtime/cranelift/entity", version = "0.74.0" }
+cranelift-native = { path = "../wasmtime/cranelift/native", version = "0.74.0" }
+cranelift-frontend = { path = "../wasmtime/cranelift/frontend", version = "0.74.0" }
+cranelift-module = { path = "../wasmtime/cranelift/module", version = "0.74.0" }
+cranelift-object = { path = "../wasmtime/cranelift/object", version = "0.74.0" }
+cranelift-wasm = { path = "../wasmtime/cranelift/wasm", version = "0.74.0" }
+target-lexicon = "0.12"
 lucet-module = { path = "../lucet-module", version = "=0.7.0-dev" }
 lucet-wiggle-generate = { path = "../lucet-wiggle/generate", version = "=0.7.0-dev" }
 witx = { path = "../wasmtime/crates/wasi-common/WASI/tools/witx", version = "0.9" }
@@ -32,7 +32,7 @@ clap="2.32"
 
 log = "0.4"
 env_logger = "0.6"
-object = { version = "0.23.0", default-features = false, features = ["write"] }
+object = { version = "0.24.0", default-features = false, features = ["write"] }
 byteorder = "1.2"
 wabt = "0.9.1"
 tempfile = "3.0"

--- a/lucetc/src/sparsedata.rs
+++ b/lucetc/src/sparsedata.rs
@@ -7,37 +7,39 @@ use std::collections::HashMap;
 
 pub use lucet_module::SparseData;
 
-const PAGE_SIZE: usize = 4096;
+const PAGE_SIZE: u32 = 4096;
 
-fn linear_memory_range<'a>(di: &DataInitializer<'a>, start: usize, end: usize) -> &'a [u8] {
-    let offs = di.offset as usize;
+fn linear_memory_range<'a>(di: &DataInitializer<'a>, start: u32, end: u32) -> &'a [u8] {
+    let offs = di.offset;
     // The range of linear memory we're interested in is:
     // valid: end is past the start
     assert!(end >= start);
     // in this initializer: starts at or past the offset of this initializer,
     assert!(start >= offs);
     // and before the end of this initializer,
-    assert!(start < offs + di.data.len());
+    assert!(start < offs.checked_add(di.data.len() as u32).unwrap());
     // ends past the offset of this initializer (redundant: implied by end >= start),
     assert!(end >= offs);
     // and ends before or at the end of this initializer.
-    assert!(end <= offs + di.data.len());
-    &di.data[(start - offs)..(end - offs)]
+    assert!(end <= offs.checked_add(di.data.len() as u32).unwrap());
+    &di.data[((start - offs) as usize)..((end - offs) as usize)]
 }
 
-fn split<'a>(di: &DataInitializer<'a>) -> Vec<(usize, DataInitializer<'a>)> {
+// XXX when changing the start/end/offsets from usize to u32 i introduced a bug here! fix it on
+// monday
+fn split<'a>(di: &DataInitializer<'a>) -> Vec<(u32, DataInitializer<'a>)> {
     // Divide a data initializer for linear memory into a set of data initializers for pages, and
     // the index of the page they cover.
     // The input initializer can cover many pages. Each output initializer covers exactly one.
-    let start = di.offset as usize;
-    let end = start + di.data.len();
+    let start = di.offset;
+    let end = start + di.data.len() as u32;
     let mut offs = start;
     let mut out = Vec::new();
 
     while offs < end {
         let page = offs / PAGE_SIZE;
         let page_offs = offs % PAGE_SIZE;
-        let next = usize::min((page + 1) * PAGE_SIZE, end);
+        let next = u32::min((page + 1) * PAGE_SIZE, end);
 
         let subslice = linear_memory_range(di, offs, next);
         out.push((
@@ -57,7 +59,7 @@ pub fn owned_sparse_data_from_initializers<'a>(
     initializers: &[DataInitializer<'a>],
     heap: &HeapSpec,
 ) -> Result<OwnedSparseData, Error> {
-    let mut pagemap: HashMap<usize, Vec<u8>> = HashMap::new();
+    let mut pagemap: HashMap<u32, Vec<u8>> = HashMap::new();
 
     for initializer in initializers {
         if initializer.base.is_some() {
@@ -67,25 +69,25 @@ pub fn owned_sparse_data_from_initializers<'a>(
         }
         let chunks = split(initializer);
         for (pagenumber, chunk) in chunks {
-            if pagenumber > heap.initial_size as usize / PAGE_SIZE {
+            if pagenumber > heap.initial_size as u32 / PAGE_SIZE {
                 return Err(Error::InitData);
             }
             let base = chunk.offset as usize;
             let page = match pagemap.entry(pagenumber) {
                 Entry::Occupied(occ) => occ.into_mut(),
-                Entry::Vacant(vac) => vac.insert(vec![0; PAGE_SIZE]),
+                Entry::Vacant(vac) => vac.insert(vec![0; PAGE_SIZE as usize]),
             };
             page[base..base + chunk.data.len()].copy_from_slice(chunk.data);
-            debug_assert!(page.len() == PAGE_SIZE);
+            debug_assert!(page.len() == PAGE_SIZE as usize);
         }
     }
 
-    assert_eq!(heap.initial_size as usize % PAGE_SIZE, 0);
-    let highest_page = heap.initial_size as usize / PAGE_SIZE;
+    assert_eq!(heap.initial_size % PAGE_SIZE as u64, 0);
+    let highest_page = heap.initial_size / PAGE_SIZE as u64;
 
     let mut out = Vec::new();
     for page_ix in 0..highest_page {
-        if let Some(chunk) = pagemap.remove(&page_ix) {
+        if let Some(chunk) = pagemap.remove(&(page_ix as u32)) {
             assert!(chunk.len() == 4096);
             out.push(Some(chunk))
         } else {


### PR DESCRIPTION
Pull in the fix for CVE-2021-32629: https://github.com/bytecodealliance/wasmtime/pull/2919

As well as several other changes to cranelift-wasm & related interfaces.