### PR TITLE
Fix veriwasm fuzzing script

### DIFF
--- a/fuzz/fuzz_targets/veriwasm.rs
+++ b/fuzz/fuzz_targets/veriwasm.rs
@@ -77,7 +77,9 @@ fn run_test(bytes: &[u8]) -> Result<(), Error> {
         return Ok(());
     }
 
-    build(/* with_veriwasm = */ true, bytes, &tempdir, "veriwasm")?;
+    if build(/* with_veriwasm = */ true, bytes, &tempdir, "veriwasm").is_err(){
+        panic!("Veriwasm returned an error!");
+    }
 
     Ok(())
 }


### PR DESCRIPTION
To the best of my knowledge, the current veriwasm fuzzing script will not actually report an error when veriwasm fails to verify the compiled code. This is because the fuzz_target! harness will only catch panics, and the script does not panic on error. This change will make the script panic on verification failure. I'm not super familiar with using libfuzzer in rust, so if this is a mistake let me know.