### PR TITLE
uffd: fix eager heap init bug, add testing, update defaults to reflect production

### DIFF
--- a/lucet-runtime/lucet-runtime-internals/src/region/uffd.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/region/uffd.rs
@@ -710,9 +710,9 @@ impl Default for UffdConfig {
         UffdConfig {
             heap_page_size: HeapPageSize::Wasm,
             heap_init: Disposition::Lazy,
-            stack_init: Disposition::Lazy,
-            abort_on_handler_error: false,
-            enoent_retry_limit: 4,
+            stack_init: Disposition::Eager,
+            abort_on_handler_error: true,
+            enoent_retry_limit: 9,
         }
     }
 }

--- a/lucet-runtime/lucet-runtime-internals/src/region/uffd.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/region/uffd.rs
@@ -365,16 +365,18 @@ impl RegionInternal for UffdRegion {
                     0,
                     "initial heap is page divisible"
                 );
-                // All associated host pages gets zeroed
-                unsafe {
-                    zeropage(
-                        &self.uffd,
-                        slot.heap,
-                        initial_size,
-                        false,
-                        self.config.enoent_retry_limit,
-                    )
-                    .map_err(|e| Error::InternalError(e.into()))?;
+                if initial_size > 0 {
+                    // All associated host pages gets zeroed
+                    unsafe {
+                        zeropage(
+                            &self.uffd,
+                            slot.heap,
+                            initial_size,
+                            false,
+                            self.config.enoent_retry_limit,
+                        )
+                        .map_err(|e| Error::InternalError(e.into()))?;
+                    }
                 }
 
                 let heap_pages = initial_size / host_page_size();

--- a/lucet-runtime/lucet-runtime-tests/guests/memory/zero_memory.wat
+++ b/lucet-runtime/lucet-runtime-tests/guests/memory/zero_memory.wat
@@ -1,0 +1,4 @@
+(module
+  (import "env" "memory" (memory 0))
+  (func $main (export "main"))
+)


### PR DESCRIPTION
* bugfix in the eager heap initialization: guard against initializing zero-sized memory. the zeropage ioctl will helpfully return EINVAL when this code path is exercised with initial_size = 0, e.g. when your wasm has `(memory (export "memory") 0)`
* add better testing coverage, checking the existing uffd test with both lazy (default, as before) and eager heap disposition, and add a test specifically for the bug fixed above.
* update `impl Default for UffdConfig` to the values we use in production.