### PR TITLE
Update `userfaultfd` dependency to 0.3.2

### DIFF
--- a/lucet-runtime/lucet-runtime-internals/Cargo.toml
+++ b/lucet-runtime/lucet-runtime-internals/Cargo.toml
@@ -32,7 +32,7 @@ thiserror = "1.0.4"
 tracing = "0.1.12"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-userfaultfd = { version = "0.2.0", optional = true }
+userfaultfd = { version = "^0.3.2", optional = true }
 
 [dev-dependencies]
 byteorder = "1.2"


### PR DESCRIPTION
This is to allow a newer version of bindgen to be picked up in the dependency tree.