### PR TITLE
remove wasmtime submodule, depend on latest wasmtime packages from crates.io

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "wasmtime"]
-	path = wasmtime
-	url = https://github.com/bytecodealliance/wasmtime
 [submodule "lucet-spectest/spec"]
 	path = lucet-spectest/spec
 	url = https://github.com/webassembly/spec

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,21 +147,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bit-set"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e11e16035ea35e4e5997b393eacbf6f63983188f7a2ad25bfb13465f5ad59de"
-dependencies = [
- "bit-vec",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
-
-[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -420,14 +405,18 @@ checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.74.0"
+version = "0.75.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3f8dd4f920a422c96c53fb6a91cc7932b865fdb60066ae9df7c329342d303f"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.74.0"
+version = "0.75.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe85f9a8dbf3c9dfa47ecb89828a7dc17c0b62015b84b5505fd4beba61c542c"
 dependencies = [
  "cranelift-bforest",
  "cranelift-codegen-meta",
@@ -443,7 +432,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.74.0"
+version = "0.75.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12bc4be68da214a56bf9beea4212eb3b9eac16ca9f0b47762f907c4cd4684073"
 dependencies = [
  "cranelift-codegen-shared",
  "cranelift-entity",
@@ -451,21 +442,27 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.74.0"
+version = "0.75.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c87b69923825cfbc3efde17d929a68cd5b50a4016b2bd0eb8c3933cc5bd8cd"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.74.0"
+version = "0.75.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe683e7ec6e627facf44b2eab4b263507be4e7ef7ea06eb8cee5283d9b45370e"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.74.0"
+version = "0.75.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5da80025ca214f0118273f8b94c4790add3b776f0dc97afba6b711757497743b"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -475,7 +472,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.74.0"
+version = "0.75.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d69b61b0eef8776d148a88523b9f0805d786a1b5d9dba0adcd52dbc033680ff"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -485,7 +484,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.74.0"
+version = "0.75.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1c0e8c56f9a63f352a64aaa9c9eef7c205008b03593af7b128a3fbc46eae7e9"
 dependencies = [
  "cranelift-codegen",
  "target-lexicon 0.12.0",
@@ -493,7 +494,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-object"
-version = "0.74.0"
+version = "0.75.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5b59dedeaaeaa5baea1dd0fed3d596f67d39f3b8bf9469b197335035519d174"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -505,7 +508,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.74.0"
+version = "0.75.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d10ddafc5f1230d2190eb55018fcdecfcce728c9c2b975f2690ef13691d18eb5"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -752,12 +757,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
 name = "fs-set-times"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -926,7 +925,7 @@ version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
 dependencies = [
- "quick-error 1.2.3",
+ "quick-error",
 ]
 
 [[package]]
@@ -1285,7 +1284,6 @@ dependencies = [
  "lucetc",
  "tempfile",
  "wiggle",
- "wiggle-test",
 ]
 
 [[package]]
@@ -1680,26 +1678,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proptest"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0d9cc07f18492d879586c92b485def06bc850da3118075cd45d50e9c95b0e5"
-dependencies = [
- "bit-set",
- "bitflags",
- "byteorder",
- "lazy_static",
- "num-traits",
- "quick-error 2.0.1",
- "rand 0.8.3",
- "rand_chacha 0.3.0",
- "rand_xorshift 0.3.0",
- "regex-syntax",
- "rusty-fork",
- "tempfile",
-]
-
-[[package]]
 name = "psm"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1713,12 +1691,6 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-
-[[package]]
-name = "quick-error"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
@@ -1753,7 +1725,7 @@ dependencies = [
  "rand_jitter",
  "rand_os",
  "rand_pcg",
- "rand_xorshift 0.1.1",
+ "rand_xorshift",
  "winapi",
 ]
 
@@ -1926,15 +1898,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_xorshift"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
-dependencies = [
- "rand_core 0.6.2",
-]
-
-[[package]]
 name = "raw-cpuid"
 version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2095,18 +2058,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
 dependencies = [
  "semver 0.11.0",
-]
-
-[[package]]
-name = "rusty-fork"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
-dependencies = [
- "fnv",
- "quick-error 1.2.3",
- "tempfile",
- "wait-timeout",
 ]
 
 [[package]]
@@ -2740,7 +2691,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasi-cap-std-sync"
-version = "0.27.0"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54ed414ed6ff3b95653ea07b237cf03c513015d94169aac159755e05a2eaa80f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2761,7 +2714,9 @@ dependencies = [
 
 [[package]]
 name = "wasi-common"
-version = "0.27.0"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c67b1e49ae6d9bcab37a6f13594aed98d8ab8f5c2117b3bed543d8019688733"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -2776,7 +2731,9 @@ dependencies = [
 
 [[package]]
 name = "wasi-tokio"
-version = "0.27.0"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dfdfbdc16c6a9fd99655f0990b5a2c1d14fca20b3f6018c2d81d4bdde25a1ba"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -2892,7 +2849,9 @@ checksum = "52144d4c78e5cf8b055ceab8e5fa22814ce4315d6002ad32cfd914f37c12fd65"
 
 [[package]]
 name = "wasmtime"
-version = "0.27.0"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56828b11cd743a0e9b4207d1c7a8c1a66cb32d14601df10422072802a6aee86c"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -2920,7 +2879,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "0.27.0"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "519fa80abe29dc46fc43177cbe391e38c8613c59229c8d1d90d7f226c3c7cede"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -2933,7 +2894,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-debug"
-version = "0.27.0"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ddf6e9bca2f3bc1dd499db2a93d35c735176cff0de7daacdc18c3794f7082e0"
 dependencies = [
  "anyhow",
  "gimli",
@@ -2947,7 +2910,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "0.27.0"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a991635b1cf1d1336fbea7a5f2c0e1dafaa54cb21c632d8414885278fa5d1b1"
 dependencies = [
  "cfg-if 1.0.0",
  "cranelift-codegen",
@@ -2964,7 +2929,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit"
-version = "0.27.0"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f33a0ae79b7c8d050156b22e10fdc49dfb09cc482c251d12bf10e8a833498fb"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -2994,7 +2961,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-obj"
-version = "0.27.0"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a879f03d416615f322dcb3aa5cb4cbc47b64b12be6aa235a64ab63a4281d50a"
 dependencies = [
  "anyhow",
  "more-asserts",
@@ -3006,7 +2975,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-profiling"
-version = "0.27.0"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171ae3107e8502667b16d336a1dd03e370aa6630a1ce26559aba572ade1031d1"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
@@ -3020,7 +2991,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-runtime"
-version = "0.27.0"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0404e10f8b07f940be42aa4b8785b4ab42e96d7167ccc92e35d36eee040309c2"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -3061,7 +3034,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "0.27.0"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79ca01f1388a549eb3eaa221a072c3cfd3e383618ec6b423e82f2734ee28dd40"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3075,7 +3050,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "0.27.0"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "544fd41029c33b179656ab1674cd813db7cd473f38f1976ae6e08effb46dd269"
 dependencies = [
  "anyhow",
  "heck",
@@ -3088,21 +3065,15 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "0.27.0"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e31ae77a274c9800e6f1342fa4a6dde5e2d72eb9d9b2e0418781be6efc35b58"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
  "syn 1.0.67",
  "wiggle-generate",
  "witx",
-]
-
-[[package]]
-name = "wiggle-test"
-version = "0.21.0"
-dependencies = [
- "proptest",
- "wiggle",
 ]
 
 [[package]]
@@ -3149,6 +3120,8 @@ dependencies = [
 [[package]]
 name = "witx"
 version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df4a58e03db38d5e0762afc768ac9abacf826de59602b0a1dfa1b9099f03388e"
 dependencies = [
  "anyhow",
  "log",

--- a/lucet-module/Cargo.toml
+++ b/lucet-module/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
-cranelift-entity = { path = "../wasmtime/cranelift/entity", version = "0.74.0" }
+cranelift-entity = "0.75.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bincode = "1.1.4"

--- a/lucet-runtime/lucet-runtime-internals/Cargo.toml
+++ b/lucet-runtime/lucet-runtime-internals/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 lucet-module = { path = "../../lucet-module", version = "=0.7.0-dev" }
 lucet-runtime-macros = { path = "../lucet-runtime-macros", version = "=0.7.0-dev" }
-wiggle = { path = "../../wasmtime/crates/wiggle", version = "0.27.0", default-features = false }
+wiggle = { version = "0.28.0", default-features = false }
 
 anyhow = "1.0"
 bitflags = "1.0"

--- a/lucet-wasi-fuzz/Cargo.toml
+++ b/lucet-wasi-fuzz/Cargo.toml
@@ -28,4 +28,4 @@ task-group = "0.2"
 tempfile = "3.0"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 wait-timeout = "0.2"
-wasi-common = { path = "../wasmtime/crates/wasi-common" }
+wasi-common = "0.28.0"

--- a/lucet-wasi/Cargo.toml
+++ b/lucet-wasi/Cargo.toml
@@ -23,9 +23,9 @@ lucet-wiggle-generate = { path = "../lucet-wiggle/generate", version = "=0.7.0-d
 libc = "0.2.65"
 nix = "0.17"
 rand = "0.6"
-wasi-common = { path = "../wasmtime/crates/wasi-common", version = "0.27.0", default-features = false,  features = ["wiggle_metadata"] }
-wasi-tokio = { path = "../wasmtime/crates/wasi-common/tokio", version = "0.27.0"}
-wiggle = { path = "../wasmtime/crates/wiggle", version = "0.27.0" }
+wasi-common = { version = "0.28.0", default-features = false,  features = ["wiggle_metadata"] }
+wasi-tokio = "0.28.0"
+wiggle = "0.28.0"
 tracing = "0.1.19"
 tracing-subscriber = "0.2.0"
 cap-std = "0.13"

--- a/lucet-wiggle/Cargo.toml
+++ b/lucet-wiggle/Cargo.toml
@@ -14,10 +14,9 @@ edition = "2018"
 lucet-wiggle-macro = { path = "./macro", version = "0.7.0-dev" }
 lucet-wiggle-generate = { path = "./generate", version = "0.7.0-dev" }
 lucet-runtime = { path = "../lucet-runtime", version = "0.7.0-dev" }
-wiggle =  { path = "../wasmtime/crates/wiggle", version = "0.27.0", default-features = false }
+wiggle =  { version = "0.28.0", default-features = false }
 
 [dev-dependencies]
-wiggle-test = { path = "../wasmtime/crates/wiggle/test-helpers" }
 tempfile = "3.1"
 lucet-wasi-sdk = { path = "../lucet-wasi-sdk", version = "0.7.0-dev" }
 lucetc = { path = "../lucetc", version = "0.7.0-dev" }

--- a/lucet-wiggle/generate/Cargo.toml
+++ b/lucet-wiggle/generate/Cargo.toml
@@ -9,9 +9,9 @@ authors = ["Lucet team <lucet@fastly.com>"]
 edition = "2018"
 
 [dependencies]
-wiggle-generate = { path = "../../wasmtime/crates/wiggle/generate", version = "0.27.0" }
+wiggle-generate = "0.28.0"
 lucet-module = { path = "../../lucet-module", version = "0.7.0-dev" }
-witx = { path = "../../wasmtime/crates/wasi-common/WASI/tools/witx", version = "0.9" }
+witx = "0.9.0"
 quote = "1.0"
 proc-macro2 = "1.0"
 heck = "*"

--- a/lucet-wiggle/macro/Cargo.toml
+++ b/lucet-wiggle/macro/Cargo.toml
@@ -13,5 +13,5 @@ proc-macro = true
 
 [dependencies]
 lucet-wiggle-generate = { path = "../generate", version = "0.7.0-dev" }
-witx = { path = "../../wasmtime/crates/wasi-common/WASI/tools/witx", version = "0.9" }
+witx = "0.9.0"
 syn = { version = "1.0", features = ["full"] }

--- a/lucetc/Cargo.toml
+++ b/lucetc/Cargo.toml
@@ -16,23 +16,23 @@ path = "lucetc/main.rs"
 [dependencies]
 anyhow = "1"
 bincode = "1.1.4"
-cranelift-codegen = { path = "../wasmtime/cranelift/codegen", version = "0.74.0", features = ["x86" ] }
-cranelift-entity = { path = "../wasmtime/cranelift/entity", version = "0.74.0" }
-cranelift-native = { path = "../wasmtime/cranelift/native", version = "0.74.0" }
-cranelift-frontend = { path = "../wasmtime/cranelift/frontend", version = "0.74.0" }
-cranelift-module = { path = "../wasmtime/cranelift/module", version = "0.74.0" }
-cranelift-object = { path = "../wasmtime/cranelift/object", version = "0.74.0" }
-cranelift-wasm = { path = "../wasmtime/cranelift/wasm", version = "0.74.0" }
+cranelift-codegen = { version = "0.75.0", features = ["x86" ] }
+cranelift-entity = "0.75.0"
+cranelift-native = "0.75.0"
+cranelift-frontend = "0.75.0"
+cranelift-module =  "0.75.0"
+cranelift-object =  "0.75.0"
+cranelift-wasm = "0.75.0"
 target-lexicon = "0.12"
 lucet-module = { path = "../lucet-module", version = "=0.7.0-dev" }
 lucet-wiggle-generate = { path = "../lucet-wiggle/generate", version = "=0.7.0-dev" }
-witx = { path = "../wasmtime/crates/wasi-common/WASI/tools/witx", version = "0.9" }
+witx = "0.9.0"
 wasmparser = "0.59.0"
 clap="2.32"
 
 log = "0.4"
 env_logger = "0.6"
-object = { version = "0.25.1", default-features = false, features = ["write"] }
+object = { version = "0.25.2", default-features = false, features = ["write"] }
 byteorder = "1.2"
 wabt = "0.9.1"
 tempfile = "3.0"


### PR DESCRIPTION
Lucet is nearing EOL so we no longer need to track changes between releases in wasmtime. In case we do, we will use `[patch]` in Cargo.toml for a path or git dependency.

Having path dependencies in Lucet is causing integration headaches downstream, because you cannot `[patch]` over a path!

This PR removes the wasmtime submodule, and changes all deps to the latest crates.io release: cranelift-* is at 0.75.0, and the rest are at 0.28.0.
