### PR TITLE
Integrate VeriWasm.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,9 +46,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afddf7f520a80dbf76e6f50a35bca42a2331ef227a28b3b6dc5c2e2338d114b1"
+checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
 
 [[package]]
 name = "arbitrary"
@@ -375,6 +375,17 @@ name = "colored"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4ffc801dacf156c5854b9df4f425a626539c3a6ef7893cc0c5084a23f0b6c59"
+dependencies = [
+ "atty",
+ "lazy_static",
+ "winapi",
+]
+
+[[package]]
+name = "colored"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
 dependencies = [
  "atty",
  "lazy_static",
@@ -711,7 +722,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
 dependencies = [
  "atty",
- "humantime",
+ "humantime 1.3.0",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
+dependencies = [
+ "atty",
+ "humantime 2.1.0",
  "log",
  "regex",
  "termcolor",
@@ -743,6 +767,12 @@ name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
+name = "fixedbitset"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86d4de0081402f5e88cdac65c8dcdcc73118c1a7a465e2a05f0da05843a8ea33"
 
 [[package]]
 name = "flate2"
@@ -830,13 +860,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+checksum = "8d1dffef07351aafe6ef177e4dd2b8dcf503e6bc765dea3b0de9ed149a3db1ec"
 dependencies = [
- "cfg-if 1.0.0",
+ "cloudabi",
+ "fuchsia-cprng",
  "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
+ "winapi",
 ]
 
 [[package]]
@@ -847,7 +878,7 @@ checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "wasi 0.10.2+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -872,6 +903,28 @@ name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+
+[[package]]
+name = "goblin"
+version = "0.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84473a5302fa5094d3d9911c2f312f522f9a37462a777f195f63fae1bf7faf4d"
+dependencies = [
+ "log",
+ "plain",
+ "scroll 0.9.2",
+]
+
+[[package]]
+name = "goblin"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee05c709047abe5eb0571880d2887ac77299c5f0835f8e6b7f4d5404f8962921"
+dependencies = [
+ "log",
+ "plain",
+ "scroll 0.10.2",
+]
 
 [[package]]
 name = "half"
@@ -927,6 +980,12 @@ checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
 dependencies = [
  "quick-error",
 ]
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "indexmap"
@@ -1027,6 +1086,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libproc"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15fb50befee2d3be15b38c93ef79ba22ecbd667874bf692309ffdff179282b8d"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "log"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1047,7 +1116,7 @@ dependencies = [
  "lucet-wasi",
  "lucet-wasi-sdk",
  "lucetc",
- "nix",
+ "nix 0.17.0",
  "num_cpus",
  "rayon",
  "tempfile",
@@ -1103,7 +1172,7 @@ name = "lucet-objdump"
 version = "0.7.0-dev"
 dependencies = [
  "byteorder",
- "colored",
+ "colored 1.9.3",
  "lucet-module",
  "object 0.22.0",
 ]
@@ -1124,7 +1193,7 @@ dependencies = [
  "lucet-runtime-tests",
  "lucet-wasi-sdk",
  "lucetc",
- "nix",
+ "nix 0.17.0",
  "num-derive",
  "num-traits",
  "rayon",
@@ -1155,7 +1224,7 @@ dependencies = [
  "lucet-module",
  "lucet-runtime-macros",
  "memoffset 0.5.6",
- "nix",
+ "nix 0.17.0",
  "num-derive",
  "num-traits",
  "rand 0.7.3",
@@ -1223,7 +1292,7 @@ dependencies = [
  "lucet-wiggle",
  "lucet-wiggle-generate",
  "lucetc",
- "nix",
+ "nix 0.17.0",
  "rand 0.6.5",
  "tempfile",
  "tokio",
@@ -1246,7 +1315,7 @@ dependencies = [
  "lucet-wasi",
  "lucet-wasi-sdk",
  "lucetc",
- "nix",
+ "nix 0.17.0",
  "num_cpus",
  "progress",
  "rand 0.6.5",
@@ -1324,7 +1393,7 @@ dependencies = [
  "cranelift-native",
  "cranelift-object",
  "cranelift-wasm",
- "env_logger",
+ "env_logger 0.6.2",
  "human-size",
  "log",
  "lucet-module",
@@ -1339,6 +1408,7 @@ dependencies = [
  "target-lexicon 0.12.0",
  "tempfile",
  "thiserror",
+ "veriwasm",
  "wabt",
  "wasmparser 0.59.0",
  "witx",
@@ -1443,6 +1513,19 @@ checksum = "0debeb9fcf88823ea64d64e4a815ab1643f33127d995978e099942ce38f25238"
 
 [[package]]
 name = "nix"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "319fffb13b63c0f4ff5a4e1c97566e7e741561ff5d03bf8bbf11653454bbd70b"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if 0.1.10",
+ "libc",
+ "void",
+]
+
+[[package]]
+name = "nix"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50e4785f2c3b7589a0d0c1dd60285e1188adac4006e8abd6dd578e1567027363"
@@ -1514,6 +1597,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "numtoa"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
+
+[[package]]
+name = "object"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37fd5004feb2ce328a52b0b3d01dbf4ffff72583493900ed15f22d4111c51693"
+dependencies = [
+ "flate2",
+ "wasmparser 0.57.0",
+]
+
+[[package]]
 name = "object"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1553,6 +1652,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "ordermap"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a86ed3f5f244b372d6b1a00b72ef7f8876d0bc6a78a4c9985c53614041512063"
+
+[[package]]
 name = "paste"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1583,6 +1688,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "petgraph"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3659d1ee90221741f65dd128d9998311b0e40c5d3c23a62445938214abce4f"
+dependencies = [
+ "fixedbitset",
+ "ordermap",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1593,6 +1708,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plotters"
@@ -1669,6 +1790,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-maps"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f7e49bf46401bf141cb9d2bba151efcfa85f2956e51c6794fe07a3803ec6004"
+dependencies = [
+ "anyhow",
+ "libc",
+ "libproc",
+ "mach",
+ "winapi",
+]
+
+[[package]]
 name = "progress"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1735,7 +1869,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom 0.1.16",
+ "getrandom 0.1.3",
  "libc",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
@@ -1805,7 +1939,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom 0.1.16",
+ "getrandom 0.1.3",
 ]
 
 [[package]]
@@ -1950,6 +2084,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_termios"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8440d8acb4fd3d277125b4bd01a6f38aee8d814b3b5fc09b3f2b825d37d3fe8f"
+dependencies = [
+ "redox_syscall",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2091,6 +2234,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
+name = "scroll"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f84d114ef17fd144153d608fba7c446b0145d038985e7a8cc5d08bb0ce20383"
+dependencies = [
+ "rustc_version 0.2.3",
+ "scroll_derive 0.9.5",
+]
+
+[[package]]
+name = "scroll"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fda28d4b4830b807a8b43f7b0e6b5df875311b3e7621d84577188c175b6ec1ec"
+dependencies = [
+ "scroll_derive 0.10.5",
+]
+
+[[package]]
+name = "scroll_derive"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1aa96c45e7f5a91cb7fabe7b279f02fea7126239fc40b732316e8b6a2d0fcb"
+dependencies = [
+ "proc-macro2 0.4.30",
+ "quote 0.6.13",
+ "syn 0.15.44",
+]
+
+[[package]]
+name = "scroll_derive"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaaae8f38bb311444cfb7f1979af0bc9240d95795f75f9ceddf6a59b79ceffa0"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.9",
+ "syn 1.0.67",
+]
+
+[[package]]
 name = "scrypt"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2222,6 +2406,12 @@ name = "shlex"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
+
+[[package]]
+name = "siphasher"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbce6d4507c7e4a3962091436e56e95290cb71fa302d0d270e32130b75fbff27"
 
 [[package]]
 name = "slab"
@@ -2368,6 +2558,27 @@ checksum = "86ca8ced750734db02076f44132d802af0b33b09942331f4459dde8636fd2406"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "termion"
+version = "1.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "077185e2eac69c3f8379a4298e1e07cd36beb962290d4a51199acf0fdc10607e"
+dependencies = [
+ "libc",
+ "numtoa",
+ "redox_syscall",
+ "redox_termios",
+]
+
+[[package]]
+name = "termios"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5d9cf598a6d7ce700a4e6a9199da127e6819a61e64b68609683cc9a01b5683a"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -2585,7 +2796,7 @@ checksum = "4865e0b536ef0eae67cd7576075ac7212fe23a9e190dbbcabc2e7895fa379a9a"
 dependencies = [
  "bitflags",
  "libc",
- "nix",
+ "nix 0.17.0",
  "thiserror",
  "userfaultfd-sys",
 ]
@@ -2615,6 +2826,26 @@ name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
+name = "veriwasm"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c68a82d0e26aabc716e29389706ac1f07516c9c87e7dfc0e4c40e21a3585e6c3"
+dependencies = [
+ "byteorder",
+ "clap",
+ "colored 2.0.0",
+ "env_logger 0.8.4",
+ "goblin 0.4.1",
+ "log",
+ "object 0.21.1",
+ "petgraph",
+ "serde_json",
+ "yaxpeax-arch",
+ "yaxpeax-core",
+ "yaxpeax-x86",
+]
 
 [[package]]
 name = "version_check"
@@ -2676,12 +2907,6 @@ dependencies = [
  "winapi",
  "winapi-util",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
@@ -3127,4 +3352,101 @@ dependencies = [
  "log",
  "thiserror",
  "wast",
+]
+
+[[package]]
+name = "yaxpeax-arch"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4d184a208255bb62f2d55c3875ee3fe459f2b8d9190b8427986b91d11ced7f"
+dependencies = [
+ "num-traits",
+ "serde",
+ "serde_derive",
+ "termion",
+]
+
+[[package]]
+name = "yaxpeax-arm"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd9ff5d85124b77a3c251585a72ab7db55af2ef2b178f43501c975005a21ad"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "yaxpeax-arch",
+]
+
+[[package]]
+name = "yaxpeax-core"
+version = "0.0.2-vw-tweaks"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3af606703f3d2476dbeefcc3031cc1fa12d6909a12537757976d10e7cf7ca11"
+dependencies = [
+ "goblin 0.0.20",
+ "nix 0.12.1",
+ "num-traits",
+ "petgraph",
+ "proc-maps",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "siphasher",
+ "smallvec",
+ "termion",
+ "termios",
+ "tracing",
+ "yaxpeax-arch",
+ "yaxpeax-arm",
+ "yaxpeax-msp430",
+ "yaxpeax-pic17",
+ "yaxpeax-pic18",
+ "yaxpeax-x86",
+]
+
+[[package]]
+name = "yaxpeax-msp430"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d556fe4705aaadc1e14375550e6f344976958f930580adf32388c150cb8e1f24"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "termion",
+ "yaxpeax-arch",
+]
+
+[[package]]
+name = "yaxpeax-pic17"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb949b4c5d7afb8210cbaa3d1f2153d12bcac9dd81167dc6275f9f0fb243fb98"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "termion",
+ "yaxpeax-arch",
+]
+
+[[package]]
+name = "yaxpeax-pic18"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f5a722e1de4671c1cfe46f54ebe21fe3233823e62d8cc33d698f50b5fcf2e19"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "yaxpeax-arch",
+]
+
+[[package]]
+name = "yaxpeax-x86"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d31af457e440548b402c8a716d15b7bce1e6ce54da4382e592052539a0c61a8"
+dependencies = [
+ "num-traits",
+ "serde",
+ "serde_derive",
+ "yaxpeax-arch",
 ]

--- a/lucetc/Cargo.toml
+++ b/lucetc/Cargo.toml
@@ -28,7 +28,7 @@ lucet-module = { path = "../lucet-module", version = "=0.7.0-dev" }
 lucet-wiggle-generate = { path = "../lucet-wiggle/generate", version = "=0.7.0-dev" }
 witx = "0.9.1"
 wasmparser = "0.59.0"
-clap="2.32"
+clap = "2.32"
 
 log = "0.4"
 env_logger = "0.6"
@@ -45,6 +45,7 @@ serde_json = "1.0"
 thiserror = "1.0.4"
 raw-cpuid = "9.0.0"
 rayon = "1.5.0"
+veriwasm = "0.1.1"
 
 [features]
 default = []

--- a/lucetc/lucetc/main.rs
+++ b/lucetc/lucetc/main.rs
@@ -158,6 +158,10 @@ pub fn run(opts: &Options) -> Result<(), Error> {
         c.count_instructions(true);
     }
 
+    if opts.veriwasm {
+        c.veriwasm(true);
+    }
+
     c.translate_wat(opts.translate_wat);
 
     match opts.codegen {

--- a/lucetc/lucetc/options.rs
+++ b/lucetc/lucetc/options.rs
@@ -127,6 +127,7 @@ pub struct Options {
     pub target_version: TargetVersion,
     pub translate_wat: bool,
     pub version_info: Option<VersionInfo>,
+    pub veriwasm: bool,
 }
 
 impl Options {
@@ -232,6 +233,7 @@ impl Options {
         let version_info = m
             .value_of("version_info")
             .map(|v| VersionInfo::from_str(v).expect("parsing version-info"));
+        let veriwasm = m.is_present("veriwasm");
 
         let error_style = match m.value_of("error_style") {
             None => ErrorStyle::default(),
@@ -265,6 +267,7 @@ impl Options {
             target_version,
             translate_wat,
             version_info,
+            veriwasm,
         })
     }
     pub fn get() -> Result<Self, Error> {
@@ -484,6 +487,12 @@ SSE3 but not AVX:
                     .long("--count-instructions")
                     .takes_value(false)
                     .help("Instrument the produced binary to count the number of wasm operations the translated program executes")
+            )
+            .arg(
+                Arg::with_name("veriwasm")
+                    .long("--veriwasm")
+                    .takes_value(false)
+                    .help("Run VeriWasm's heap-access verifier on the produced binary")
             )
             .arg(
                 Arg::with_name("error_style")

--- a/lucetc/src/error.rs
+++ b/lucetc/src/error.rs
@@ -20,6 +20,8 @@ pub enum Error {
     LucetModule(#[from] LucetModuleError),
     #[error("Lucet validation errors: {0:?}")]
     LucetValidation(Vec<ValidationError>),
+    #[error("VeriWasm error in {0}")]
+    VeriWasm(String),
     #[error("I/O: {0}")]
     IOError(#[from] std::io::Error),
     #[error("Converting to Wasm signature: {0}")]

--- a/lucetc/src/lib.rs
+++ b/lucetc/src/lib.rs
@@ -121,6 +121,8 @@ pub trait LucetcOpts {
     fn with_count_instructions(self, enable_count: bool) -> Self;
     fn canonicalize_nans(&mut self, enable_canonicalize_nans: bool);
     fn with_canonicalize_nans(self, enable_canonicalize_nans: bool) -> Self;
+    fn veriwasm(&mut self, veriwasm: bool);
+    fn with_veriwasm(self, veriwasm: bool) -> Self;
     fn translate_wat(&mut self, enable_translate_wat: bool);
     fn with_translate_wat(self, enable_translate_wat: bool) -> Self;
 }
@@ -310,6 +312,15 @@ impl<T: AsLucetc> LucetcOpts for T {
 
     fn with_translate_wat(mut self, enable_translate_wat: bool) -> Self {
         self.translate_wat(enable_translate_wat);
+        self
+    }
+
+    fn veriwasm(&mut self, veriwasm: bool) {
+        self.as_lucetc().builder.veriwasm(veriwasm);
+    }
+
+    fn with_veriwasm(mut self, veriwasm: bool) -> Self {
+        self.veriwasm(veriwasm);
         self
     }
 }

--- a/lucetc/tests/wasm.rs
+++ b/lucetc/tests/wasm.rs
@@ -61,6 +61,7 @@ mod module_data {
             None,
             false,
             None,
+            false,
         )
         .expect("compiling exported_import");
         let mdata = c.module_data().unwrap();
@@ -557,6 +558,7 @@ mod validate {
             Some(v),
             false,
             None,
+            false,
         )
         .expect("compile");
         let _obj = c.object_file().expect("codegen");
@@ -736,5 +738,15 @@ mod validate {
             }
             e => panic!("expected FunctionTranslation error, got {:?}", e),
         }
+    }
+
+    #[test]
+    fn veriwasm() {
+        let m = load_wat_module("fibonacci");
+        let b = super::test_bindings();
+        let mut builder = Compiler::builder();
+        builder.veriwasm(true);
+        let c = builder.create(&m, &b).expect("creating compiler");
+        let _ = c.object_file().expect("compiling with VeriWasm enabled");
     }
 }


### PR DESCRIPTION
This commit brings in VeriWasm, a static analysis tool that
independently verifies the sound heap-sandboxing and other properties of
machine code generated by Cranelift as used by Lucet. It adds an option
`--veriwasm` to the compiler `lucetc` so that, in concert with changes
recently made to VeriWasm and Cranelift, we can verify generated code in
memory, right after we generate it, and with reasonable overhead
(measured at ~30% additional compile time for some simple test cases).

This PR currently refers to my fork of VeriWasm as a submodule; the fork
has additional work on top of upstream that was reviewed internally by
@iximeow. Once we work out where this should live permanently, we can
update the submodule location, but this should be good enough for review.