### PR TITLE
fix for `semicolon_in_expressions_from_macros` warning in lucet_bail

### DIFF
--- a/lucet-runtime/lucet-runtime-internals/src/error.rs
+++ b/lucet-runtime/lucet-runtime-internals/src/error.rs
@@ -115,10 +115,10 @@ pub enum ModuleError {
 #[macro_export]
 macro_rules! lucet_bail {
     ($e:expr) => {
-        return Err(lucet_format_err!($e));
+        return Err(lucet_format_err!($e))
     };
     ($fmt:expr, $($arg:tt)*) => {
-        return Err(lucet_format_err!($fmt, $($arg)*));
+        return Err(lucet_format_err!($fmt, $($arg)*))
     };
 }
 


### PR DESCRIPTION
new warning in 1.56.