### PR TITLE
Add fuzz target to test VeriWasm validation.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1140,6 +1140,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "arbitrary",
+ "env_logger 0.8.4",
  "libfuzzer-sys",
  "lucet-module",
  "lucet-runtime",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -18,9 +18,16 @@ wasm-smith = "0.3"
 tempfile = "3.0"
 anyhow = "1"
 arbitrary = { version = "0.4.1", features = ["derive"] }
+env_logger = "0.8.4"
 
 [[bin]]
 name = "differential_backends"
 path = "fuzz_targets/differential_backends.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "veriwasm"
+path = "fuzz_targets/veriwasm.rs"
 test = false
 doc = false

--- a/fuzz/fuzz_targets/veriwasm.rs
+++ b/fuzz/fuzz_targets/veriwasm.rs
@@ -1,0 +1,89 @@
+//! VeriWasm fuzz target: ensure that VeriWasm does not reject the compilation
+//! result of any valid Wasm module.
+
+#![no_main]
+
+use anyhow::Error;
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+use lucetc::{Lucetc, LucetcOpts};
+use tempfile::TempDir;
+
+#[derive(Clone, Copy, Default, Debug, Arbitrary)]
+struct WasmSmithConfig;
+
+impl wasm_smith::Config for WasmSmithConfig {
+    fn allow_start_export(&self) -> bool {
+        true
+    }
+
+    fn min_funcs(&self) -> usize {
+        1
+    }
+
+    fn max_funcs(&self) -> usize {
+        1
+    }
+
+    fn min_memories(&self) -> u32 {
+        1
+    }
+
+    fn max_memories(&self) -> usize {
+        1
+    }
+
+    fn max_imports(&self) -> usize {
+        0
+    }
+
+    fn min_exports(&self) -> usize {
+        2
+    }
+
+    fn max_memory_pages(&self) -> u32 {
+        1
+    }
+
+    fn max_data_segments(&self) -> usize {
+        0
+    }
+
+    fn max_tables(&self) -> usize {
+        0
+    }
+
+    fn memory_max_size_required(&self) -> bool {
+        true
+    }
+}
+
+fn build(with_veriwasm: bool, bytes: &[u8], tempdir: &TempDir, suffix: &str) -> Result<(), Error> {
+    let lucetc = Lucetc::try_from_bytes(bytes)?.with_veriwasm(with_veriwasm);
+    let so_file = tempdir.path().join(format!("out_{}.so", suffix));
+    lucetc.shared_object_file(so_file.clone())?;
+    Ok(())
+}
+
+fn run_test(bytes: &[u8]) -> Result<(), Error> {
+    let tempdir = TempDir::new()?;
+    if build(
+        /* with_veriwasm = */ false, bytes, &tempdir, "baseline",
+    )
+    .is_err()
+    {
+        // If baseline Lucet can't build it, then there is some other issue with the Wasm module
+        // and we reject it with a silent "pass" result.
+        return Ok(());
+    }
+
+    build(/* with_veriwasm = */ true, bytes, &tempdir, "veriwasm")?;
+
+    Ok(())
+}
+
+fuzz_target!(|module: wasm_smith::ConfiguredModule<WasmSmithConfig>| {
+    let _ = env_logger::try_init();
+    let bytes = module.to_bytes();
+    run_test(&bytes[..]).expect("build with VeriWasm check failed");
+});


### PR DESCRIPTION
This fuzz target tests the property: any Wasm module that Lucet can
compile should produce an artifact that validates with VeriWasm. We are
looking for both "false positive" bugs in VeriWasm, i.e. compilation
results which are correct but which the validator can't handle, as well
as "true positive" validator errors that result from a genuine Lucet
miscompilation. If we see neither, then we have some more confidence
that both (i) Lucet is less likely to have heap-soundness bugs, and (ii)
VeriWasm is solid enough that one could consider requiring it to pass
before using a module.