### PR TITLE
wasmtime 0.32

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,32 +223,11 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f8499797f7e264c83334d9fc98b2c9889ebe5839514a14d81769ca09d71fd1d"
 dependencies = [
- "cap-primitives 0.21.1",
- "cap-std 0.21.1",
+ "cap-primitives",
+ "cap-std",
  "io-lifetimes",
  "rustc_version 0.4.0",
  "winapi",
-]
-
-[[package]]
-name = "cap-primitives"
-version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b51bd736eec54ae6552d18b0c958885b01d88c84c5fe6985e28c2b57ff385e94"
-dependencies = [
- "ambient-authority",
- "errno",
- "fs-set-times 0.12.0",
- "io-lifetimes",
- "ipnet",
- "maybe-owned",
- "once_cell",
- "rsix",
- "rustc_version 0.4.0",
- "unsafe-io",
- "winapi",
- "winapi-util",
- "winx",
 ]
 
 [[package]]
@@ -259,7 +238,7 @@ checksum = "c5998b8b3a49736500aec3c123fa3f6f605a125b41a6df725e6b7c924a612ab4"
 dependencies = [
  "ambient-authority",
  "errno",
- "fs-set-times 0.13.1",
+ "fs-set-times",
  "io-extras",
  "io-lifetimes",
  "ipnet",
@@ -283,25 +262,11 @@ dependencies = [
 
 [[package]]
 name = "cap-std"
-version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037334fe2f30ec71bcc51af1e8cbb8a9f9ac6a6b8cbd657d58dfef2ad5b9f19a"
-dependencies = [
- "cap-primitives 0.19.1",
- "io-lifetimes",
- "ipnet",
- "rsix",
- "rustc_version 0.4.0",
- "unsafe-io",
-]
-
-[[package]]
-name = "cap-std"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "811de89a7ede4ba32f2b75fe5c668a534da24942d81c081248a9d2843ebd517d"
 dependencies = [
- "cap-primitives 0.21.1",
+ "cap-primitives",
  "io-extras",
  "io-lifetimes",
  "ipnet",
@@ -311,11 +276,11 @@ dependencies = [
 
 [[package]]
 name = "cap-tempfile"
-version = "0.19.1"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5160158dd17a01cfaf359e27a17fb6cc37c083347ed8c6e10583e08055d12c94"
+checksum = "a4fa925a69a454293146bc04dfcbeba993093b1816531f9408e229130d7fc465"
 dependencies = [
- "cap-std 0.19.1",
+ "cap-std",
  "rand 0.8.4",
  "uuid 0.8.2",
 ]
@@ -326,7 +291,7 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85f263d62447efe8829efdf947bbb4824ba2a3e2852b3be1d62f76fc05c326b0"
 dependencies = [
- "cap-primitives 0.21.1",
+ "cap-primitives",
  "once_cell",
  "rustix",
  "winx",
@@ -922,17 +887,6 @@ dependencies = [
 
 [[package]]
 name = "fs-set-times"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "807e3ef0de04fbe498bebd560ae041e006d97bf9f726dc0b485a86316be0ebc8"
-dependencies = [
- "io-lifetimes",
- "rsix",
- "winapi",
-]
-
-[[package]]
-name = "fs-set-times"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa838950e8e36a567ce96a945c303e88d9916ff97df27c315a0d263a72bd816f"
@@ -1302,12 +1256,6 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.0.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "687387ff42ec7ea4f2149035a5675fedb675d26f98db90a1846ac63d3addb5f5"
-
-[[package]]
-name = "linux-raw-sys"
 version = "0.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a261afc61b7a5e323933b402ca6a1765183687c614789b1e4db7762ed4230bca"
@@ -1533,7 +1481,7 @@ version = "0.7.0-dev"
 dependencies = [
  "ambient-authority",
  "anyhow",
- "cap-std 0.21.1",
+ "cap-std",
  "cap-tempfile",
  "cast",
  "clap",
@@ -2497,23 +2445,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rsix"
-version = "0.23.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f64c5788d5aab8b75441499d99576a24eb09f76fb267b36fec7e3d970c66431"
-dependencies = [
- "bitflags",
- "cc",
- "errno",
- "io-lifetimes",
- "itoa",
- "libc",
- "linux-raw-sys 0.0.28",
- "once_cell",
- "rustc_version 0.4.0",
-]
-
-[[package]]
 name = "rustc-demangle"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2554,7 +2485,7 @@ dependencies = [
  "io-lifetimes",
  "itoa",
  "libc",
- "linux-raw-sys 0.0.36",
+ "linux-raw-sys",
  "once_cell",
  "rustc_version 0.4.0",
  "winapi",
@@ -2916,7 +2847,7 @@ dependencies = [
  "atty",
  "bitflags",
  "cap-fs-ext",
- "cap-std 0.21.1",
+ "cap-std",
  "io-lifetimes",
  "rustc_version 0.4.0",
  "rustix",
@@ -3191,17 +3122,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
-name = "unsafe-io"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11e8cceed59fe60bd092be347343917cbc14b9239536980f09fe34e22c8efbc7"
-dependencies = [
- "io-lifetimes",
- "rustc_version 0.4.0",
- "winapi",
-]
-
-[[package]]
 name = "userfaultfd"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3347,9 +3267,9 @@ dependencies = [
  "async-trait",
  "cap-fs-ext",
  "cap-rand",
- "cap-std 0.21.1",
+ "cap-std",
  "cap-time-ext",
- "fs-set-times 0.13.1",
+ "fs-set-times",
  "io-lifetimes",
  "lazy_static",
  "rustix",
@@ -3368,7 +3288,7 @@ dependencies = [
  "anyhow",
  "bitflags",
  "cap-rand",
- "cap-std 0.21.1",
+ "cap-std",
  "rustix",
  "thiserror",
  "tracing",
@@ -3383,7 +3303,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "871451d80bd1a9584b9ac5eaec3dc77ff67417fbfadba0eeb6f1abfeba03ae9b"
 dependencies = [
  "anyhow",
- "cap-std 0.21.1",
+ "cap-std",
  "io-lifetimes",
  "lazy_static",
  "rustix",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,16 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e61f2b7f93d2c7d2b08263acaa4a363b3e276806c68af6134c44f523bf1aacd"
 dependencies = [
- "gimli",
+ "gimli 0.25.0",
+]
+
+[[package]]
+name = "addr2line"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
+dependencies = [
+ "gimli 0.26.1",
 ]
 
 [[package]]
@@ -105,7 +114,7 @@ version = "0.3.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "091bcdf2da9950f96aa522681ce805e6857f6ca8df73833d35736ab2dc78e152"
 dependencies = [
- "addr2line",
+ "addr2line 0.16.0",
  "cc",
  "cfg-if 1.0.0",
  "libc",
@@ -210,12 +219,12 @@ checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "cap-fs-ext"
-version = "0.19.1"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf5c3b436b94a1adac74032ff35d8aa5bae6ec2a7900e76432c9ae8dac4d673"
+checksum = "4f8499797f7e264c83334d9fc98b2c9889ebe5839514a14d81769ca09d71fd1d"
 dependencies = [
- "cap-primitives",
- "cap-std",
+ "cap-primitives 0.21.1",
+ "cap-std 0.21.1",
  "io-lifetimes",
  "rustc_version 0.4.0",
  "winapi",
@@ -229,7 +238,7 @@ checksum = "b51bd736eec54ae6552d18b0c958885b01d88c84c5fe6985e28c2b57ff385e94"
 dependencies = [
  "ambient-authority",
  "errno",
- "fs-set-times",
+ "fs-set-times 0.12.0",
  "io-lifetimes",
  "ipnet",
  "maybe-owned",
@@ -243,10 +252,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "cap-rand"
-version = "0.19.1"
+name = "cap-primitives"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e6e89d00b0cebeb6da7a459b81e6a49cf2092cc4afe03f28eb99b8f0e889344"
+checksum = "c5998b8b3a49736500aec3c123fa3f6f605a125b41a6df725e6b7c924a612ab4"
+dependencies = [
+ "ambient-authority",
+ "errno",
+ "fs-set-times 0.13.1",
+ "io-extras",
+ "io-lifetimes",
+ "ipnet",
+ "maybe-owned",
+ "rustc_version 0.4.0",
+ "rustix",
+ "winapi",
+ "winapi-util",
+ "winx",
+]
+
+[[package]]
+name = "cap-rand"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fafda903eb4a85903b106439cf62524275f3ae0609bb9e1ae9da7e7c26d4150c"
 dependencies = [
  "ambient-authority",
  "rand 0.8.4",
@@ -258,7 +287,7 @@ version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037334fe2f30ec71bcc51af1e8cbb8a9f9ac6a6b8cbd657d58dfef2ad5b9f19a"
 dependencies = [
- "cap-primitives",
+ "cap-primitives 0.19.1",
  "io-lifetimes",
  "ipnet",
  "rsix",
@@ -267,25 +296,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "cap-std"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "811de89a7ede4ba32f2b75fe5c668a534da24942d81c081248a9d2843ebd517d"
+dependencies = [
+ "cap-primitives 0.21.1",
+ "io-extras",
+ "io-lifetimes",
+ "ipnet",
+ "rustc_version 0.4.0",
+ "rustix",
+]
+
+[[package]]
 name = "cap-tempfile"
 version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5160158dd17a01cfaf359e27a17fb6cc37c083347ed8c6e10583e08055d12c94"
 dependencies = [
- "cap-std",
+ "cap-std 0.19.1",
  "rand 0.8.4",
  "uuid 0.8.2",
 ]
 
 [[package]]
 name = "cap-time-ext"
-version = "0.19.1"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aea5319ada3a9517fc70eafe9cf3275f04da795c53770ebc5d91f4a33f4dd2b5"
+checksum = "85f263d62447efe8829efdf947bbb4824ba2a3e2852b3be1d62f76fc05c326b0"
 dependencies = [
- "cap-primitives",
+ "cap-primitives 0.21.1",
  "once_cell",
- "rsix",
+ "rustix",
  "winx",
 ]
 
@@ -429,41 +472,45 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.78.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=b0246038666464837ffeb08fd85fb5d75e5a682b#b0246038666464837ffeb08fd85fb5d75e5a682b"
+version = "0.79.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0fb5e025141af5b9cbfff4351dc393596d017725f126c954bf472ce78dbba6b"
 dependencies = [
- "cranelift-entity 0.78.0",
+ "cranelift-entity 0.79.0",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.78.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=b0246038666464837ffeb08fd85fb5d75e5a682b#b0246038666464837ffeb08fd85fb5d75e5a682b"
+version = "0.79.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a278c67cc48d0e8ff2275fb6fc31527def4be8f3d81640ecc8cd005a3aa45ded"
 dependencies = [
  "cranelift-bforest",
  "cranelift-codegen-meta",
  "cranelift-codegen-shared",
- "cranelift-entity 0.78.0",
- "gimli",
+ "cranelift-entity 0.79.0",
+ "gimli 0.26.1",
  "log",
  "regalloc",
+ "sha2",
  "smallvec",
  "target-lexicon 0.12.2",
 ]
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.78.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=b0246038666464837ffeb08fd85fb5d75e5a682b#b0246038666464837ffeb08fd85fb5d75e5a682b"
+version = "0.79.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28274c1916c931c5603d94c5479d2ddacaaa574d298814ac1c99964ce92cbe85"
 dependencies = [
  "cranelift-codegen-shared",
- "cranelift-entity 0.78.0",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.78.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=b0246038666464837ffeb08fd85fb5d75e5a682b#b0246038666464837ffeb08fd85fb5d75e5a682b"
+version = "0.79.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5411cf49ab440b749d4da5129dfc45caf6e5fb7b2742b1fe1a421964fda2ee88"
 
 [[package]]
 name = "cranelift-entity"
@@ -473,17 +520,18 @@ checksum = "057e78f3dba2f41e2ff2723cce197b18f5ffa603fb67fbabf57aca8d2b55cb95"
 
 [[package]]
 name = "cranelift-entity"
-version = "0.78.0"
-source = "git+https://github.com/bytecodealliance/wasmtime?rev=b0246038666464837ffeb08fd85fb5d75e5a682b#b0246038666464837ffeb08fd85fb5d75e5a682b"
+version = "0.79.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64dde596f98462a37b029d81c8567c23cc68b8356b017f12945c545ac0a83203"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.78.0"
+version = "0.79.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e07339bd461766deb7605169de039e01954768ff730fa1254e149001884a8525"
+checksum = "544605d400710bd9c89924050b30c2e0222a387a5a8b5f04da9a9fdcbd8656a5"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -493,21 +541,19 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.78.0"
+version = "0.79.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "825ac7e0959cbe7ddc9cc21209f0319e611a57f9fcb2b723861fe7ef2017e651"
+checksum = "decb7d353b972b60c617ea5b4d09b9574ffc61daef7cd534c060ca728dadc10c"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
- "cranelift-entity 0.78.0",
- "log",
 ]
 
 [[package]]
 name = "cranelift-native"
-version = "0.78.0"
+version = "0.79.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03e2fca76ff57e0532936a71e3fc267eae6a19a86656716479c66e7f912e3d7b"
+checksum = "b7f8839befb64f7a39cb855241ae2c8eb74cea27c97fff2a007075fdb8a7f7d4"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -516,9 +562,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-object"
-version = "0.78.0"
+version = "0.79.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55500d0fc9bb05c0944fc4506649249d28f55bd4fe95b87f0e55bf41058f0e6d"
+checksum = "9fe4d91d7e85ad84e3e1b9cf0bba1bb117d35de867e72e4740cb7423d5351792"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -530,12 +576,12 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.78.0"
+version = "0.79.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f46fec547a1f8a32c54ea61c28be4f4ad234ad95342b718a9a9adcaadb0c778"
+checksum = "80c9e14062c6a1cd2367dd30ea8945976639d5fe2062da8bdd40ada9ce3cb82e"
 dependencies = [
  "cranelift-codegen",
- "cranelift-entity 0.78.0",
+ "cranelift-entity 0.79.0",
  "cranelift-frontend",
  "itertools 0.10.1",
  "log",
@@ -810,9 +856,9 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa68f2fb9cae9d37c9b2b3584aba698a2e97f72d7aef7b9f7aa71d8b54ce46fe"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
 dependencies = [
  "errno-dragonfly",
  "libc",
@@ -882,6 +928,17 @@ checksum = "807e3ef0de04fbe498bebd560ae041e006d97bf9f726dc0b485a86316be0ebc8"
 dependencies = [
  "io-lifetimes",
  "rsix",
+ "winapi",
+]
+
+[[package]]
+name = "fs-set-times"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa838950e8e36a567ce96a945c303e88d9916ff97df27c315a0d263a72bd816f"
+dependencies = [
+ "io-lifetimes",
+ "rustix",
  "winapi",
 ]
 
@@ -971,6 +1028,12 @@ name = "gimli"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0a01e0497841a3b2db4f8afa483cce65f7e96a3498bd6c541734792aeac8fe7"
+
+[[package]]
+name = "gimli"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 dependencies = [
  "fallible-iterator",
  "indexmap",
@@ -1114,10 +1177,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-lifetimes"
-version = "0.3.1"
+name = "io-extras"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47f5ce4afb9bf504b9f496a3307676bc232122f91a93c4da6d540aa99a0a0e0b"
+checksum = "2a1d9a66d8b0312e3601a04a2dcf8f0ddd873319560ddeabe2110fa1e5af781a"
+dependencies = [
+ "io-lifetimes",
+ "rustc_version 0.4.0",
+ "winapi",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "278e90d6f8a6c76a8334b336e306efa3c5f2b604048cbfd486d6f49878e3af14"
 dependencies = [
  "rustc_version 0.4.0",
  "winapi",
@@ -1233,6 +1307,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "687387ff42ec7ea4f2149035a5675fedb675d26f98db90a1846ac63d3addb5f5"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.0.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a261afc61b7a5e323933b402ca6a1765183687c614789b1e4db7762ed4230bca"
+
+[[package]]
 name = "lock_api"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1324,7 +1404,7 @@ dependencies = [
  "anyhow",
  "bincode",
  "byteorder",
- "cranelift-entity 0.78.0",
+ "cranelift-entity 0.79.0",
  "derivative",
  "memoffset 0.5.6",
  "minisign 0.7.0",
@@ -1453,7 +1533,7 @@ version = "0.7.0-dev"
 dependencies = [
  "ambient-authority",
  "anyhow",
- "cap-std",
+ "cap-std 0.21.1",
  "cap-tempfile",
  "cast",
  "clap",
@@ -1562,7 +1642,7 @@ dependencies = [
  "byteorder",
  "clap",
  "cranelift-codegen",
- "cranelift-entity 0.78.0",
+ "cranelift-entity 0.79.0",
  "cranelift-frontend",
  "cranelift-module",
  "cranelift-native",
@@ -2350,9 +2430,9 @@ dependencies = [
 
 [[package]]
 name = "regalloc"
-version = "0.0.32"
+version = "0.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6304468554ed921da3d32c355ea107b8d13d7b8996c3adfb7aab48d3bc321f4"
+checksum = "7d808cff91dfca7b239d40b972ba628add94892b1d9e19a842aedc5cfae8ab1a"
 dependencies = [
  "log",
  "rustc-hash",
@@ -2428,7 +2508,7 @@ dependencies = [
  "io-lifetimes",
  "itoa",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.0.28",
  "once_cell",
  "rustc_version 0.4.0",
 ]
@@ -2461,6 +2541,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver 1.0.4",
+]
+
+[[package]]
+name = "rustix"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18c44018277ec7195538f5631b90def7ad975bb46370cb0f4eff4012de9333f8"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "itoa",
+ "libc",
+ "linux-raw-sys 0.0.36",
+ "once_cell",
+ "rustc_version 0.4.0",
+ "winapi",
 ]
 
 [[package]]
@@ -2812,17 +2909,17 @@ dependencies = [
 
 [[package]]
 name = "system-interface"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb3a23bf923c3fdaf0c36a8c016047e415f0559a5b891de7ec3d19d58b9b503"
+checksum = "b1b5163055c386394170493ec1827cf7975035dc0bb23dcb7070bd1b1f672baa"
 dependencies = [
  "atty",
  "bitflags",
  "cap-fs-ext",
- "cap-std",
+ "cap-std 0.21.1",
  "io-lifetimes",
- "rsix",
  "rustc_version 0.4.0",
+ "rustix",
  "winapi",
  "winx",
 ]
@@ -3242,21 +3339,20 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasi-cap-std-sync"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fb334665c513dc1bbffce3a60d1fa099c240c63630c33244a7f1a93ff828824"
+checksum = "f23cb8c01ff3b733418d594df1fab090a4ece29a1260c5364df67e8fe7e08634"
 dependencies = [
  "anyhow",
  "async-trait",
- "bitflags",
  "cap-fs-ext",
  "cap-rand",
- "cap-std",
+ "cap-std 0.21.1",
  "cap-time-ext",
- "fs-set-times",
+ "fs-set-times 0.13.1",
  "io-lifetimes",
  "lazy_static",
- "rsix",
+ "rustix",
  "system-interface",
  "tracing",
  "wasi-common",
@@ -3265,16 +3361,15 @@ dependencies = [
 
 [[package]]
 name = "wasi-common"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e41159a3e4a3216c913bd861349d93600bf08d31c64a04457d43a4c0685a31"
+checksum = "6c1e8cb75656702a5b843ef609c4e49b7a257f3bfcbf95ce9f32e4d1c9cf933b"
 dependencies = [
  "anyhow",
  "bitflags",
  "cap-rand",
- "cap-std",
- "io-lifetimes",
- "rsix",
+ "cap-std 0.21.1",
+ "rustix",
  "thiserror",
  "tracing",
  "wiggle",
@@ -3283,22 +3378,16 @@ dependencies = [
 
 [[package]]
 name = "wasi-tokio"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19f73fa9b9fb5264bf5926a93ae018ec0f8a10de6cdd0a120bf8c78143b1035"
+checksum = "871451d80bd1a9584b9ac5eaec3dc77ff67417fbfadba0eeb6f1abfeba03ae9b"
 dependencies = [
  "anyhow",
- "bitflags",
- "cap-fs-ext",
- "cap-std",
- "cap-time-ext",
- "fs-set-times",
+ "cap-std 0.21.1",
  "io-lifetimes",
  "lazy_static",
- "rsix",
- "system-interface",
+ "rustix",
  "tokio",
- "tracing",
  "wasi-cap-std-sync",
  "wasi-common",
  "wiggle",
@@ -3400,9 +3489,9 @@ checksum = "98930446519f63d00a836efdc22f67766ceae8dbcc1571379f2bcabc6b2b9abc"
 
 [[package]]
 name = "wasmtime"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "311d06b0c49346d1fbf48a17052e844036b95a7753c1afb34e8c0af3f6b5bb13"
+checksum = "5d59b4bcc681f894d018e7032ba3149ab8e5f86828fab0b6ff31999c5691f20b"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -3429,14 +3518,13 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c2d194b655321053bc4111a1aa4ead552655c8a17d17264bc97766e70073510"
+checksum = "c39e4ba1fb154cca6a0f2350acc83248e22defb0cc647ae78879fe246a49dd61"
 dependencies = [
  "anyhow",
- "cfg-if 1.0.0",
- "cranelift-entity 0.78.0",
- "gimli",
+ "cranelift-entity 0.79.0",
+ "gimli 0.26.1",
  "indexmap",
  "log",
  "more-asserts",
@@ -3450,23 +3538,20 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "864ac8dfe4ce310ac59f16fdbd560c257389cb009ee5d030ac6e30523b023d11"
+checksum = "3dd538de9501eb0f2c4c7b3d8acc7f918276ca28591a67d4ebe0672ebd558b65"
 dependencies = [
- "addr2line",
+ "addr2line 0.17.0",
  "anyhow",
  "bincode",
  "cfg-if 1.0.0",
- "gimli",
- "log",
- "more-asserts",
+ "gimli 0.26.1",
  "object 0.27.1",
  "region",
  "serde",
  "target-lexicon 0.12.2",
  "thiserror",
- "wasmparser 0.81.0",
  "wasmtime-environ",
  "wasmtime-runtime",
  "winapi",
@@ -3474,9 +3559,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-runtime"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab97da813a26b98c9abfd3b0c2d99e42f6b78b749c0646344e2e262d212d8c8b"
+checksum = "910ccbd8cc18a02f626a1b2c7a7ddb57808db3c1780fd0af0aa5a5dae86c610b"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -3491,7 +3576,7 @@ dependencies = [
  "more-asserts",
  "rand 0.8.4",
  "region",
- "rsix",
+ "rustix",
  "thiserror",
  "wasmtime-environ",
  "winapi",
@@ -3499,11 +3584,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-types"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff94409cc3557bfbbcce6b14520ccd6bd3727e965c0fe68d63ef2c185bf379c6"
+checksum = "115bfe5c6eb6aba7e4eaa931ce225871c40280fb2cfb4ce4d3ab98d082e52fc4"
 dependencies = [
- "cranelift-entity 0.78.0",
+ "cranelift-entity 0.79.0",
  "serde",
  "thiserror",
  "wasmparser 0.81.0",
@@ -3530,9 +3615,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99344dd8f050a388cfe7a7a1bc9f2fd15294e98e378d83edb51c65b1870b9353"
+checksum = "c2b956030cc391da52988f56bfbd43fed8c3d761fe20cf511e3eddb6cbc15c8c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3546,9 +3631,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f841871de59d883d38cd62529a046c17a68296b340cf15f8a6d20056a810aa06"
+checksum = "10f3fd4dc7e543742f782816877768b6b5b2bd6e8998a9c377d898dbff964dcb"
 dependencies = [
  "anyhow",
  "heck",
@@ -3561,15 +3646,14 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ccc854dbc0ebeba33c6c5fb9aa1889e605288d92a14b8621a54c2b5def9489"
+checksum = "4444dd08ea99536640db03740c04245e9e2763607a4ab58440eb852789e86283"
 dependencies = [
  "proc-macro2 1.0.32",
  "quote 1.0.10",
  "syn 1.0.81",
  "wiggle-generate",
- "witx",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3066,9 +3066,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.12.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2c2416fdedca8443ae44b4527de1ea633af61d8f7169ffa6e72c5b53d24efcc"
+checksum = "70e992e41e0d2fb9f755b37446f20900f64446ef54874f40a60c78f021ac6144"
 dependencies = [
  "autocfg 1.0.1",
  "bytes",
@@ -3083,9 +3083,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2dd85aeaba7b68df939bd357c6afb36c87951be9e80bf9c859f2fc3e9fca0fd"
+checksum = "c9efc1aba077437943f7515666aa2b882dfabfbfdf89c819ea75a8d6e9eaba5e"
 dependencies = [
  "proc-macro2 1.0.32",
  "quote 1.0.10",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,12 +23,3 @@ exclude = ["wasmtime", "sightglass"]
 
 [profile.test]
 rpath = true
-
-
-# wasmtime 0.31 / cranelift 0.78 was released missing the ifcmp_sp
-# instruction, which lucet requires. cfallin added it back in with
-# https://github.com/bytecodealliance/wasmtime/pull/3502. This patch
-# points to where that commit was merged into `main`.
-[patch.'crates-io']
-cranelift-codegen = { git = "https://github.com/bytecodealliance/wasmtime", rev = "b0246038666464837ffeb08fd85fb5d75e5a682b" }
-cranelift-entity = { git = "https://github.com/bytecodealliance/wasmtime", rev = "b0246038666464837ffeb08fd85fb5d75e5a682b" }

--- a/lucet-module/Cargo.toml
+++ b/lucet-module/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
-cranelift-entity = "0.78.0"
+cranelift-entity = "0.79.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bincode = "1.1.4"

--- a/lucet-runtime/lucet-runtime-internals/Cargo.toml
+++ b/lucet-runtime/lucet-runtime-internals/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 lucet-module = { path = "../../lucet-module", version = "=0.7.0-dev" }
 lucet-runtime-macros = { path = "../lucet-runtime-macros", version = "=0.7.0-dev" }
-wiggle = { version = "0.31.0", default-features = false }
+wiggle = { version = "0.32.0", default-features = false }
 
 anyhow = "1.0"
 async-trait = "0.1"

--- a/lucet-wasi-fuzz/Cargo.toml
+++ b/lucet-wasi-fuzz/Cargo.toml
@@ -28,4 +28,4 @@ task-group = "0.2"
 tempfile = "3.0"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 wait-timeout = "0.2"
-wasi-common = "0.31.0"
+wasi-common = "0.32.0"

--- a/lucet-wasi/Cargo.toml
+++ b/lucet-wasi/Cargo.toml
@@ -37,7 +37,7 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros"]}
 lucet-wasi-sdk = { path = "../lucet-wasi-sdk" }
 lucetc = { path = "../lucetc" }
 tempfile = "3.0"
-cap-tempfile = "0.19"
+cap-tempfile = "0.21"
 
 [lib]
 name = "lucet_wasi"

--- a/lucet-wasi/Cargo.toml
+++ b/lucet-wasi/Cargo.toml
@@ -24,13 +24,13 @@ lucet-wiggle-generate = { path = "../lucet-wiggle/generate", version = "=0.7.0-d
 libc = "0.2.103"
 nix = "0.23"
 rand = "0.6"
-wasi-common = { version = "0.31.0", default-features = false,  features = ["wiggle_metadata"] }
-wasi-tokio = "0.31.0"
-wiggle = "0.31.0"
+wasi-common = { version = "0.32.0", default-features = false,  features = ["wiggle_metadata"] }
+wasi-tokio = "0.32.0"
+wiggle = "0.32.0"
 witx = "0.9.1"
 tracing = "0.1.20"
 tracing-subscriber = { version = "0.3.1", features = ["env-filter"] }
-cap-std = "0.19.1"
+cap-std = "0.21.1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"]}
 
 [dev-dependencies]

--- a/lucet-wiggle/Cargo.toml
+++ b/lucet-wiggle/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 lucet-wiggle-macro = { path = "./macro", version = "0.7.0-dev" }
 lucet-wiggle-generate = { path = "./generate", version = "0.7.0-dev" }
 lucet-runtime = { path = "../lucet-runtime", version = "0.7.0-dev" }
-wiggle =  { version = "0.31.0", default-features = false }
+wiggle =  { version = "0.32.0", default-features = false }
 
 [dev-dependencies]
 tempfile = "3.1"

--- a/lucet-wiggle/generate/Cargo.toml
+++ b/lucet-wiggle/generate/Cargo.toml
@@ -9,7 +9,7 @@ authors = ["Lucet team <lucet@fastly.com>"]
 edition = "2018"
 
 [dependencies]
-wiggle-generate = "0.31.0"
+wiggle-generate = "0.32.0"
 lucet-module = { path = "../../lucet-module", version = "0.7.0-dev" }
 witx = "0.9.1"
 quote = "1.0"

--- a/lucetc/Cargo.toml
+++ b/lucetc/Cargo.toml
@@ -16,13 +16,13 @@ path = "lucetc/main.rs"
 [dependencies]
 anyhow = "1"
 bincode = "1.1.4"
-cranelift-codegen = { version = "0.78.0", features = ["x86" ] }
-cranelift-entity = "0.78.0"
-cranelift-native = "0.78.0"
-cranelift-frontend = "0.78.0"
-cranelift-module =  "0.78.0"
-cranelift-object =  "0.78.0"
-cranelift-wasm = "0.78.0"
+cranelift-codegen = { version = "0.79.0", features = ["x86" ] }
+cranelift-entity = "0.79.0"
+cranelift-native = "0.79.0"
+cranelift-frontend = "0.79.0"
+cranelift-module =  "0.79.0"
+cranelift-object =  "0.79.0"
+cranelift-wasm = "0.79.0"
 target-lexicon = "0.12"
 lucet-module = { path = "../lucet-module", version = "=0.7.0-dev" }
 lucet-wiggle-generate = { path = "../lucet-wiggle/generate", version = "=0.7.0-dev" }


### PR DESCRIPTION
Just some dep updates.

We can get rid of the [patch] that we needed for the forgotten cranelift API in 0.31.0
