### PR TITLE
show the entire command for LdError

### DIFF
--- a/lucetc/src/lib.rs
+++ b/lucetc/src/lib.rs
@@ -440,8 +440,8 @@ fn link_so(
 
     if !run_ld.status.success() {
         let message = format!(
-            "ld of {} failed: {}",
-            objpath.as_ref().to_str().unwrap(),
+            "ld of `{:?}` failed: {}",
+            cmd_ld,
             String::from_utf8_lossy(&run_ld.stderr)
         );
         return Err(Error::LdError(message));


### PR DESCRIPTION
I found an LdError like `{"error":"Ld error: ld of /tmp/lucetchjZBPT/tmp.o failed: ld: -f may not be used without -shared\n"}]` but it's hard to debug since it doesn't include arguments for `ld`. This PR adds the entire command including arguments in LdError.