### PR TITLE
lucet-runtime-example: fix regression from #655

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1206,6 +1206,7 @@ version = "0.1.0"
 dependencies = [
  "lucet-runtime",
  "lucet-wasi",
+ "tokio",
 ]
 
 [[package]]

--- a/docs/lucet-runtime-example/Cargo.toml
+++ b/docs/lucet-runtime-example/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 [dependencies]
 lucet-runtime = { path = "../../lucet-runtime" }
 lucet-wasi = { path = "../../lucet-wasi" }
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 
 # or, if compiling against released crates.io versions:
 # lucet-runtime = "0.5.1"

--- a/docs/lucet-runtime-example/src/main.rs
+++ b/docs/lucet-runtime-example/src/main.rs
@@ -1,7 +1,8 @@
 use lucet_runtime::{DlModule, Limits, MmapRegion, Region};
 use lucet_wasi::WasiCtxBuilder;
 
-fn main() {
+#[tokio::main]
+async fn main() {
     // ensure the WASI symbols are exported from the final executable
     lucet_wasi::export_wasi_funcs();
     // load the compiled Lucet module
@@ -10,9 +11,10 @@ fn main() {
     let region = MmapRegion::create(1, &Limits::default()).unwrap();
     // instantiate the module in the memory region
     let mut instance = region.new_instance(dl_module).unwrap();
-    // prepare the WASI context, inheriting stdio handles from the host executable
+    // prepare the WASI context, inheriting stdio handles from the host executable.
+    // Since we are using lucet-wasi, we need to run the instance as async!
     let wasi_ctx = WasiCtxBuilder::new().inherit_stdio().build();
     instance.insert_embed_ctx(wasi_ctx);
-    // run the WASI main function
-    instance.run("main", &[]).unwrap();
+    // run the WASI entrypoint.
+    instance.run_async("_start", &[], None).await.unwrap();
 }


### PR DESCRIPTION
closes #663