### PR TITLE
Update witx dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3015,9 +3015,9 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "33.0.0"
+version = "35.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d04fe175c7f78214971293e7d8875673804e736092206a3a4544dbc12811c1b"
+checksum = "2ef140f1b49946586078353a453a1d28ba90adfc54dde75710bc1931de204d68"
 dependencies = [
  "leb128",
 ]
@@ -3119,9 +3119,9 @@ dependencies = [
 
 [[package]]
 name = "witx"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df4a58e03db38d5e0762afc768ac9abacf826de59602b0a1dfa1b9099f03388e"
+checksum = "e366f27a5cabcddb2706a78296a40b8fcc451e1a6aba2fc1d94b4a01bdaaef4b"
 dependencies = [
  "anyhow",
  "log",

--- a/lucet-wiggle/generate/Cargo.toml
+++ b/lucet-wiggle/generate/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 [dependencies]
 wiggle-generate = "0.28.0"
 lucet-module = { path = "../../lucet-module", version = "0.7.0-dev" }
-witx = "0.9.0"
+witx = "0.9.1"
 quote = "1.0"
 proc-macro2 = "1.0"
 heck = "*"

--- a/lucet-wiggle/macro/Cargo.toml
+++ b/lucet-wiggle/macro/Cargo.toml
@@ -13,5 +13,5 @@ proc-macro = true
 
 [dependencies]
 lucet-wiggle-generate = { path = "../generate", version = "0.7.0-dev" }
-witx = "0.9.0"
+witx = "0.9.1"
 syn = { version = "1.0", features = ["full"] }

--- a/lucetc/Cargo.toml
+++ b/lucetc/Cargo.toml
@@ -26,7 +26,7 @@ cranelift-wasm = "0.75.0"
 target-lexicon = "0.12"
 lucet-module = { path = "../lucet-module", version = "=0.7.0-dev" }
 lucet-wiggle-generate = { path = "../lucet-wiggle/generate", version = "=0.7.0-dev" }
-witx = "0.9.0"
+witx = "0.9.1"
 wasmparser = "0.59.0"
 clap="2.32"
 


### PR DESCRIPTION
The 0.9.1 release of witx most importantly includes
WebAssembly/WASI#434, which is a bug-fix affecting transitive imports in
witx documents.

This updates `lucetc`, `lucet-wiggle-generate`, and `lucet-wiggle-macro`'s dependencies relying on 0.9.0.